### PR TITLE
perf: parallelize content access chain + stream the dashboard loader (+ sites-table UX)

### DIFF
--- a/packages/api/src/content.ts
+++ b/packages/api/src/content.ts
@@ -86,18 +86,20 @@ async function serve(c: Ctx, spaceSlug: string, siteSlug: string, rest: string, 
     return c.text('Forbidden', 403)
   } else {
     // Gated path: reconstruct the bound user from D1 and re-authorize against live state.
-    const userRow = (
-      await db
+    // The user row, membership and share all key off `userId` (the token-bound id) + siteRow,
+    // never off each other — so resolve them in one round trip instead of three serial ones.
+    const [userRow, isMember, isShared] = await Promise.all([
+      db
         .select({ id: users.id, email: users.email, name: users.name, role: users.role })
         .from(users)
         .where(eq(users.id, userId))
         .limit(1)
-    )[0]
+        .then((rows) => rows[0]),
+      isSpaceMember(db, siteRow.spaceId, userId),
+      resolveIsShared(db, siteRow.id, userId),
+    ])
     if (!userRow) return c.text('Forbidden', 403)
-    const user = toSessionUser(userRow)
-    const isMember = await isSpaceMember(db, siteRow.spaceId, user.id)
-    const isShared = await resolveIsShared(db, siteRow.id, user.id)
-    const access = checkAccess(siteRow, user, isMember, isShared)
+    const access = checkAccess(siteRow, toSessionUser(userRow), isMember, isShared)
     if (!access.ok) return c.text('Forbidden', access.status)
   }
 

--- a/packages/api/src/db/repo.ts
+++ b/packages/api/src/db/repo.ts
@@ -100,19 +100,22 @@ export async function isSpaceMember(db: DrizzleD1Database, spaceId: string, user
 
 /** True if a site is explicitly shared with the user — directly, or via a group they're in. */
 export async function resolveIsShared(db: DrizzleD1Database, siteId: string, userId: string): Promise<boolean> {
-  const direct = await db
-    .select({ siteId: siteUserShares.siteId })
-    .from(siteUserShares)
-    .where(and(eq(siteUserShares.siteId, siteId), eq(siteUserShares.userId, userId)))
-    .limit(1)
-  if (direct.length > 0) return true
-  const viaGroup = await db
-    .select({ siteId: siteGroupShares.siteId })
-    .from(siteGroupShares)
-    .innerJoin(spaceMembers, eq(spaceMembers.spaceId, siteGroupShares.spaceId))
-    .where(and(eq(siteGroupShares.siteId, siteId), eq(spaceMembers.userId, userId)))
-    .limit(1)
-  return viaGroup.length > 0
+  // Direct and via-group grants are independent — resolve both in one round trip rather than
+  // serially. Drops the direct-hit short-circuit (one extra cheap query) to save a round trip.
+  const [direct, viaGroup] = await Promise.all([
+    db
+      .select({ siteId: siteUserShares.siteId })
+      .from(siteUserShares)
+      .where(and(eq(siteUserShares.siteId, siteId), eq(siteUserShares.userId, userId)))
+      .limit(1),
+    db
+      .select({ siteId: siteGroupShares.siteId })
+      .from(siteGroupShares)
+      .innerJoin(spaceMembers, eq(spaceMembers.spaceId, siteGroupShares.spaceId))
+      .where(and(eq(siteGroupShares.siteId, siteId), eq(spaceMembers.userId, userId)))
+      .limit(1),
+  ])
+  return direct.length > 0 || viaGroup.length > 0
 }
 
 /** Set of space ids the user is a member of (mirrors `sharedSiteIds` for the search candidate query). */
@@ -126,15 +129,14 @@ export async function memberSpaceIds(db: DrizzleD1Database, userId: string): Pro
 
 /** Set of site ids explicitly shared with the user (direct + via group membership). */
 export async function sharedSiteIds(db: DrizzleD1Database, userId: string): Promise<Set<string>> {
-  const direct = await db
-    .select({ siteId: siteUserShares.siteId })
-    .from(siteUserShares)
-    .where(eq(siteUserShares.userId, userId))
-  const viaGroup = await db
-    .select({ siteId: siteGroupShares.siteId })
-    .from(siteGroupShares)
-    .innerJoin(spaceMembers, eq(spaceMembers.spaceId, siteGroupShares.spaceId))
-    .where(eq(spaceMembers.userId, userId))
+  const [direct, viaGroup] = await Promise.all([
+    db.select({ siteId: siteUserShares.siteId }).from(siteUserShares).where(eq(siteUserShares.userId, userId)),
+    db
+      .select({ siteId: siteGroupShares.siteId })
+      .from(siteGroupShares)
+      .innerJoin(spaceMembers, eq(spaceMembers.spaceId, siteGroupShares.spaceId))
+      .where(eq(spaceMembers.userId, userId)),
+  ])
   return new Set([...direct, ...viaGroup].map((r) => r.siteId))
 }
 

--- a/packages/api/src/lib/site-access.ts
+++ b/packages/api/src/lib/site-access.ts
@@ -64,8 +64,9 @@ export async function resolveSiteForAccess(
 ): Promise<SiteAccess> {
   const site = await resolveSite(db, spaceSlug, siteSlug)
   if (!site) return { site: null, isMember: false, isShared: false, access: { ok: false, status: 403 } }
-  const isMember = user ? await isSpaceMember(db, site.spaceId, user.id) : false
-  const isShared = user ? await resolveIsShared(db, site.id, user.id) : false
+  const [isMember, isShared] = user
+    ? await Promise.all([isSpaceMember(db, site.spaceId, user.id), resolveIsShared(db, site.id, user.id)])
+    : [false, false]
   const access = checkAccess(site, user, isMember, isShared)
   return { site, isMember, isShared, access }
 }

--- a/packages/web/src/components/SitesTable.tsx
+++ b/packages/web/src/components/SitesTable.tsx
@@ -1,26 +1,15 @@
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useState } from 'react'
 import { useRevalidator } from 'react-router'
-import {
-  ArrowDown,
-  ArrowUp,
-  ChevronsUpDown,
-  Copy,
-  ExternalLink,
-  FolderInput,
-  MoreVertical,
-  Pencil,
-  Share2,
-  Trash2,
-} from 'lucide-react'
+import { Copy, ExternalLink, FolderInput, MoreVertical, Pencil, Share2, Trash2 } from 'lucide-react'
 import { toast } from 'sonner'
 import { ConfirmDialog } from '@/components/ConfirmDialog'
 import { ShareDialog } from '@/components/ShareDialog'
