### PR TITLE
ci: repoint public URLs to custom domain (glance.plivo.com) on deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,6 +51,12 @@ jobs:
           # Allowed Google Workspace domain (e.g. plivo.com). Non-secret config — the OAuth callback
           # re-verifies the signed hd claim, so the value is safe to substitute in plaintext here.
           CF_ALLOWED_HD: ${{ vars.CF_ALLOWED_HD }}
+          # Optional custom-domain public URLs (served via CloudFront in front of the *.workers.dev
+          # origins). When set, the user-facing URLs (APP_URL / CONTENT_URL / SPA frame-src) are
+          # repointed off *.workers.dev to these; the workers KEEP their *.workers.dev endpoints
+          # (those are the CloudFront origins). Unset → stays on *.workers.dev (self-host default).
+          CF_APP_URL: ${{ vars.CF_APP_URL }}
+          CF_CONTENT_URL: ${{ vars.CF_CONTENT_URL }}
         run: |
           : "${CF_ACCOUNT_ID:?set repo Actions variable CF_ACCOUNT_ID}"
           : "${CF_D1_DATABASE_ID:?set repo Actions variable CF_D1_DATABASE_ID}"
@@ -66,6 +72,19 @@ jobs:
               -e "s/yourcompany.com/${CF_ALLOWED_HD}/g" \
               "$f"
           done
+          # Repoint public URLs to the custom domains, if configured (CloudFront cutover). Runs
+          # AFTER the subdomain substitution above (so glance[-content].$CF_WORKERS_SUBDOMAIN.workers.dev
+          # exist to match) and BEFORE build:web (so dist/_headers carries the real content origin).
+          if [ -n "${CF_APP_URL}${CF_CONTENT_URL}" ]; then
+            : "${CF_APP_URL:?set CF_APP_URL when CF_CONTENT_URL is set (custom domain)}"
+            : "${CF_CONTENT_URL:?set CF_CONTENT_URL when CF_APP_URL is set (custom domain)}"
+            for f in packages/api/wrangler.jsonc packages/api/wrangler.content.jsonc packages/web/public/_headers; do
+              sed -i \
+                -e "s#https://glance-content.${CF_WORKERS_SUBDOMAIN}.workers.dev#${CF_CONTENT_URL}#g" \
+                -e "s#https://glance.${CF_WORKERS_SUBDOMAIN}.workers.dev#${CF_APP_URL}#g" \
+                "$f"
+            done
+          fi
 
       - name: Build web
         run: bun run build:web


### PR DESCRIPTION
## What
Adds two optional GitHub Actions Variables, `CF_APP_URL` / `CF_CONTENT_URL`. When set, the deploy workflow repoints the user-facing URLs off `*.workers.dev` to the custom domains:
- `APP_URL` → `https://glance.plivo.com` (main + content worker — content's `frame-ancestors` depends on it)
- `CONTENT_URL` → `https://glance-content.plivo.com`
- SPA `_headers` `frame-src` → `https://glance-content.plivo.com`

The rewrite runs **after** the existing `CF_WORKERS_SUBDOMAIN` substitution and **before** `build:web` (so `dist/_headers` carries the real content origin). The workers KEEP their `*.workers.dev` endpoints — those are now the CloudFront origins for the two custom hostnames.

## Why
`glance.plivo.com` / `glance-content.plivo.com` are served via CloudFront (Route 53) in front of the workers.dev origins. The app must advertise these public origins or the content iframe (CSP) and Google OAuth redirect break.

## Safety
No-op when the two Variables are unset → the public self-host template still defaults to `*.workers.dev`. Variables already set on this repo. Dry-run confirmed the substitution yields the plivo.com hosts with no residual placeholders.

> Note: Google OAuth client must add `https://glance.plivo.com` (origin + `/api/auth/google/callback`) for login to complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)