+import { createdColumn, nameColumn, urlColumn, visRank } from '@/components/siteColumns'
+import { SortableTable, type Column } from '@/components/SortableTable'
 import { SpaceSelect } from '@/components/SpaceSelect'
 import { Spinner } from '@/components/states'
 import { VisibilityMenu } from '@/components/visibility'
-import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
-import { Card } from '@/components/ui/card'
 import {
   Dialog,
   DialogContent,
@@ -38,107 +27,45 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
 import { api } from '@/lib/api'
-import { timeAgo } from '@/lib/time'
 import type { SiteSummary, SpaceSummary, Visibility } from '@/lib/types'
-import { cn } from '@/lib/utils'
 
 const visibilityLabel = (v: Visibility): string => v.charAt(0).toUpperCase() + v.slice(1)
 
-// ─── Sortable table ──────────────────────────────────────────────────────────
-
-type SortKey = 'name' | 'visibility' | 'created'
-type Sort = { key: SortKey; dir: 'asc' | 'desc' }
-
-const VIS_RANK: Record<Visibility, number> = { private: 0, members: 1, team: 2 }
-const COMPARE: Record<SortKey, (a: SiteSummary, b: SiteSummary) => number> = {
-  name: (a, b) => (a.title ?? a.siteSlug).localeCompare(b.title ?? b.siteSlug),
-  visibility: (a, b) => VIS_RANK[a.visibility] - VIS_RANK[b.visibility],
-  created: (a, b) => a.createdAt.localeCompare(b.createdAt), // ISO 8601 sorts lexicographically
-}
-
 export function SitesTable({ sites }: { sites: SiteSummary[] }) {
-  const [sort, setSort] = useState<Sort>({ key: 'created', dir: 'desc' })
-
-  const rows = useMemo(() => {
-    const sorted = [...sites].sort(COMPARE[sort.key])
-    return sort.dir === 'asc' ? sorted : sorted.reverse()
-  }, [sites, sort])
-
-  // Click a column: flip direction if already active, else select it (newest-first for dates,
-  // A→Z otherwise).
-  const toggle = (key: SortKey) =>
-    setSort((s) =>
-      s.key === key
-        ? { key, dir: s.dir === 'asc' ? 'desc' : 'asc' }
-        : { key, dir: key === 'created' ? 'desc' : 'asc' },
-    )
-
+  const columns: Column<SiteSummary>[] = [
+    nameColumn(),
+    urlColumn(),
+    {
+      key: 'visibility',
+      label: 'Visibility',
+      compare: (a, b) => visRank(a.visibility) - visRank(b.visibility),
+      render: (s) => <OwnerVisibilityCell site={s} />,
+    },
+    createdColumn(),
+    {
+      key: 'actions',
+      label: '',
+      headClassName: 'text-right',
+      cellClassName: 'text-right',
+      render: (s) => <OwnerActions site={s} />,
+    },
+  ]
   return (
-    <Card className="gap-0 overflow-hidden py-0">
-      <Table>
-        <TableHeader>
-          <TableRow className="hover:bg-transparent">
-            <SortHead label="Name" sortKey="name" sort={sort} onToggle={toggle} />
-            <TableHead>URL</TableHead>
-            <SortHead label="Visibility" sortKey="visibility" sort={sort} onToggle={toggle} />
-            <SortHead label="Created" sortKey="created" sort={sort} onToggle={toggle} />
-            <TableHead className="text-right">
-              <span className="sr-only">Actions</span>
-            </TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {rows.map((s) => (
-            <SiteRow key={s.id} site={s} />
-          ))}
-        </TableBody>
-      </Table>
-    </Card>
+    <SortableTable
+      rows={sites}
+      columns={columns}
+      getRowKey={(s) => s.id}
+      initialSort={{ key: 'created', dir: 'desc' }}
+    />
   )
 }
 
-function SortHead({
-  label,
-  sortKey,
-  sort,
-  onToggle,
-}: {
-  label: string
-  sortKey: SortKey
-  sort: Sort
-  onToggle: (key: SortKey) => void
-}) {
-  const active = sort.key === sortKey
-  const Icon = !active ? ChevronsUpDown : sort.dir === 'asc' ? ArrowUp : ArrowDown
-  return (
-    <TableHead>
-      <button
-        type="button"
-        onClick={() => onToggle(sortKey)}
-        className="-mx-1 inline-flex items-center gap-1 rounded px-1 font-medium hover:text-foreground/70"
-        aria-label={`Sort by ${label}`}
-      >
-        {label}
-        <Icon className={cn('size-3.5', active ? 'opacity-80' : 'opacity-40')} />
-      </button>
-    </TableHead>
-  )
-}
-
-// ─── Row ──────────────────────────────────────────────────────────────────────
-
-type RowDialog = 'rename' | 'move' | 'share' | 'delete' | null
-
-function SiteRow({ site }: { site: SiteSummary }) {
+// Owner-only visibility control: an optimistic chip that opens the tier picker.
+function OwnerVisibilityCell({ site }: { site: SiteSummary }) {
   const revalidator = useRevalidator()
   const [pendingVis, setPendingVis] = useState<Visibility | null>(null)
-  const [dialog, setDialog] = useState<RowDialog>(null)
   const visibility = pendingVis ?? site.visibility
-  const archived = site.status === 'archived'
-  const refresh = () => revalidator.revalidate()
-  const close = () => setDialog(null)
 
   async function changeVisibility(v: Visibility) {
     setPendingVis(v)
@@ -146,7 +73,7 @@ function SiteRow({ site }: { site: SiteSummary }) {
       await api.patch(`/api/sites/${site.spaceSlug}/${site.siteSlug}`, { visibility: v })
       toast.success('Visibility updated', { description: visibilityLabel(v) })
       setPendingVis(null) // drop the optimistic value; revalidated loader is source of truth
-      refresh()
+      revalidator.revalidate()
     } catch (err) {
       setPendingVis(null)
       toast.error('Could not update visibility', {
@@ -154,6 +81,18 @@ function SiteRow({ site }: { site: SiteSummary }) {
       })
     }
   }
+
+  return <VisibilityMenu trigger="chip" value={visibility} onChange={changeVisibility} />
+}
+
+type RowDialog = 'rename' | 'move' | 'share' | 'delete' | null
+
+// Open + a kebab that collapses Rename / Move / Share / Copy link / Delete.
+function OwnerActions({ site }: { site: SiteSummary }) {
+  const revalidator = useRevalidator()
+  const [dialog, setDialog] = useState<RowDialog>(null)
+  const refresh = () => revalidator.revalidate()
+  const close = () => setDialog(null)
 
   async function copyLink() {
     try {
@@ -165,107 +104,69 @@ function SiteRow({ site }: { site: SiteSummary }) {
   }
 
   return (
-    <TableRow>
-      <TableCell className="max-w-[15rem]">
-        <div className="flex items-center gap-2">
-          <span className="truncate font-medium">{site.title ?? site.siteSlug}</span>
-          {archived && <Badge variant="secondary">archived</Badge>}
-        </div>
-      </TableCell>
-      <TableCell className="max-w-[22rem]">
-        <a
-          href={site.url}
-          target="_blank"
-          rel="noreferrer"
-          className="block truncate font-mono text-sm text-muted-foreground hover:text-foreground hover:underline"
-        >
-          {site.url.replace(/^https?:\/\//, '')}
+    <div className="flex items-center justify-end gap-1">
+      <Button asChild variant="outline" size="sm">
+        <a href={site.url} target="_blank" rel="noreferrer">
+          <ExternalLink />
+          Open
         </a>
-      </TableCell>
-      <TableCell>
-        <VisibilityMenu trigger="chip" value={visibility} onChange={changeVisibility} />
-      </TableCell>
-      <TableCell className="text-sm text-muted-foreground">
-        <time dateTime={site.createdAt} title={new Date(site.createdAt).toLocaleString()}>
-          {timeAgo(site.createdAt)}
-        </time>
-      </TableCell>
-      <TableCell className="text-right">
-        <div className="flex items-center justify-end gap-1">
-          <Button asChild variant="outline" size="sm">
-            <a href={site.url} target="_blank" rel="noreferrer">
-              <ExternalLink />
-              Open
-            </a>
+      </Button>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="ghost" size="icon" aria-label="More actions">
+            <MoreVertical />
           </Button>
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button variant="ghost" size="icon" aria-label="More actions">
-                <MoreVertical />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="w-44">
-              <DropdownMenuItem onSelect={() => setDialog('rename')}>
-                <Pencil />
-                Rename
-              </DropdownMenuItem>
-              <DropdownMenuItem onSelect={() => setDialog('move')}>
-                <FolderInput />
-                Move
-              </DropdownMenuItem>
-              <DropdownMenuItem onSelect={() => setDialog('share')}>
-                <Share2 />
-                Share…
-              </DropdownMenuItem>
-              <DropdownMenuItem onSelect={() => void copyLink()}>
-                <Copy />
-                Copy link
-              </DropdownMenuItem>
-              <DropdownMenuSeparator />
-              <DropdownMenuItem variant="destructive" onSelect={() => setDialog('delete')}>
-                <Trash2 />
-                Delete
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
-        </div>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-44">
+          <DropdownMenuItem onSelect={() => setDialog('rename')}>
+            <Pencil />
+            Rename
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => setDialog('move')}>
+            <FolderInput />
+            Move
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => setDialog('share')}>
+            <Share2 />
+            Share…
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => void copyLink()}>
+            <Copy />
+            Copy link
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem variant="destructive" onSelect={() => setDialog('delete')}>
+            <Trash2 />
+            Delete
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
 
-        {/* Controlled dialogs driven by the kebab (a Dialog trigger can't live inside a menu item
-            cleanly). Each renders only a portaled body — nothing inline in the cell. */}
-        <RenameDialog
-          site={site}
-          open={dialog === 'rename'}
-          onOpenChange={(o) => !o && close()}
-          onDone={refresh}
-        />
-        <MoveDialog
-          site={site}
-          open={dialog === 'move'}
-          onOpenChange={(o) => !o && close()}
-          onDone={refresh}
-        />
-        <ShareDialog
-          spaceSlug={site.spaceSlug}
-          siteSlug={site.siteSlug}
-          title={site.title}
-          open={dialog === 'share'}
-          onOpenChange={(o) => !o && close()}
-        />
-        <ConfirmDialog
-          open={dialog === 'delete'}
-          onOpenChange={(o) => !o && close()}
-          title={`Delete ${site.spaceSlug}/${site.siteSlug}?`}
-          description="This permanently removes the site and all its files."
-          confirmLabel="Delete"
-          destructive
-          onConfirm={async () => {
-            await api.delete(`/api/sites/${site.spaceSlug}/${site.siteSlug}`)
-            toast.success('Site deleted')
-            refresh()
-          }}
-        />
-      </TableCell>
-    </TableRow>
+      {/* Controlled dialogs driven by the kebab (a Dialog trigger can't live inside a menu item
+          cleanly). Each renders only a portaled body — nothing inline in the cell. */}
+      <RenameDialog site={site} open={dialog === 'rename'} onOpenChange={(o) => !o && close()} onDone={refresh} />
+      <MoveDialog site={site} open={dialog === 'move'} onOpenChange={(o) => !o && close()} onDone={refresh} />
+      <ShareDialog
+        spaceSlug={site.spaceSlug}
+        siteSlug={site.siteSlug}
+        title={site.title}
+        open={dialog === 'share'}
+        onOpenChange={(o) => !o && close()}
+      />
+      <ConfirmDialog
+        open={dialog === 'delete'}
+        onOpenChange={(o) => !o && close()}
+        title={`Delete ${site.spaceSlug}/${site.siteSlug}?`}
+        description="This permanently removes the site and all its files."
+        confirmLabel="Delete"
+        destructive
+        onConfirm={async () => {
+          await api.delete(`/api/sites/${site.spaceSlug}/${site.siteSlug}`)
+          toast.success('Site deleted')
+          refresh()
+        }}
+      />
+    </div>
   )
 }
 

--- a/packages/web/src/components/SitesTable.tsx
+++ b/packages/web/src/components/SitesTable.tsx
@@ -1,10 +1,17 @@
 import { useCallback, useState } from 'react'
 import { useRevalidator } from 'react-router'
-import { Copy, ExternalLink, FolderInput, MoreVertical, Pencil, Share2, Trash2 } from 'lucide-react'
+import { Copy, FolderInput, MoreVertical, Pencil, Share2, Trash2 } from 'lucide-react'
 import { toast } from 'sonner'
 import { ConfirmDialog } from '@/components/ConfirmDialog'
 import { ShareDialog } from '@/components/ShareDialog'
-import { createdColumn, nameColumn, urlColumn, visRank } from '@/components/siteColumns'
+import {
+  actionsColumn,
+  createdColumn,
+  nameColumn,
+  OpenLinkButton,
+  urlColumn,
+  visibilityColumn,
+} from '@/components/siteColumns'
 import { SortableTable, type Column } from '@/components/SortableTable'
 import { SpaceSelect } from '@/components/SpaceSelect'
 import { Spinner } from '@/components/states'
@@ -32,29 +39,20 @@ import type { SiteSummary, SpaceSummary, Visibility } from '@/lib/types'
 
 const visibilityLabel = (v: Visibility): string => v.charAt(0).toUpperCase() + v.slice(1)
 
+// Stable module-scope columns so SortableTable's sort memo doesn't rebuild every render.
+const OWNER_COLUMNS: Column<SiteSummary>[] = [
+  nameColumn(),
+  urlColumn(),
+  visibilityColumn((s) => <OwnerVisibilityCell site={s} />),
+  createdColumn(),
+  actionsColumn((s) => <OwnerActions site={s} />),
+]
+
 export function SitesTable({ sites }: { sites: SiteSummary[] }) {
-  const columns: Column<SiteSummary>[] = [
-    nameColumn(),
-    urlColumn(),
-    {
-      key: 'visibility',
-      label: 'Visibility',
-      compare: (a, b) => visRank(a.visibility) - visRank(b.visibility),
-      render: (s) => <OwnerVisibilityCell site={s} />,
-    },
-    createdColumn(),
-    {
-      key: 'actions',
-      label: '',
-      headClassName: 'text-right',
-      cellClassName: 'text-right',
-      render: (s) => <OwnerActions site={s} />,
-    },
-  ]
   return (
     <SortableTable
       rows={sites}
-      columns={columns}
+      columns={OWNER_COLUMNS}
       getRowKey={(s) => s.id}
       initialSort={{ key: 'created', dir: 'desc' }}
     />
@@ -105,12 +103,7 @@ function OwnerActions({ site }: { site: SiteSummary }) {
 
   return (
     <div className="flex items-center justify-end gap-1">
-      <Button asChild variant="outline" size="sm">
-        <a href={site.url} target="_blank" rel="noreferrer">
-          <ExternalLink />
-          Open
-        </a>
-      </Button>
+      <OpenLinkButton url={site.url} />
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button variant="ghost" size="icon" aria-label="More actions">

--- a/packages/web/src/components/SortableTable.tsx
+++ b/packages/web/src/components/SortableTable.tsx
@@ -1,0 +1,116 @@
+import { type ReactNode, useMemo, useState } from 'react'
+import { ArrowDown, ArrowUp, ChevronsUpDown } from 'lucide-react'
+import { Card } from '@/components/ui/card'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
+import { cn } from '@/lib/utils'
+
+export type SortDir = 'asc' | 'desc'
+
+export type Column<T> = {
+  key: string
+  label: string
+  render: (row: T) => ReactNode
+  // Provide `compare` to make the column sortable; omit for a static column (URL, actions).
+  compare?: (a: T, b: T) => number
+  // Direction applied when this column is first selected (e.g. 'desc' for dates).
+  defaultDir?: SortDir
+  headClassName?: string
+  cellClassName?: string
+}
+
+// One sortable table shell shared by every site-collection (Your sites / Shared / Team activity)
+// so they stay visually identical — columns and per-cell rendering are the only differences.
+export function SortableTable<T>({
+  rows,
+  columns,
+  getRowKey,
+  initialSort,
+}: {
+  rows: T[]
+  columns: Column<T>[]
+  getRowKey: (row: T) => string
+  initialSort: { key: string; dir: SortDir }
+}) {
+  const [sort, setSort] = useState(initialSort)
+  const active = columns.find((c) => c.key === sort.key)
+
+  const sorted = useMemo(() => {
+    if (!active?.compare) return rows
+    const arr = [...rows].sort(active.compare)
+    return sort.dir === 'asc' ? arr : arr.reverse()
+  }, [rows, active, sort.dir])
+
+  const toggle = (col: Column<T>) =>
+    setSort((s) =>
+      s.key === col.key
+        ? { key: col.key, dir: s.dir === 'asc' ? 'desc' : 'asc' }
+        : { key: col.key, dir: col.defaultDir ?? 'asc' },
+    )
+
+  return (
+    <Card className="gap-0 overflow-hidden py-0">
+      <Table>
+        <TableHeader>
+          <TableRow className="hover:bg-transparent">
+            {columns.map((c) =>
+              c.compare ? (
+                <SortHead
+                  key={c.key}
+                  label={c.label}
+                  active={sort.key === c.key}
+                  dir={sort.dir}
+                  onToggle={() => toggle(c)}
+                  className={c.headClassName}
+                />
+              ) : (
+                <TableHead key={c.key} className={c.headClassName}>
+                  {c.label ? c.label : <span className="sr-only">Actions</span>}
+                </TableHead>
+              ),
+            )}
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {sorted.map((row) => (
+            <TableRow key={getRowKey(row)}>
+              {columns.map((c) => (
+                <TableCell key={c.key} className={c.cellClassName}>
+                  {c.render(row)}
+                </TableCell>
+              ))}
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </Card>
+  )
+}
+
+function SortHead({
+  label,
+  active,
+  dir,
+  onToggle,
+  className,
+}: {
+  label: string
+  active: boolean
+  dir: SortDir
+  onToggle: () => void
+  className?: string
+}) {
+  const Icon = !active ? ChevronsUpDown : dir === 'asc' ? ArrowUp : ArrowDown
+  return (
+    <TableHead className={className}>
+      <button
+        type="button"
+        onClick={onToggle}
+        className="-mx-1 inline-flex items-center gap-1 rounded px-1 font-medium hover:text-foreground/70"
+        aria-label={`Sort by ${label}`}
+      >
+        {label}
+        <Icon className={cn('size-3.5', active ? 'opacity-80' : 'opacity-40')} />
+      </button>
+    </TableHead>
+  )
+}

--- a/packages/web/src/components/SortableTable.tsx
+++ b/packages/web/src/components/SortableTable.tsx
@@ -18,8 +18,15 @@ export type Column<T> = {
   cellClassName?: string
 }
 
+// Below `sm` the table reflows into stacked label/value rows so actions are reachable without a
+// horizontal scroll; each cell's column label rides in via `data-label`. At `sm`+ it's a table.
+const mobileRow = 'max-sm:block max-sm:py-2'
+const mobileCell =
+  'max-sm:flex max-sm:items-center max-sm:justify-between max-sm:gap-4 max-sm:max-w-none max-sm:whitespace-normal max-sm:px-4 max-sm:py-1.5 max-sm:before:font-medium max-sm:before:text-sm max-sm:before:text-muted-foreground max-sm:before:content-[attr(data-label)]'
+
 // One sortable table shell shared by every site-collection (Your sites / Shared / Team activity)
 // so they stay visually identical — columns and per-cell rendering are the only differences.
+// Pass a STABLE `columns` (module-scope or memoized): the sort memo keys on the resolved column.
 export function SortableTable<T>({
   rows,
   columns,
@@ -36,8 +43,10 @@ export function SortableTable<T>({
 
   const sorted = useMemo(() => {
     if (!active?.compare) return rows
-    const arr = [...rows].sort(active.compare)
-    return sort.dir === 'asc' ? arr : arr.reverse()
+    const compare = active.compare
+    const dir = sort.dir === 'asc' ? 1 : -1
+    // Negate rather than `.reverse()` so equal-key rows keep their relative order in both directions.
+    return [...rows].sort((a, b) => dir * compare(a, b))
   }, [rows, active, sort.dir])
 
   const toggle = (col: Column<T>) =>
@@ -49,8 +58,8 @@ export function SortableTable<T>({
 
   return (
     <Card className="gap-0 overflow-hidden py-0">
-      <Table>
-        <TableHeader>
+      <Table className="max-sm:block">
+        <TableHeader className="max-sm:hidden">
           <TableRow className="hover:bg-transparent">
             {columns.map((c) =>
               c.compare ? (
@@ -70,11 +79,11 @@ export function SortableTable<T>({
             )}
           </TableRow>
         </TableHeader>
-        <TableBody>
+        <TableBody className="max-sm:block">
           {sorted.map((row) => (
-            <TableRow key={getRowKey(row)}>
+            <TableRow key={getRowKey(row)} className={mobileRow}>
               {columns.map((c) => (
-                <TableCell key={c.key} className={c.cellClassName}>
+                <TableCell key={c.key} data-label={c.label} className={cn(mobileCell, c.cellClassName)}>
                   {c.render(row)}
                 </TableCell>
               ))}
@@ -101,7 +110,7 @@ function SortHead({
 }) {
   const Icon = !active ? ChevronsUpDown : dir === 'asc' ? ArrowUp : ArrowDown
   return (
-    <TableHead className={className}>
+    <TableHead className={className} aria-sort={active ? (dir === 'asc' ? 'ascending' : 'descending') : 'none'}>
       <button
         type="button"
         onClick={onToggle}

--- a/packages/web/src/components/siteColumns.tsx
+++ b/packages/web/src/components/siteColumns.tsx
@@ -1,0 +1,70 @@
+import type { Column } from '@/components/SortableTable'
+import { VisibilityBadge } from '@/components/visibility'
+import { Badge } from '@/components/ui/badge'
+import { timeAgo } from '@/lib/time'
+import type { SiteSummary, Visibility } from '@/lib/types'
+
+// Reusable site-table columns. Every site-collection shares Name / URL / Visibility / Created so
+// the three tables read as one system; the owner table swaps in its own interactive visibility
+// cell + actions.
+
+const VIS_RANK: Record<Visibility, number> = { private: 0, members: 1, team: 2 }
+export const visRank = (v: Visibility): number => VIS_RANK[v]
+
+export function nameColumn<T extends SiteSummary>(): Column<T> {
+  return {
+    key: 'name',
+    label: 'Name',
+    headClassName: 'max-w-[15rem]',
+    cellClassName: 'max-w-[15rem]',
+    compare: (a, b) => (a.title ?? a.siteSlug).localeCompare(b.title ?? b.siteSlug),
+    render: (s) => (
+      <div className="flex items-center gap-2">
+        <span className="truncate font-medium">{s.title ?? s.siteSlug}</span>
+        {s.status === 'archived' && <Badge variant="secondary">archived</Badge>}
+      </div>
+    ),
+  }
+}
+
+export function urlColumn<T extends SiteSummary>(): Column<T> {
+  return {
+    key: 'url',
+    label: 'URL',
+    cellClassName: 'max-w-[22rem]',
+    render: (s) => (
+      <a
+        href={s.url}
+        target="_blank"
+        rel="noreferrer"
+        className="block truncate font-mono text-sm text-muted-foreground hover:text-foreground hover:underline"
+      >
+        {s.url.replace(/^https?:\/\//, '')}
+      </a>
+    ),
+  }
+}
+
+export function visibilityBadgeColumn<T extends SiteSummary>(): Column<T> {
+  return {
+    key: 'visibility',
+    label: 'Visibility',
+    compare: (a, b) => visRank(a.visibility) - visRank(b.visibility),
+    render: (s) => <VisibilityBadge value={s.visibility} />,
+  }
+}
+
+export function createdColumn<T extends SiteSummary>(key = 'created', label = 'Created'): Column<T> {
+  return {
+    key,
+    label,
+    defaultDir: 'desc',
+    compare: (a, b) => a.createdAt.localeCompare(b.createdAt), // ISO 8601 sorts lexicographically
+    cellClassName: 'text-sm text-muted-foreground',
+    render: (s) => (
+      <time dateTime={s.createdAt} title={new Date(s.createdAt).toLocaleString()}>
+        {timeAgo(s.createdAt)}
+      </time>
+    ),
+  }
+}

--- a/packages/web/src/components/siteColumns.tsx
+++ b/packages/web/src/components/siteColumns.tsx
@@ -1,6 +1,9 @@
+import type { ReactNode } from 'react'
+import { ExternalLink } from 'lucide-react'
 import type { Column } from '@/components/SortableTable'
 import { VisibilityBadge } from '@/components/visibility'
 import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
 import { timeAgo } from '@/lib/time'
 import type { SiteSummary, Visibility } from '@/lib/types'
 
@@ -45,13 +48,37 @@ export function urlColumn<T extends SiteSummary>(): Column<T> {
   }
 }
 
-export function visibilityBadgeColumn<T extends SiteSummary>(): Column<T> {
+// Visibility column owns the rank-compare; callers supply the cell (a static badge, or the
+// owner's interactive tier picker) so the sort stays defined in one place.
+export function visibilityColumn<T extends SiteSummary>(render: (row: T) => ReactNode): Column<T> {
   return {
     key: 'visibility',
     label: 'Visibility',
     compare: (a, b) => visRank(a.visibility) - visRank(b.visibility),
-    render: (s) => <VisibilityBadge value={s.visibility} />,
+    render,
   }
+}
+
+export function visibilityBadgeColumn<T extends SiteSummary>(): Column<T> {
+  return visibilityColumn<T>((s) => <VisibilityBadge value={s.visibility} />)
+}
+
+// "Open in a new tab" button — the trailing action every site row carries.
+export function OpenLinkButton({ url }: { url: string }) {
+  return (
+    <Button asChild variant="outline" size="sm">
+      <a href={url} target="_blank" rel="noreferrer">
+        <ExternalLink />
+        Open
+      </a>
+    </Button>
+  )
+}
+
+// Trailing actions cell — the right-aligned shape shared by all three tables; `render` supplies
+// the buttons (Open + kebab / Copy + Open / Open).
+export function actionsColumn<T>(render: (row: T) => ReactNode): Column<T> {
+  return { key: 'actions', label: '', headClassName: 'text-right', cellClassName: 'text-right', render }
 }
 
 export function createdColumn<T extends SiteSummary>(key = 'created', label = 'Created'): Column<T> {

--- a/packages/web/src/routes/dashboard.tsx
+++ b/packages/web/src/routes/dashboard.tsx
@@ -1,8 +1,11 @@
-import { useRef, useState } from 'react'
+import { Suspense, useMemo, useRef, useState } from 'react'
 import {
+  Await,
   Link,
-  type LoaderFunctionArgs,
+  Navigate,
+  useAsyncError,
   useLoaderData,
+  useLocation,
   useNavigate,
   useRevalidator,
   useSearchParams,
@@ -16,10 +19,12 @@ import {
 } from 'lucide-react'
 import { toast } from 'sonner'
 import { CopyButton } from '@/components/CopyButton'
+import { createdColumn, nameColumn, urlColumn, visibilityBadgeColumn } from '@/components/siteColumns'
 import { SitesTable } from '@/components/SitesTable'
+import { SortableTable, type Column } from '@/components/SortableTable'
 import { SpaceSelect } from '@/components/SpaceSelect'
 import { EmptyState, PageHeader, Spinner } from '@/components/states'
-import { VisibilityBadge, VisibilityMenu } from '@/components/visibility'
+import { VisibilityMenu } from '@/components/visibility'
 import { Button } from '@/components/ui/button'
 import {
   Card,
@@ -49,59 +54,59 @@ import {
 } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { Skeleton } from '@/components/ui/skeleton'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { api, ApiError } from '@/lib/api'
-import { toLogin } from '@/lib/nav'
-import { timeAgo } from '@/lib/time'
 import type { SiteSummary, SlugExists, SpaceSummary, TeamUpload, Visibility } from '@/lib/types'
 import { type DroppedFile, filesFromDataTransfer, filesFromInput } from '@/lib/walkFiles'
 import { uploadFiles } from '@/lib/uploadWithProgress'
 import { cn } from '@/lib/utils'
 
-export async function loader({ request }: LoaderFunctionArgs) {
-  try {
-    const [sites, shared, spaces, team] = await Promise.all([
-      api.get<SiteSummary[]>('/api/sites/mine'),
-      api.get<SiteSummary[]>('/api/sites/shared'),
-      api.get<SpaceSummary[]>('/api/spaces/mine'),
-      api.get<TeamUpload[]>('/api/sites/team'),
-    ])
-    return { sites, shared, spaces, team }
-  } catch (err) {
-    if (err instanceof ApiError && err.status === 401) throw toLogin(request)
-    throw err
+// Stream the feeds instead of blocking the route on them: the shell paints at root-loader time,
+// the deploy card streams on `spaces` alone, and the tabs stream once their feeds resolve —
+// rather than the whole page staying blank until the slowest call returns. Promises are consumed
+// via <Await>; a failed feed degrades only its own section (FeedError), and a 401 → login.
+export function loader() {
+  return {
+    sites: api.get<SiteSummary[]>('/api/sites/mine'),
+    shared: api.get<SiteSummary[]>('/api/sites/shared'),
+    spaces: api.get<SpaceSummary[]>('/api/spaces/mine'),
+    team: api.get<TeamUpload[]>('/api/sites/team'),
   }
 }
 
-function SharedSiteRow({ site }: { site: SiteSummary }) {
-  return (
-    <Card className="gap-0 py-0">
-      <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-3 p-4">
-        <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-2">
-            <span className="truncate font-medium">{site.title ?? site.siteSlug}</span>
-            <VisibilityBadge value={site.visibility} />
-          </div>
-          <a
-            href={site.url}
-            target="_blank"
-            rel="noreferrer"
-            className="font-mono text-sm text-muted-foreground hover:text-foreground hover:underline"
-          >
-            {site.url}
-          </a>
-        </div>
-        <div className="flex flex-wrap items-center gap-2">
-          <CopyButton text={site.url} label="" variant="outline" />
+// Sites shared with me — same table shell as Your sites, minus the owner-only actions.
+function SharedSitesTable({ sites }: { sites: SiteSummary[] }) {
+  const columns: Column<SiteSummary>[] = [
+    nameColumn(),
+    urlColumn(),
+    visibilityBadgeColumn(),
+    createdColumn(),
+    {
+      key: 'actions',
+      label: '',
+      headClassName: 'text-right',
+      cellClassName: 'text-right',
+      render: (s) => (
+        <div className="flex items-center justify-end gap-1">
+          <CopyButton text={s.url} label="" variant="outline" />
           <Button asChild variant="outline" size="sm">
-            <a href={site.url} target="_blank" rel="noreferrer">
+            <a href={s.url} target="_blank" rel="noreferrer">
               <ExternalLink />
               Open
             </a>
           </Button>
         </div>
-      </div>
-    </Card>
+      ),
+    },
+  ]
+  return (
+    <SortableTable
+      rows={sites}
+      columns={columns}
+      getRowKey={(s) => s.id}
+      initialSort={{ key: 'created', dir: 'desc' }}
+    />
   )
 }
 
@@ -113,12 +118,18 @@ type UploadState =
 
 export function Component() {
   const { sites, shared, spaces, team } = useLoaderData() as {
-    sites: SiteSummary[]
-    shared: SiteSummary[]
-    spaces: SpaceSummary[]
-    team: TeamUpload[]
+    sites: Promise<SiteSummary[]>
+    shared: Promise<SiteSummary[]>
+    spaces: Promise<SpaceSummary[]>
+    team: Promise<TeamUpload[]>
   }
-  const groupSpaces = spaces.filter((s) => s.type === 'group')
+  // The tabs need every count (and the conditional Shared tab) up front, so they share one Await on
+  // all four feeds. The deploy card only needs `spaces`, so it streams on its own — the primary
+  // action paints as soon as spaces resolves and a slow or failing feed can't block or break it.
+  // Each <Await> sees a STABLE promise across re-renders (a fresh Promise.all would re-suspend);
+  // revalidation yields new promises but React keeps the resolved UI through the RR transition, so
+  // refetch won't flash the skeletons — only the first paint does.
+  const tabsData = useMemo(() => Promise.all([sites, shared, spaces, team]), [sites, shared, spaces, team])
 
   return (
     <div className="space-y-10">
@@ -126,9 +137,37 @@ export function Component() {
         title="Drop a folder, get a URL"
         description="HTML and markdown render in the browser; everything else downloads."
       />
+      <Suspense fallback={<DeployCardSkeleton />}>
+        <Await resolve={spaces} errorElement={<FeedError what="the deploy form" />}>
+          {(spaces) => <DeployCard spaces={spaces} />}
+        </Await>
+      </Suspense>
+      <Suspense fallback={<TabsSkeleton />}>
+        <Await resolve={tabsData} errorElement={<FeedError what="your sites" />}>
+          {([sites, shared, spaces, team]) => (
+            <DashboardTabs sites={sites} shared={shared} spaces={spaces} team={team} />
+          )}
+        </Await>
+      </Suspense>
+    </div>
+  )
+}
 
-      <DeployCard spaces={spaces} />
+function DashboardTabs({
+  sites,
+  shared,
+  spaces,
+  team,
+}: {
+  sites: SiteSummary[]
+  shared: SiteSummary[]
+  spaces: SpaceSummary[]
+  team: TeamUpload[]
+}) {
+  const groupSpaces = spaces.filter((s) => s.type === 'group')
 
+  return (
+    <div className="space-y-10">
       <Tabs defaultValue="sites" className="gap-6">
         <TabsList variant="line">
           <TabsTrigger value="sites">
@@ -161,10 +200,8 @@ export function Component() {
         </TabsContent>
 
         {shared.length > 0 && (
-          <TabsContent value="shared" className="grid gap-3">
-            {shared.map((s) => (
-              <SharedSiteRow key={s.id} site={s} />
-            ))}
+          <TabsContent value="shared">
+            <SharedSitesTable sites={shared} />
           </TabsContent>
         )}
 
@@ -194,17 +231,50 @@ export function Component() {
               description="Team-visible sites show up here as people deploy them."
             />
           ) : (
-            <Card className="gap-0 py-0">
-              <ul className="divide-y">
-                {team.map((u) => (
-                  <TeamActivityRow key={u.id} upload={u} />
-                ))}
-              </ul>
-            </Card>
+            <TeamActivityTable team={team} />
           )}
         </TabsContent>
       </Tabs>
     </div>
+  )
+}
+
+// First paint, before the feeds resolve — one placeholder per streamed section.
+function DeployCardSkeleton() {
+  return <Skeleton className="h-44 w-full rounded-xl" aria-hidden />
+}
+
+function TabsSkeleton() {
+  return (
+    <div className="space-y-6" aria-hidden>
+      <div className="flex gap-4">
+        {['a', 'b', 'c', 'd'].map((k) => (
+          <Skeleton key={k} className="h-7 w-28" />
+        ))}
+      </div>
+      <div className="space-y-2">
+        {['a', 'b', 'c', 'd', 'e'].map((k) => (
+          <Skeleton key={k} className="h-12 w-full rounded-lg" />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+// A feed rejected. 401 = the session lapsed → bounce to login, preserving where we were. Anything
+// else renders a contained inline error so one failed feed degrades only its own section instead
+// of taking down the whole route.
+function FeedError({ what }: { what: string }) {
+  const error = useAsyncError()
+  const location = useLocation()
+  if (error instanceof ApiError && error.status === 401) {
+    return <Navigate to={`/login?next=${encodeURIComponent(location.pathname + location.search)}`} replace />
+  }
+  return (
+    <EmptyState
+      title={`Couldn't load ${what}`}
+      description={error instanceof Error ? error.message : 'Something went wrong. Try refreshing.'}
+    />
   )
 }
 
@@ -216,43 +286,43 @@ function TabCount({ n }: { n: number }) {
 
 // ─── Team activity ───────────────────────────────────────────────────────────
 
-function TeamActivityRow({ upload }: { upload: TeamUpload }) {
-  const who = upload.uploaderName ?? upload.uploaderEmail
-  return (
-    <li className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2 p-4">
-      <div className="min-w-0 flex-1">
-        <div className="flex items-center gap-2">
-          <span className="truncate font-medium">{upload.title ?? upload.siteSlug}</span>
-          <VisibilityBadge value={upload.visibility} />
-        </div>
-        <a
-          href={upload.url}
-          target="_blank"
-          rel="noreferrer"
-          className="font-mono text-sm text-muted-foreground hover:text-foreground hover:underline"
-        >
-          {upload.url}
-        </a>
-      </div>
-      <div className="flex shrink-0 items-center gap-3">
-        <div className="text-right text-sm">
-          <div className="truncate font-medium">{who}</div>
-          <time
-            className="text-xs text-muted-foreground"
-            dateTime={upload.createdAt}
-            title={new Date(upload.createdAt).toLocaleString()}
-          >
-            {timeAgo(upload.createdAt)}
-          </time>
-        </div>
+// Same table shell, with who-shipped + when columns. Defaults to newest-first (a feed).
+function TeamActivityTable({ team }: { team: TeamUpload[] }) {
+  const who = (u: TeamUpload) => u.uploaderName ?? u.uploaderEmail
+  const columns: Column<TeamUpload>[] = [
+    nameColumn(),
+    urlColumn(),
+    visibilityBadgeColumn(),
+    {
+      key: 'who',
+      label: 'Shipped by',
+      compare: (a, b) => who(a).localeCompare(who(b)),
+      cellClassName: 'max-w-[12rem]',
+      render: (u) => <span className="block truncate text-sm">{who(u)}</span>,
+    },
+    createdColumn('when', 'When'),
+    {
+      key: 'actions',
+      label: '',
+      headClassName: 'text-right',
+      cellClassName: 'text-right',
+      render: (u) => (
         <Button asChild variant="outline" size="sm">
-          <a href={upload.url} target="_blank" rel="noreferrer">
+          <a href={u.url} target="_blank" rel="noreferrer">
             <ExternalLink />
             Open
           </a>
         </Button>
-      </div>
-    </li>
+      ),
+    },
+  ]
+  return (
+    <SortableTable
+      rows={team}
+      columns={columns}
+      getRowKey={(u) => u.id}
+      initialSort={{ key: 'when', dir: 'desc' }}
+    />
   )
 }
 

--- a/packages/web/src/routes/dashboard.tsx
+++ b/packages/web/src/routes/dashboard.tsx
@@ -19,7 +19,14 @@ import {
 } from 'lucide-react'
 import { toast } from 'sonner'
 import { CopyButton } from '@/components/CopyButton'
-import { createdColumn, nameColumn, urlColumn, visibilityBadgeColumn } from '@/components/siteColumns'
+import {
+  actionsColumn,
+  createdColumn,
+  nameColumn,
+  OpenLinkButton,
+  urlColumn,
+  visibilityBadgeColumn,
+} from '@/components/siteColumns'
 import { SitesTable } from '@/components/SitesTable'
 import { SortableTable, type Column } from '@/components/SortableTable'
 import { SpaceSelect } from '@/components/SpaceSelect'
@@ -76,34 +83,24 @@ export function loader() {
 }
 
 // Sites shared with me — same table shell as Your sites, minus the owner-only actions.
+const SHARED_COLUMNS: Column<SiteSummary>[] = [
+  nameColumn(),
+  urlColumn(),
+  visibilityBadgeColumn(),
+  createdColumn(),
+  actionsColumn((s) => (
+    <div className="flex items-center justify-end gap-1">
+      <CopyButton text={s.url} label="" variant="outline" />
+      <OpenLinkButton url={s.url} />
+    </div>
+  )),
+]
+
 function SharedSitesTable({ sites }: { sites: SiteSummary[] }) {
-  const columns: Column<SiteSummary>[] = [
-    nameColumn(),
-    urlColumn(),
-    visibilityBadgeColumn(),
-    createdColumn(),
-    {
-      key: 'actions',
-      label: '',
-      headClassName: 'text-right',
-      cellClassName: 'text-right',
-      render: (s) => (
-        <div className="flex items-center justify-end gap-1">
-          <CopyButton text={s.url} label="" variant="outline" />
-          <Button asChild variant="outline" size="sm">
-            <a href={s.url} target="_blank" rel="noreferrer">
-              <ExternalLink />
-              Open
-            </a>
-          </Button>
-        </div>
-      ),
-    },
-  ]
   return (
     <SortableTable
       rows={sites}
-      columns={columns}
+      columns={SHARED_COLUMNS}
       getRowKey={(s) => s.id}
       initialSort={{ key: 'created', dir: 'desc' }}
     />
@@ -287,39 +284,28 @@ function TabCount({ n }: { n: number }) {
 // ─── Team activity ───────────────────────────────────────────────────────────
 
 // Same table shell, with who-shipped + when columns. Defaults to newest-first (a feed).
+const who = (u: TeamUpload) => u.uploaderName ?? u.uploaderEmail
+
+const TEAM_COLUMNS: Column<TeamUpload>[] = [
+  nameColumn(),
+  urlColumn(),
+  visibilityBadgeColumn(),
+  {
+    key: 'who',
+    label: 'Shipped by',
+    compare: (a, b) => who(a).localeCompare(who(b)),
+    cellClassName: 'max-w-[12rem]',
+    render: (u) => <span className="block truncate text-sm">{who(u)}</span>,
+  },
+  createdColumn('when', 'When'),
+  actionsColumn((u) => <OpenLinkButton url={u.url} />),
+]
+
 function TeamActivityTable({ team }: { team: TeamUpload[] }) {
-  const who = (u: TeamUpload) => u.uploaderName ?? u.uploaderEmail
-  const columns: Column<TeamUpload>[] = [
-    nameColumn(),
-    urlColumn(),
-    visibilityBadgeColumn(),
-    {
-      key: 'who',
-      label: 'Shipped by',
-      compare: (a, b) => who(a).localeCompare(who(b)),
-      cellClassName: 'max-w-[12rem]',
-      render: (u) => <span className="block truncate text-sm">{who(u)}</span>,
-    },
-    createdColumn('when', 'When'),
-    {
-      key: 'actions',
-      label: '',
-      headClassName: 'text-right',
-      cellClassName: 'text-right',
-      render: (u) => (
-        <Button asChild variant="outline" size="sm">
-          <a href={u.url} target="_blank" rel="noreferrer">
-            <ExternalLink />
-            Open
-          </a>
-        </Button>
-      ),
-    },
-  ]
   return (
     <SortableTable
       rows={team}
-      columns={columns}
+      columns={TEAM_COLUMNS}
       getRowKey={(u) => u.id}
       initialSort={{ key: 'when', dir: 'desc' }}
     />


### PR DESCRIPTION
## What

Two perf fixes for the two symptoms reported (site-open feels slow; dashboard shows a blank screen on load), plus a sites-table UX refactor that landed alongside.

### Perf — backend latency, not bundle/React (measured in-browser)
- **Content-worker site-open (~1.2s steady-state)** was ~6 **serial** D1 round trips: `site → user → membership → share×2 → file`, then R2. Now the user/membership/share lookups resolve in one round trip (`content.ts`), and the direct+group share queries (`repo.ts` `resolveIsShared` / `sharedSiteIds`) and `resolveSiteForAccess` (`site-access.ts`) are parallelized. **File + R2 stay after the access gate** — the zero-work-gate (forbidden → no R2) is preserved.
- **Dashboard FCP (~1750ms blank)** was the route loader blocking first paint on the slowest of 4 feeds. The loader now **streams** (returns the promises unawaited); the shell paints immediately with a `Suspense`/`Await` skeleton. A 401 surfaces through the `Await` errorElement → login.

### UX — sites-table refactor
Shared + Team activity render via a shared `SortableTable` scaffold (new `SortableTable.tsx` + `siteColumns.tsx`; `SitesTable.tsx` refactored onto it). Spaces stay cards.

## Screenshots

**Your sites — sortable table + tabs** (Name / URL / Visibility chip / Created; Open + ⋮ kebab per row)

![Your sites table](https://github.com/plivo-labs/glance/releases/download/assets-pr5-sites-tables/your-sites-table.png)

**Team activity — same table shell**, with sortable **Shipped by** / **When** columns (Spaces intentionally stay a card grid — they're containers you click into, not actionable rows)

![Team activity table](https://github.com/plivo-labs/glance/releases/download/assets-pr5-sites-tables/team-activity-table.png)

## Verification
- typecheck + biome lint + **169 tests** (api 155, web 6, cli 8) green on the settled tree.
- sites-table UX browser-smoked on the production bundle (worker :8787): tables render, kebab actions collapse, controlled dialogs open from menu items, **0 console errors**.
- Annotate transform ruled out as a cost (A/B ≈ identical); the gain is in the serial-D1 collapse.

## Not yet verified
Latency win is **predicted, not measured post-change**: ~1.2s→~0.7s site-open, ~1750ms→~250ms FCP (warm). Needs a deploy + the same browser decomposition to confirm.

## Do not merge
Merge handled separately.

Co-authored by the perf agent (streaming + access-chain) and the sites-table UX agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
