### PR TITLE
feat: usage analytics — views, CLI, comments, storage + admin dashboard

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,16 @@ jobs:
         with:
           bun-version: latest
 
+      # Stamp the release tag (v1.2.3 → 1.2.3) into package.json BEFORE building, so the static
+      # `import pkg from './package.json'` baked into each binary reports the exact release version
+      # in its User-Agent (drives CLI-usage analytics).
+      - name: Stamp version from tag
+        working-directory: packages/cli
+        run: |
+          v="${GITHUB_REF_NAME#v}"
+          tmp="$(mktemp)"
+          jq --arg v "$v" '.version = $v' package.json > "$tmp" && mv "$tmp" package.json
+
       - name: Build standalone binaries
         working-directory: packages/cli
         run: |

--- a/packages/api/drizzle/0005_peaceful_onslaught.sql
+++ b/packages/api/drizzle/0005_peaceful_onslaught.sql
@@ -1,0 +1,16 @@
+CREATE TABLE `events` (
+	`id` text PRIMARY KEY NOT NULL,
+	`type` text NOT NULL,
+	`action` text,
+	`userId` text,
+	`siteId` text,
+	`siteLabel` text,
+	`cliVersion` text,
+	`createdAt` text NOT NULL,
+	FOREIGN KEY (`userId`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null,
+	FOREIGN KEY (`siteId`) REFERENCES `sites`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE INDEX `events_type_created` ON `events` (`type`,`createdAt`);--> statement-breakpoint
+CREATE INDEX `events_site_created` ON `events` (`siteId`,`createdAt`);--> statement-breakpoint
+CREATE INDEX `events_user_created` ON `events` (`userId`,`createdAt`);

--- a/packages/api/drizzle/meta/0005_snapshot.json
+++ b/packages/api/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,941 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "dbff177f-f20b-482a-ab53-ced187735630",
+  "prevId": "8efde753-f51d-4428-a54a-912fb94122bd",
+  "tables": {
+    "comment_threads": {
+      "name": "comment_threads",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "siteId": {
+          "name": "siteId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "filePath": {
+          "name": "filePath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "anchorType": {
+          "name": "anchorType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'text'"
+        },
+        "anchor": {
+          "name": "anchor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quote": {
+          "name": "quote",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "contentHash": {
+          "name": "contentHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "anchorStatus": {
+          "name": "anchorStatus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'anchored'"
+        },
+        "start": {
+          "name": "start",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "end": {
+          "name": "end",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'open'"
+        },
+        "resolvedBy": {
+          "name": "resolvedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolvedAt": {
+          "name": "resolvedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "threads_site_file_status": {
+          "name": "threads_site_file_status",
+          "columns": [
+            "siteId",
+            "filePath",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "threads_site_status_updated": {
+          "name": "threads_site_status_updated",
+          "columns": [
+            "siteId",
+            "status",
+            "updatedAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "comment_threads_siteId_sites_id_fk": {
+          "name": "comment_threads_siteId_sites_id_fk",
+          "tableFrom": "comment_threads",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "siteId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "comment_threads_resolvedBy_users_id_fk": {
+          "name": "comment_threads_resolvedBy_users_id_fk",
+          "tableFrom": "comment_threads",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolvedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "comment_threads_createdBy_users_id_fk": {
+          "name": "comment_threads_createdBy_users_id_fk",
+          "tableFrom": "comment_threads",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comments": {
+      "name": "comments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "threadId": {
+          "name": "threadId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "authorId": {
+          "name": "authorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "editedAt": {
+          "name": "editedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "comments_thread_created": {
+          "name": "comments_thread_created",
+          "columns": [
+            "threadId",
+            "createdAt"
+          ],
+          "isUnique": false
+        },
+        "comments_author": {
+          "name": "comments_author",
+          "columns": [
+            "authorId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "comments_threadId_comment_threads_id_fk": {
+          "name": "comments_threadId_comment_threads_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "comment_threads",
+          "columnsFrom": [
+            "threadId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "comments_authorId_users_id_fk": {
+          "name": "comments_authorId_users_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "authorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "siteId": {
+          "name": "siteId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "siteLabel": {
+          "name": "siteLabel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cliVersion": {
+          "name": "cliVersion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "events_type_created": {
+          "name": "events_type_created",
+          "columns": [
+            "type",
+            "createdAt"
+          ],
+          "isUnique": false
+        },
+        "events_site_created": {
+          "name": "events_site_created",
+          "columns": [
+            "siteId",
+            "createdAt"
+          ],
+          "isUnique": false
+        },
+        "events_user_created": {
+          "name": "events_user_created",
+          "columns": [
+            "userId",
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "events_userId_users_id_fk": {
+          "name": "events_userId_users_id_fk",
+          "tableFrom": "events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "events_siteId_sites_id_fk": {
+          "name": "events_siteId_sites_id_fk",
+          "tableFrom": "events",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "siteId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "files": {
+      "name": "files",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "siteId": {
+          "name": "siteId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "storageKey": {
+          "name": "storageKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mimeType": {
+          "name": "mimeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "contentHash": {
+          "name": "contentHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "files_storageKey_unique": {
+          "name": "files_storageKey_unique",
+          "columns": [
+            "storageKey"
+          ],
+          "isUnique": true
+        },
+        "files_site_path_unq": {
+          "name": "files_site_path_unq",
+          "columns": [
+            "siteId",
+            "path"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "files_siteId_sites_id_fk": {
+          "name": "files_siteId_sites_id_fk",
+          "tableFrom": "files",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "siteId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "site_group_shares": {
+      "name": "site_group_shares",
+      "columns": {
+        "siteId": {
+          "name": "siteId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "spaceId": {
+          "name": "spaceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "site_group_shares_siteId_sites_id_fk": {
+          "name": "site_group_shares_siteId_sites_id_fk",
+          "tableFrom": "site_group_shares",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "siteId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "site_group_shares_spaceId_spaces_id_fk": {
+          "name": "site_group_shares_spaceId_spaces_id_fk",
+          "tableFrom": "site_group_shares",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "spaceId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "site_group_shares_siteId_spaceId_pk": {
+          "columns": [
+            "siteId",
+            "spaceId"
+          ],
+          "name": "site_group_shares_siteId_spaceId_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "site_user_shares": {
+      "name": "site_user_shares",
+      "columns": {
+        "siteId": {
+          "name": "siteId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "site_user_shares_siteId_sites_id_fk": {
+          "name": "site_user_shares_siteId_sites_id_fk",
+          "tableFrom": "site_user_shares",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "siteId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "site_user_shares_userId_users_id_fk": {
+          "name": "site_user_shares_userId_users_id_fk",
+          "tableFrom": "site_user_shares",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "site_user_shares_siteId_userId_pk": {
+          "columns": [
+            "siteId",
+            "userId"
+          ],
+          "name": "site_user_shares_siteId_userId_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sites": {
+      "name": "sites",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "spaceId": {
+          "name": "spaceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'team'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "sites_space_slug_unq": {
+          "name": "sites_space_slug_unq",
+          "columns": [
+            "spaceId",
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "sites_spaceId_spaces_id_fk": {
+          "name": "sites_spaceId_spaces_id_fk",
+          "tableFrom": "sites",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "spaceId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sites_ownerId_users_id_fk": {
+          "name": "sites_ownerId_users_id_fk",
+          "tableFrom": "sites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "ownerId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "space_members": {
+      "name": "space_members",
+      "columns": {
+        "spaceId": {
+          "name": "spaceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "space_members_spaceId_spaces_id_fk": {
+          "name": "space_members_spaceId_spaces_id_fk",
+          "tableFrom": "space_members",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "spaceId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "space_members_userId_users_id_fk": {
+          "name": "space_members_userId_users_id_fk",
+          "tableFrom": "space_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "space_members_spaceId_userId_pk": {
+          "columns": [
+            "spaceId",
+            "userId"
+          ],
+          "name": "space_members_spaceId_userId_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "spaces": {
+      "name": "spaces",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "spaces_slug_unique": {
+          "name": "spaces_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "spaces_createdBy_users_id_fk": {
+          "name": "spaces_createdBy_users_id_fk",
+          "tableFrom": "spaces",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "googleId": {
+          "name": "googleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "users_googleId_unique": {
+          "name": "users_googleId_unique",
+          "columns": [
+            "googleId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/api/drizzle/meta/_journal.json
+++ b/packages/api/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1782800000000,
       "tag": "0004_drop_public_visibility",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "6",
+      "when": 1783078966943,
+      "tag": "0005_peaceful_onslaught",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/src/content.test.ts
+++ b/packages/api/src/content.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'bun:test'
 import { Hono } from 'hono'
 import contentApp, { contentType, markdown, normalizePath, restOf } from './content'
-import { sites, spaces, users } from './db/schema'
+import { events, sites, spaces, users } from './db/schema'
 import { sanitizePath } from './lib/storage'
 import { signToken, verifyToken } from './lib/token'
 import { makeDb, makeR2, seedFile, seedSite, seedSpace, seedUser } from './test/harness'
@@ -201,6 +201,60 @@ describe('directory listing fallback (no index.html)', () => {
     const res = await app.request(`/_t/${token}/sam/site/`, {}, env)
     expect(res.status).toBe(200)
     expect(await res.text()).toBe('<h1>Report</h1>')
+  })
+})
+
+describe('view analytics (page-view events)', () => {
+  function setup() {
+    const db = makeDb()
+    const r2 = makeR2()
+    const app = new Hono()
+    app.use('*', async (c, next) => {
+      c.set('db', db)
+      await next()
+    })
+    app.route('/', contentApp)
+    return { app, db, r2, env: { APP_URL: 'https://glance.example.com', CONTENT_TOKEN_SECRET: secret, GLANCE_FILES: r2 } }
+  }
+
+  async function gatedSite(db: ReturnType<typeof makeDb>) {
+    const uid = await seedUser(db, { id: 'u1' })
+    const sp = await seedSpace(db, { createdBy: uid, slug: 'sam' })
+    const siteId = await seedSite(db, { spaceId: sp, ownerId: uid, slug: 'site', visibility: 'team' })
+    const token = await signToken(secret, uid, 'sam/site', 300)
+    return { uid, siteId, token }
+  }
+
+  test('serving an HTML page records one view attributed to the viewer + site', async () => {
+    const { app, db, r2, env } = setup()
+    const { uid, siteId, token } = await gatedSite(db)
+    await seedFile(db, r2, siteId, { path: 'index.html', text: '<h1>hi</h1>' })
+
+    await app.request(`/_t/${token}/sam/site/`, {}, env)
+
+    const rows = await db.select().from(events)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({ type: 'view', action: 'index.html', userId: uid, siteId, siteLabel: 'sam/site' })
+  })
+
+  test('sub-resources (css/js/images) do NOT record a view — only page loads count', async () => {
+    const { app, db, r2, env } = setup()
+    const { siteId, token } = await gatedSite(db)
+    await seedFile(db, r2, siteId, { path: 'app.css', text: 'body{}', mimeType: 'text/css' })
+
+    await app.request(`/_t/${token}/sam/site/app.css`, {}, env)
+
+    expect(await db.select().from(events)).toHaveLength(0)
+  })
+
+  test('a forbidden (anonymous, untokened) request records no view', async () => {
+    const { app, db, r2, env } = setup()
+    const { siteId } = await gatedSite(db)
+    await seedFile(db, r2, siteId, { path: 'index.html', text: '<h1>hi</h1>' })
+
+    const res = await app.request('/sam/site/', {}, env)
+    expect(res.status).toBe(403)
+    expect(await db.select().from(events)).toHaveLength(0)
   })
 })
 

--- a/packages/api/src/content.ts
+++ b/packages/api/src/content.ts
@@ -4,8 +4,9 @@ import { type Context, Hono } from 'hono'
 import { Marked } from 'marked'
 import { ANNOTATE_CSS, ANNOTATE_JS, ANNOTATE_VERSION } from './annotate/bundle'
 import { isSpaceMember, resolveIsShared, toSessionUser } from './db/repo'
-import { files, sites, spaces, users } from './db/schema'
+import { type NewEvent, files, sites, spaces, users } from './db/schema'
 import { checkAccess } from './lib/access'
+import { fireAndForget, recordEvent } from './lib/events'
 import { verifyToken } from './lib/token'
 import type { Bindings } from './types'
 
@@ -129,6 +130,20 @@ async function serve(c: Ctx, spaceSlug: string, siteSlug: string, rest: string, 
   const object = await c.env.GLANCE_FILES.get(file.storageKey)
   if (!object) return notFound(c)
 
+  // Usage analytics: count this as a viewer hit only for actual page loads (HTML + rendered
+  // markdown), not every CSS/JS/image sub-resource — otherwise one navigation inflates to many.
+  // userId is guaranteed non-null here (anonymous requests 403'd above), so every view is
+  // attributable to a known team member: exact unique-viewer counts, no IP hashing needed.
+  if (/\.(md|markdown)$/i.test(file.path) || isHtmlFile(file.path)) {
+    await trackView(c, db, {
+      type: 'view',
+      action: file.path,
+      userId,
+      siteId: siteRow.id,
+      siteLabel: `${spaceSlug}/${siteSlug}`,
+    })
+  }
+
   const frameAncestors = `frame-ancestors 'self' ${c.env.APP_URL}`
 
   // Markdown → rendered HTML (served as text/html). Use the RESOLVED file's path for
@@ -168,6 +183,13 @@ async function serve(c: Ctx, spaceSlug: string, siteSlug: string, rest: string, 
   // that token leaking to third parties via the Referer header on outbound requests.
   headers.set('referrer-policy', 'no-referrer')
   return new Response(object.body, { headers })
+}
+
+// Record a page-view event without blocking the response. fireAndForget hands the D1 write to
+// ctx.waitUntil in the Workers runtime (off the serving critical path) and awaits inline in tests;
+// recordEvent never throws, so a failed insert can never break serving.
+async function trackView(c: Ctx, db: DrizzleD1Database, e: NewEvent): Promise<void> {
+  await fireAndForget(c, recordEvent(db, e))
 }
 
 // Extract the file path after the first `skip` path segments (e.g. /space/site → skip 2).

--- a/packages/api/src/db/schema.ts
+++ b/packages/api/src/db/schema.ts
@@ -142,6 +142,35 @@ export const comments = sqliteTable(
   (t) => [index('comments_thread_created').on(t.threadId, t.createdAt), index('comments_author').on(t.authorId)],
 )
 
+// Usage-analytics event stream. Append-only; one row per tracked action:
+//   type 'view' — a top-level HTML page served by the content worker (action = file path).
+//   type 'cli'  — a Bearer-authenticated API call from the CLI (action = route, e.g. 'upload').
+// User/site FKs are SET NULL (not cascade) so deleting a user or site never erases historical
+// counts — same durability rule the comments table follows. siteLabel denormalizes "space/site"
+// so the row stays human-readable after its site is gone. Writes go through ctx.waitUntil on the
+// serving path, so recording an event never blocks the response.
+export const events = sqliteTable(
+  'events',
+  {
+    id: text('id').primaryKey().$defaultFn(() => crypto.randomUUID()),
+    type: text('type', { enum: ['view', 'cli'] }).notNull(),
+    // view: served file path; cli: the API route/command (e.g. 'upload', 'comments', 'read').
+    action: text('action'),
+    userId: text('userId').references(() => users.id, { onDelete: 'set null' }),
+    siteId: text('siteId').references(() => sites.id, { onDelete: 'set null' }),
+    // Denormalized "space/site" slug pair — survives a site delete for readable per-site rollups.
+    siteLabel: text('siteLabel'),
+    // CLI semver from the User-Agent (glance-cli/<version>); null for views and legacy CLIs.
+    cliVersion: text('cliVersion'),
+    createdAt: text('createdAt').notNull().$defaultFn(() => new Date().toISOString()),
+  },
+  (t) => [
+    index('events_type_created').on(t.type, t.createdAt),
+    index('events_site_created').on(t.siteId, t.createdAt),
+    index('events_user_created').on(t.userId, t.createdAt),
+  ],
+)
+
 export type User = typeof users.$inferSelect
 export type NewUser = typeof users.$inferInsert
 export type Space = typeof spaces.$inferSelect
@@ -158,6 +187,9 @@ export type CommentThread = typeof commentThreads.$inferSelect
 export type NewCommentThread = typeof commentThreads.$inferInsert
 export type Comment = typeof comments.$inferSelect
 export type NewComment = typeof comments.$inferInsert
+export type Event = typeof events.$inferSelect
+export type NewEvent = typeof events.$inferInsert
+export type EventType = Event['type']
 
 export type Visibility = Site['visibility']
 export type SpaceType = Space['type']

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -5,6 +5,7 @@ import { superadminExists } from './db/repo'
 import { buildPublicConfig } from './lib/bootstrap'
 import { INSTALL_SH } from './install-script'
 import { isGoogleEnabled } from './lib/oauth'
+import { trackCliUsage } from './middleware/analytics'
 import { requireSameOrigin } from './middleware/auth'
 import { admin } from './routes/admin'
 import { auth } from './routes/auth'
@@ -58,6 +59,7 @@ app.get('/api/install', (c) => {
 
 app.use('/api/*', requireSameOrigin)
 app.use('/api/*', withDb)
+app.use('/api/*', trackCliUsage)
 
 app.get('/api/health', (c) => c.json({ status: 'ok' }))
 

--- a/packages/api/src/lib/events.ts
+++ b/packages/api/src/lib/events.ts
@@ -1,0 +1,32 @@
+import type { DrizzleD1Database } from 'drizzle-orm/d1'
+import type { Context } from 'hono'
+import { type NewEvent, events } from '../db/schema'
+
+// Best-effort usage-analytics write. NEVER throws: a failed insert must not break page serving
+// or an API response. Callers hand this to ctx.waitUntil so it runs after the response is sent,
+// keeping the D1 write off the request's critical path.
+export async function recordEvent(db: DrizzleD1Database, e: NewEvent): Promise<void> {
+  try {
+    await db.insert(events).values(e)
+  } catch {
+    // Swallow — analytics is non-critical and must never surface to the caller.
+  }
+}
+
+// Hand a best-effort write to the Workers runtime's waitUntil so it runs off the response's
+// critical path. In tests there is no ExecutionContext (c.executionCtx throws), so fall back to
+// awaiting inline — keeps assertions deterministic without ever blocking the real serving path.
+export async function fireAndForget(c: Context, write: Promise<unknown>): Promise<void> {
+  try {
+    c.executionCtx.waitUntil(write)
+  } catch {
+    await write
+  }
+}
+
+// Extract the CLI semver from a `glance-cli/<version>` User-Agent. Returns null for browsers,
+// unknown agents, or legacy CLIs that send no version.
+export function parseCliVersion(userAgent: string | undefined): string | null {
+  const match = userAgent?.match(/glance-cli\/(\S+)/)
+  return match?.[1] ?? null
+}

--- a/packages/api/src/lib/stats.test.ts
+++ b/packages/api/src/lib/stats.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from 'bun:test'
+import { makeDb, seedComment, seedEvent, seedFile, seedSite, seedSpace, seedThread, seedUser } from '../test/harness'
+import { computeStats } from './stats'
+
+// A fixed "now" so window math is deterministic. Days are UTC.
+const NOW = new Date('2026-07-03T12:00:00.000Z')
+const daysAgo = (n: number) => new Date(NOW.getTime() - n * 24 * 60 * 60 * 1000).toISOString()
+
+async function fixture() {
+  const db = makeDb()
+  const u1 = await seedUser(db, { id: 'u1' })
+  const u2 = await seedUser(db, { id: 'u2' })
+  const sp = await seedSpace(db, { createdBy: u1, slug: 'acme' })
+  const siteA = await seedSite(db, { id: 'siteA', spaceId: sp, ownerId: u1, slug: 'a' })
+  const siteB = await seedSite(db, { id: 'siteB', spaceId: sp, ownerId: u1, slug: 'b' })
+  return { db, u1, u2, sp, siteA, siteB }
+}
+
+describe('computeStats totals', () => {
+  test('counts users, sites, files, storage bytes, live comments', async () => {
+    const { db, siteA } = await fixture()
+    await seedFile(db, null, siteA, { path: 'a.html', text: 'hello' }) // size 5
+    await seedFile(db, null, siteA, { path: 'b.html', text: 'hi' }) // size 2
+    const th = await seedThread(db, { siteId: siteA, filePath: 'a.html' })
+    await seedComment(db, { threadId: th, body: 'live' })
+    await seedComment(db, { threadId: th, body: 'gone', deletedAt: daysAgo(1) }) // soft-deleted → excluded
+
+    const s = await computeStats(db, NOW)
+    expect(s.totals.users).toBe(2)
+    expect(s.totals.sites).toBe(2)
+    expect(s.totals.files).toBe(2)
+    expect(s.totals.storageBytes).toBe(7)
+    expect(s.totals.comments).toBe(1) // soft-deleted not counted
+  })
+
+  test('views vs cli events, and unique viewers (distinct userId)', async () => {
+    const { db, u1, u2, siteA } = await fixture()
+    await seedEvent(db, { type: 'view', userId: u1, siteId: siteA, siteLabel: 'acme/a' })
+    await seedEvent(db, { type: 'view', userId: u1, siteId: siteA, siteLabel: 'acme/a' })
+    await seedEvent(db, { type: 'view', userId: u2, siteId: siteA, siteLabel: 'acme/a' })
+    await seedEvent(db, { type: 'cli', action: 'upload', userId: u1, cliVersion: '1.0.0' })
+
+    const s = await computeStats(db, NOW)
+    expect(s.totals.views).toBe(3)
+    expect(s.totals.cliInvocations).toBe(1)
+    expect(s.totals.uniqueViewers).toBe(2) // u1 counted once
+  })
+})
+
+describe('computeStats window + series', () => {
+  test('activeViewers30d excludes viewers outside the window', async () => {
+    const { db, u1, u2, siteA } = await fixture()
+    await seedEvent(db, { type: 'view', userId: u1, siteId: siteA, createdAt: daysAgo(2) }) // in window
+    await seedEvent(db, { type: 'view', userId: u2, siteId: siteA, createdAt: daysAgo(40) }) // out of window
+
+    const s = await computeStats(db, NOW)
+    expect(s.activeViewers30d).toBe(1)
+  })
+
+  test('series has 30 zero-filled days, oldest first, with counts landing on the right day', async () => {
+    const { db, u1, siteA } = await fixture()
+    await seedEvent(db, { type: 'view', userId: u1, siteId: siteA, createdAt: daysAgo(0) })
+    await seedEvent(db, { type: 'view', userId: u1, siteId: siteA, createdAt: daysAgo(0) })
+    await seedEvent(db, { type: 'cli', action: 'upload', userId: u1, createdAt: daysAgo(5) })
+
+    const s = await computeStats(db, NOW)
+    expect(s.series).toHaveLength(30)
+    expect(s.series[0].date < s.series[29].date).toBe(true) // oldest → newest
+    expect(s.series[29].date).toBe('2026-07-03') // today
+    expect(s.series[29].views).toBe(2)
+    expect(s.series[24].cli).toBe(1) // 5 days ago = index 24
+  })
+})
+
+describe('computeStats topSites', () => {
+  test('ranks sites by view count within the window', async () => {
+    const { db, u1, siteA, siteB } = await fixture()
+    for (let i = 0; i < 3; i++) await seedEvent(db, { type: 'view', userId: u1, siteId: siteB, siteLabel: 'acme/b' })
+    await seedEvent(db, { type: 'view', userId: u1, siteId: siteA, siteLabel: 'acme/a' })
+
+    const s = await computeStats(db, NOW)
+    expect(s.topSites[0]).toMatchObject({ siteId: siteB, siteLabel: 'acme/b', views: 3 })
+    expect(s.topSites[1]).toMatchObject({ siteId: siteA, siteLabel: 'acme/a', views: 1 })
+  })
+})

--- a/packages/api/src/lib/stats.ts
+++ b/packages/api/src/lib/stats.ts
@@ -1,0 +1,175 @@
+import { and, count, desc, eq, gte, isNull, sql } from 'drizzle-orm'
+import type { DrizzleD1Database } from 'drizzle-orm/d1'
+import { comments, events, files, sites, users } from '../db/schema'
+
+// Usage-analytics rollups for the admin dashboard. Everything is derived from existing state
+// (users/sites/files/comments) plus the append-only `events` stream (views + CLI), so counts are
+// exact and joinable. Superadmin-only surface (see routes/admin.ts) — read-only aggregation.
+
+export interface StatsTotals {
+  users: number
+  sites: number
+  files: number
+  storageBytes: number
+  comments: number
+  views: number
+  cliInvocations: number
+  uniqueViewers: number
+}
+
+export interface DailyPoint {
+  date: string // YYYY-MM-DD (UTC)
+  signups: number
+  sites: number
+  views: number
+  comments: number
+  cli: number
+}
+
+export interface TopSite {
+  siteId: string | null
+  siteLabel: string | null
+  views: number
+}
+
+export interface Stats {
+  totals: StatsTotals
+  activeViewers30d: number
+  series: DailyPoint[] // one zero-filled row per day, oldest → newest
+  topSites: TopSite[]
+  windowDays: number
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000
+const WINDOW_DAYS = 30
+
+/** YYYY-MM-DD (UTC) for a date — matches substr(createdAt, 1, 10) on our ISO-8601 timestamps. */
+const dayKey = (d: Date): string => d.toISOString().slice(0, 10)
+
+/** `count(*)` helper: unwrap drizzle's row shape to a plain number. */
+async function scalarCount(query: Promise<{ n: number }[]>): Promise<number> {
+  const rows = await query
+  return Number(rows[0]?.n ?? 0)
+}
+
+export async function computeStats(db: DrizzleD1Database, now: Date = new Date()): Promise<Stats> {
+  // Inclusive 30-day window: today back through 29 days ago, from midnight UTC of the first day.
+  const startDay = new Date(now.getTime() - (WINDOW_DAYS - 1) * DAY_MS)
+  const sinceTs = `${dayKey(startDay)}T00:00:00.000Z`
+  const day = sql<string>`substr(${events.createdAt}, 1, 10)`
+  const uDay = sql<string>`substr(${users.createdAt}, 1, 10)`
+  const sDay = sql<string>`substr(${sites.createdAt}, 1, 10)`
+  const cDay = sql<string>`substr(${comments.createdAt}, 1, 10)`
+
+  const [totals, activeViewers30d, signupsByDay, sitesByDay, viewsByDay, commentsByDay, cliByDay, topSites] =
+    await Promise.all([
+      // Headline totals (all-time).
+      (async (): Promise<StatsTotals> => {
+        const [u, s, f, storage, cm, vw, cli, uv] = await Promise.all([
+          scalarCount(db.select({ n: count() }).from(users)),
+          scalarCount(db.select({ n: count() }).from(sites)),
+          scalarCount(db.select({ n: count() }).from(files)),
+          db
+            .select({ n: sql<number>`coalesce(sum(${files.size}), 0)` })
+            .from(files)
+            .then((r) => Number(r[0]?.n ?? 0)),
+          scalarCount(db.select({ n: count() }).from(comments).where(isNull(comments.deletedAt))),
+          scalarCount(db.select({ n: count() }).from(events).where(eq(events.type, 'view'))),
+          scalarCount(db.select({ n: count() }).from(events).where(eq(events.type, 'cli'))),
+          db
+            .select({ n: sql<number>`count(distinct ${events.userId})` })
+            .from(events)
+            .where(eq(events.type, 'view'))
+            .then((r) => Number(r[0]?.n ?? 0)),
+        ])
+        return {
+          users: u,
+          sites: s,
+          files: f,
+          storageBytes: storage,
+          comments: cm,
+          views: vw,
+          cliInvocations: cli,
+          uniqueViewers: uv,
+        }
+      })(),
+      // Distinct viewers active in the window.
+      db
+        .select({ n: sql<number>`count(distinct ${events.userId})` })
+        .from(events)
+        .where(and(eq(events.type, 'view'), gte(events.createdAt, sinceTs)))
+        .then((r) => Number(r[0]?.n ?? 0)),
+      // Per-day series (sparse; zero-filled below).
+      db.select({ date: uDay, n: count() }).from(users).where(gte(users.createdAt, sinceTs)).groupBy(uDay),
+      db.select({ date: sDay, n: count() }).from(sites).where(gte(sites.createdAt, sinceTs)).groupBy(sDay),
+      db
+        .select({ date: day, n: count() })
+        .from(events)
+        .where(and(eq(events.type, 'view'), gte(events.createdAt, sinceTs)))
+        .groupBy(day),
+      db
+        .select({ date: cDay, n: count() })
+        .from(comments)
+        .where(and(isNull(comments.deletedAt), gte(comments.createdAt, sinceTs)))
+        .groupBy(cDay),
+      db
+        .select({ date: day, n: count() })
+        .from(events)
+        .where(and(eq(events.type, 'cli'), gte(events.createdAt, sinceTs)))
+        .groupBy(day),
+      // Most-viewed sites in the window. siteLabel is stable per site, so max() picks it safely.
+      db
+        .select({
+          siteId: events.siteId,
+          siteLabel: sql<string>`max(${events.siteLabel})`,
+          views: count(),
+        })
+        .from(events)
+        .where(and(eq(events.type, 'view'), gte(events.createdAt, sinceTs)))
+        .groupBy(events.siteId)
+        .orderBy(desc(count()))
+        .limit(10),
+    ])
+
+  const series = buildSeries(now, {
+    signups: signupsByDay,
+    sites: sitesByDay,
+    views: viewsByDay,
+    comments: commentsByDay,
+    cli: cliByDay,
+  })
+
+  return {
+    totals,
+    activeViewers30d,
+    series,
+    topSites: topSites.map((t) => ({ siteId: t.siteId, siteLabel: t.siteLabel ?? null, views: Number(t.views) })),
+    windowDays: WINDOW_DAYS,
+  }
+}
+
+type DayRows = { date: string; n: number }[]
+
+/** Zero-fill the window: one row per day (oldest → newest), merging each metric's sparse counts. */
+function buildSeries(
+  now: Date,
+  metrics: Record<'signups' | 'sites' | 'views' | 'comments' | 'cli', DayRows>,
+): DailyPoint[] {
+  const index: Record<string, Map<string, number>> = {}
+  for (const [key, rows] of Object.entries(metrics)) {
+    index[key] = new Map(rows.map((r) => [r.date, Number(r.n)]))
+  }
+  const out: DailyPoint[] = []
+  for (let i = WINDOW_DAYS - 1; i >= 0; i--) {
+    const date = dayKey(new Date(now.getTime() - i * DAY_MS))
+    out.push({
+      date,
+      signups: index.signups.get(date) ?? 0,
+      sites: index.sites.get(date) ?? 0,
+      views: index.views.get(date) ?? 0,
+      comments: index.comments.get(date) ?? 0,
+      cli: index.cli.get(date) ?? 0,
+    })
+  }
+  return out
+}

--- a/packages/api/src/middleware/analytics.test.ts
+++ b/packages/api/src/middleware/analytics.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from 'bun:test'
+import { Hono } from 'hono'
+import { events } from '../db/schema'
+import { parseCliVersion } from '../lib/events'
+import { makeDb, makeKv, seedUser } from '../test/harness'
+import type { AppEnv } from '../types'
+import { trackCliUsage } from './analytics'
+import { requireAuth } from './auth'
+
+// Mirror index.ts's chain: inject the harness db, tag the credential (requireAuth), track usage.
+// A route guarded by requireAuth stands in for any CLI-reachable endpoint.
+function setup() {
+  const db = makeDb()
+  const kv = makeKv()
+  const app = new Hono<AppEnv>()
+  app.use('/api/*', async (c, next) => {
+    c.set('db', db)
+    await next()
+  })
+  app.use('/api/*', trackCliUsage)
+  app.get('/api/upload/:a/:b', requireAuth, (c) => c.json({ ok: true }))
+  app.get('/api/sites/:a', requireAuth, (c) => c.json({ ok: true }))
+  const env = { GLANCE_SESSIONS: kv, SESSION_SECRET: 'sekret', APP_URL: 'https://glance.example.com' }
+  return { app, db, kv, env }
+}
+
+describe('parseCliVersion', () => {
+  test('extracts semver from a glance-cli User-Agent', () => {
+    expect(parseCliVersion('glance-cli/1.4.2')).toBe('1.4.2')
+  })
+  test('returns null for browsers / unknown / missing agents', () => {
+    expect(parseCliVersion('Mozilla/5.0')).toBeNull()
+    expect(parseCliVersion(undefined)).toBeNull()
+    expect(parseCliVersion('glance-cli')).toBeNull()
+  })
+})
+
+describe('trackCliUsage', () => {
+  async function cliToken(kv: ReturnType<typeof makeKv>, userId: string) {
+    await kv.put(
+      `cli:tok-${userId}`,
+      JSON.stringify({ id: userId, email: `${userId}@x.com`, name: null, role: 'member' }),
+    )
+    return `tok-${userId}`
+  }
+
+  test('a Bearer (CLI) request records one cli event with action + version', async () => {
+    const { app, db, kv, env } = setup()
+    const uid = await seedUser(db, { id: 'u1' })
+    const tok = await cliToken(kv, uid)
+
+    const res = await app.request(
+      '/api/upload/acme/site',
+      { headers: { Authorization: `Bearer ${tok}`, 'User-Agent': 'glance-cli/2.0.0' } },
+      env,
+    )
+    expect(res.status).toBe(200)
+
+    const rows = await db.select().from(events)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({ type: 'cli', action: 'upload', userId: uid, cliVersion: '2.0.0' })
+  })
+
+  test('action is the top-level resource segment (sites, not the slug)', async () => {
+    const { app, db, kv, env } = setup()
+    const uid = await seedUser(db, { id: 'u1' })
+    const tok = await cliToken(kv, uid)
+
+    await app.request('/api/sites/acme', { headers: { Authorization: `Bearer ${tok}` } }, env)
+
+    const rows = await db.select().from(events)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({ type: 'cli', action: 'sites', cliVersion: null })
+  })
+
+  test('an unauthorized request (bad token) records nothing', async () => {
+    const { app, db, env } = setup()
+    const res = await app.request('/api/upload/acme/site', { headers: { Authorization: 'Bearer nope' } }, env)
+    expect(res.status).toBe(401)
+    expect(await db.select().from(events)).toHaveLength(0)
+  })
+})

--- a/packages/api/src/middleware/analytics.ts
+++ b/packages/api/src/middleware/analytics.ts
@@ -1,0 +1,23 @@
+import { createMiddleware } from 'hono/factory'
+import { fireAndForget, parseCliVersion, recordEvent } from '../lib/events'
+import type { AppEnv } from '../types'
+
+// CLI-usage analytics. Mounted on /api/*, it runs AFTER the route (so requireAuth has set
+// authKind + user), then records one event per Bearer-authenticated (CLI) request. `action` is
+// the top-level resource segment — 'upload' (deploy), 'sites' (read/viewer), 'users', etc. — a
+// stable command bucket that covers every current and future CLI endpoint. The write is handed
+// to waitUntil (never blocks the response) and web traffic is skipped entirely.
+export const trackCliUsage = createMiddleware<AppEnv>(async (c, next) => {
+  await next()
+  if (c.get('authKind') !== 'cli') return
+  const action = c.req.path.replace(/^\/api\//, '').split('/')[0] || 'root'
+  await fireAndForget(
+    c,
+    recordEvent(c.get('db'), {
+      type: 'cli',
+      action,
+      userId: c.get('user')?.id ?? null,
+      cliVersion: parseCliVersion(c.req.header('User-Agent')),
+    }),
+  )
+})

--- a/packages/api/src/middleware/auth.ts
+++ b/packages/api/src/middleware/auth.ts
@@ -31,6 +31,12 @@ export const requireAuth = createMiddleware<AppEnv>(async (c, next) => {
   const user = await readSessionOrBearer(c)
   if (!user) return c.json({ error: 'unauthorized' }, 401)
   c.set('user', user)
+  // Tag the credential for usage analytics. The CLI sends a Bearer token and never a cookie;
+  // browsers always carry the cookie. Session cookie wins (mirrors readSessionOrBearer), so a
+  // request is 'cli' only when there's no cookie AND a Bearer token is present.
+  const isBearer = c.req.header('Authorization')?.startsWith('Bearer ') ?? false
+  const hasCookie = getCookie(c, SESSION_COOKIE) !== undefined
+  c.set('authKind', !hasCookie && isBearer ? 'cli' : 'web')
   await next()
 })
 

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -1,6 +1,7 @@
 import { and, desc, eq, sql } from 'drizzle-orm'
 import { Hono } from 'hono'
 import { sites, spaceMembers, spaces as spacesTable, users } from '../db/schema'
+import { computeStats } from '../lib/stats'
 import { deleteSiteObjects } from '../lib/storage'
 import { isVisibility, normalizeVisibility } from '../lib/visibility'
 import { requireAuth, requireSuperAdmin } from '../middleware/auth'
@@ -120,3 +121,8 @@ admin.get('/users', async (c) => {
     .orderBy(desc(users.createdAt))
   return c.json(rows)
 })
+
+// GET /api/admin/stats — usage-analytics rollups: headline totals (users, sites, files, storage,
+// comments, views, CLI invocations, unique viewers), a 30-day per-day series, and the top sites
+// by views. Read-only aggregation over existing state + the events stream.
+admin.get('/stats', async (c) => c.json(await computeStats(c.get('db'))))

--- a/packages/api/src/test/harness.ts
+++ b/packages/api/src/test/harness.ts
@@ -11,12 +11,14 @@ import { hashContent } from '../lib/anchor'
 import {
   type NewComment,
   type NewCommentThread,
+  type NewEvent,
   type NewFileRow,
   type NewSite,
   type NewSpace,
   type NewUser,
   comments,
   commentThreads,
+  events,
   files,
   siteGroupShares,
   siteUserShares,
@@ -32,6 +34,7 @@ const MIGRATIONS = [
   'drizzle/0002_silly_gertrude_yorkes.sql',
   'drizzle/0003_rename_group_visibility.sql',
   'drizzle/0004_drop_public_visibility.sql',
+  'drizzle/0005_peaceful_onslaught.sql',
 ]
 
 /** Fresh in-memory DB with the real schema applied. */
@@ -179,6 +182,22 @@ export async function seedComment(
     createdAt: o.createdAt ?? new Date().toISOString(),
     editedAt: o.editedAt ?? null,
     deletedAt: o.deletedAt ?? null,
+  })
+  return id
+}
+
+/** Insert an `events` row; returns its id. Defaults: view type, now. */
+export async function seedEvent(db: DrizzleD1Database, o: Partial<NewEvent> = {}): Promise<string> {
+  const id = o.id ?? nextId('ev')
+  await db.insert(events).values({
+    id,
+    type: o.type ?? 'view',
+    action: o.action ?? null,
+    userId: o.userId ?? null,
+    siteId: o.siteId ?? null,
+    siteLabel: o.siteLabel ?? null,
+    cliVersion: o.cliVersion ?? null,
+    createdAt: o.createdAt ?? new Date().toISOString(),
   })
   return id
 }

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -33,6 +33,9 @@ export interface SessionUser {
 export interface Variables {
   db: DrizzleD1Database
   user: SessionUser
+  // Which credential authenticated the request, set by requireAuth. 'cli' = Bearer token,
+  // 'web' = session cookie. Drives CLI-usage analytics. Absent on unauthenticated routes.
+  authKind: 'cli' | 'web'
 }
 
 export type AppEnv = { Bindings: Bindings; Variables: Variables }

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -4,7 +4,14 @@ import { mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync }
 import { homedir, platform } from 'node:os'
 import { basename, join, relative, resolve, sep } from 'node:path'
 import { createInterface } from 'node:readline/promises'
+import pkg from './package.json'
 import { SKILL_MD, SKILL_NAME } from './skill-content'
+
+// Sent as the User-Agent on every authenticated request so the server can attribute CLI usage
+// (and segment by version) in its analytics. Static JSON import → inlined into the compiled
+// binary at `bun build` time; the release workflow stamps the git tag into package.json first,
+// so a released CLI reports its exact release version.
+const USER_AGENT = `glance-cli/${pkg.version}`
 
 // Glance CLI — deploy folders to Glance from the terminal.
 //   glance login | deploy <path> --space <s> --name <s> [--visibility v] | list | delete <space/slug> | move <space/slug> <new-space> | comments <space/slug> | read <space/slug> | logout
@@ -52,7 +59,7 @@ function requireAuth(): Config {
 function authed(cfg: Config, path: string, init: RequestInit = {}): Promise<Response> {
   return fetch(`${cfg.apiUrl}${path}`, {
     ...init,
-    headers: { ...init.headers, Authorization: `Bearer ${cfg.token}` },
+    headers: { ...init.headers, Authorization: `Bearer ${cfg.token}`, 'User-Agent': USER_AGENT },
   })
 }
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@glance/cli",
   "private": true,
+  "version": "0.1.0",
   "description": "CLI for deploying folders to a Glance instance.",
   "type": "module",
   "bin": { "glance": "./index.ts" },

--- a/packages/web/src/routes/admin.tsx
+++ b/packages/web/src/routes/admin.tsx
@@ -1,5 +1,19 @@
 import { useState } from 'react'
-import { Archive, ArchiveRestore, Boxes, FolderOpen, Trash2, Users2 } from 'lucide-react'
+import {
+  Activity,
+  Archive,
+  ArchiveRestore,
+  Boxes,
+  Eye,
+  FileText,
+  FolderOpen,
+  HardDrive,
+  MessageSquare,
+  Terminal,
+  Trash2,
+  UserCheck,
+  Users2,
+} from 'lucide-react'
 import {
   type LoaderFunctionArgs,
   redirect,
@@ -9,9 +23,10 @@ import {
 } from 'react-router'
 import { toast } from 'sonner'
 import { ConfirmDialog } from '@/components/ConfirmDialog'
-import { EmptyState, PageHeader, Spinner } from '@/components/states'
+import { EmptyState, PageHeader, SectionHeader, Spinner } from '@/components/states'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import {
   Select,
   SelectContent,
@@ -54,7 +69,7 @@ interface AdminUser {
   createdAt: string
 }
 
-type AdminTab = 'sites' | 'spaces' | 'users'
+type AdminTab = 'overview' | 'sites' | 'spaces' | 'users'
 
 interface SitesData {
   sites: AdminSite[]
@@ -63,15 +78,34 @@ interface SitesData {
   total: number
 }
 
+// Usage-analytics payload from GET /api/admin/stats (see lib/stats.ts).
+interface StatsData {
+  totals: {
+    users: number
+    sites: number
+    files: number
+    storageBytes: number
+    comments: number
+    views: number
+    cliInvocations: number
+    uniqueViewers: number
+  }
+  activeViewers30d: number
+  series: { date: string; signups: number; sites: number; views: number; comments: number; cli: number }[]
+  topSites: { siteId: string | null; siteLabel: string | null; views: number }[]
+  windowDays: number
+}
+
 type LoaderData =
+  | { tab: 'overview'; data: StatsData }
   | { tab: 'sites'; data: SitesData }
   | { tab: 'spaces'; data: AdminSpace[] }
   | { tab: 'users'; data: AdminUser[] }
 
-const TABS: AdminTab[] = ['sites', 'spaces', 'users']
+const TABS: AdminTab[] = ['overview', 'sites', 'spaces', 'users']
 
 function asTab(value: string | null): AdminTab {
-  return value === 'spaces' || value === 'users' ? value : 'sites'
+  return value === 'sites' || value === 'spaces' || value === 'users' ? value : 'overview'
 }
 
 // ── Loader: tab-aware fetch driven by URL searchParams ──────────────────────
@@ -79,6 +113,10 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const url = new URL(request.url)
   const tab = asTab(url.searchParams.get('tab'))
   try {
+    if (tab === 'overview') {
+      const data = await api.get<StatsData>('/api/admin/stats')
+      return { tab, data } satisfies LoaderData
+    }
     if (tab === 'spaces') {
       const data = await api.get<AdminSpace[]>('/api/admin/spaces')
       return { tab, data } satisfies LoaderData
@@ -139,6 +177,186 @@ function RestoreButton({ siteId }: { siteId: string }) {
       {busy ? <Spinner className="size-3.5" /> : <ArchiveRestore className="size-3.5" />}
       Restore
     </Button>
+  )
+}
+
+// ── Overview (usage analytics) tab ──────────────────────────────────────────
+function formatCount(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1).replace(/\.0$/, '')}M`
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1).replace(/\.0$/, '')}k`
+  return String(n)
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  const units = ['KB', 'MB', 'GB', 'TB']
+  let value = bytes / 1024
+  let i = 0
+  while (value >= 1024 && i < units.length - 1) {
+    value /= 1024
+    i++
+  }
+  return `${value.toFixed(value >= 100 || value === Math.floor(value) ? 0 : 1)} ${units[i]}`
+}
+
+function StatCard({ icon: Icon, label, value, sub }: { icon: typeof Eye; label: string; value: string; sub?: string }) {
+  return (
+    <Card className="gap-0 py-4">
+      <CardHeader className="px-4 pb-1">
+        <CardTitle className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+          <Icon className="size-3.5" />
+          {label}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="px-4">
+        <div className="text-2xl font-semibold tabular-nums">{value}</div>
+        {sub && <div className="mt-0.5 text-xs text-muted-foreground">{sub}</div>}
+      </CardContent>
+    </Card>
+  )
+}
+
+// Dependency-free inline SVG sparkline. Scales a series to the viewBox; flat/empty series render
+// as a baseline. Purely decorative, so it's aria-hidden — the numbers carry the real information.
+function Sparkline({ values, className }: { values: number[]; className?: string }) {
+  const width = 240
+  const height = 40
+  const max = Math.max(1, ...values)
+  const step = values.length > 1 ? width / (values.length - 1) : width
+  const points = values.map((v, i) => `${(i * step).toFixed(1)},${(height - (v / max) * (height - 4) - 2).toFixed(1)}`)
+  const line = points.join(' ')
+  const area = `0,${height} ${line} ${width},${height}`
+  return (
+    <svg
+      viewBox={`0 0 ${width} ${height}`}
+      preserveAspectRatio="none"
+      className={className}
+      aria-hidden="true"
+      role="presentation"
+    >
+      <polygon points={area} className="fill-primary/10" />
+      <polyline points={line} fill="none" className="stroke-primary" strokeWidth={1.5} strokeLinejoin="round" />
+    </svg>
+  )
+}
+
+function TrendCard({
+  icon: Icon,
+  label,
+  total,
+  values,
+}: {
+  icon: typeof Eye
+  label: string
+  total: number
+  values: number[]
+}) {
+  return (
+    <Card className="gap-2 py-4">
+      <CardHeader className="px-4 pb-0">
+        <CardTitle className="flex items-center justify-between text-xs font-medium text-muted-foreground">
+          <span className="flex items-center gap-1.5">
+            <Icon className="size-3.5" />
+            {label}
+          </span>
+          <span className="tabular-nums">{formatCount(total)}</span>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="px-4">
+        <Sparkline values={values} className="h-10 w-full" />
+      </CardContent>
+    </Card>
+  )
+}
+
+function StatsPanel({ data }: { data: StatsData }) {
+  const { totals, series, topSites, activeViewers30d, windowDays } = data
+  const sum = (key: 'signups' | 'views' | 'cli' | 'comments') => series.reduce((acc, d) => acc + d[key], 0)
+
+  return (
+    <div className="space-y-6">
+      {/* Headline totals (all-time). */}
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
+        <StatCard icon={Users2} label="Users" value={formatCount(totals.users)} />
+        <StatCard icon={FolderOpen} label="Sites" value={formatCount(totals.sites)} />
+        <StatCard
+          icon={FileText}
+          label="Files hosted"
+          value={formatCount(totals.files)}
+          sub={formatBytes(totals.storageBytes)}
+        />
+        <StatCard icon={HardDrive} label="Storage" value={formatBytes(totals.storageBytes)} />
+        <StatCard
+          icon={Eye}
+          label="Page views"
+          value={formatCount(totals.views)}
+          sub={`${formatCount(totals.uniqueViewers)} unique viewers`}
+        />
+        <StatCard
+          icon={UserCheck}
+          label="Active viewers"
+          value={formatCount(activeViewers30d)}
+          sub={`last ${windowDays} days`}
+        />
+        <StatCard icon={MessageSquare} label="Comments" value={formatCount(totals.comments)} />
+        <StatCard icon={Terminal} label="CLI invocations" value={formatCount(totals.cliInvocations)} />
+      </div>
+
+      {/* 30-day trends. */}
+      <div>
+        <SectionHeader title={`Last ${windowDays} days`}>
+          <span className="text-sm text-muted-foreground">Daily activity</span>
+        </SectionHeader>
+        <div className="mt-3 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          <TrendCard icon={Eye} label="Views" total={sum('views')} values={series.map((d) => d.views)} />
+          <TrendCard icon={Users2} label="Signups" total={sum('signups')} values={series.map((d) => d.signups)} />
+          <TrendCard
+            icon={MessageSquare}
+            label="Comments"
+            total={sum('comments')}
+            values={series.map((d) => d.comments)}
+          />
+          <TrendCard icon={Terminal} label="CLI" total={sum('cli')} values={series.map((d) => d.cli)} />
+        </div>
+      </div>
+
+      {/* Most-viewed sites in the window. */}
+      <div>
+        <SectionHeader title="Top sites">
+          <span className="text-sm text-muted-foreground">Most viewed in the last {windowDays} days</span>
+        </SectionHeader>
+        {topSites.length === 0 ? (
+          <div className="mt-3">
+            <EmptyState
+              icon={Activity}
+              title="No views yet"
+              description="Page views will appear here once sites get traffic."
+            />
+          </div>
+        ) : (
+          <div className="mt-3 rounded-xl border">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Site</TableHead>
+                  <TableHead className="text-right">Views</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {topSites.map((s) => (
+                  <TableRow key={s.siteId ?? s.siteLabel ?? 'unknown'}>
+                    <TableCell className="font-mono text-xs text-muted-foreground">
+                      /{s.siteLabel ?? 'deleted site'}
+                    </TableCell>
+                    <TableCell className="text-right font-medium tabular-nums">{formatCount(s.views)}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+      </div>
+    </div>
   )
 }
 
@@ -429,11 +647,13 @@ export function Component() {
   const tab = loaderData.tab
 
   const description =
-    loaderData.tab === 'sites'
-      ? `${loaderData.data.total} site${loaderData.data.total === 1 ? '' : 's'}`
-      : loaderData.tab === 'spaces'
-        ? `${loaderData.data.length} space${loaderData.data.length === 1 ? '' : 's'}`
-        : `${loaderData.data.length} user${loaderData.data.length === 1 ? '' : 's'}`
+    loaderData.tab === 'overview'
+      ? 'Usage at a glance'
+      : loaderData.tab === 'sites'
+        ? `${loaderData.data.total} site${loaderData.data.total === 1 ? '' : 's'}`
+        : loaderData.tab === 'spaces'
+          ? `${loaderData.data.length} space${loaderData.data.length === 1 ? '' : 's'}`
+          : `${loaderData.data.length} user${loaderData.data.length === 1 ? '' : 's'}`
 
   function onTabChange(next: string) {
     // Switching tabs starts fresh — drop site-only filters/pagination.
@@ -453,6 +673,7 @@ export function Component() {
           ))}
         </TabsList>
 
+        {loaderData.tab === 'overview' && <StatsPanel data={loaderData.data} />}
         {loaderData.tab === 'sites' && <SitesPanel data={loaderData.data} />}
         {loaderData.tab === 'spaces' && <SpacesPanel spaces={loaderData.data} />}
         {loaderData.tab === 'users' && <UsersPanel users={loaderData.data} />}


### PR DESCRIPTION
## What

Adds an append-only `events` table and surfaces usage at a glance for superadmins. Covers: how many people use it, files hosted + storage, visitors, comments, and CLI usage.

![Overview dashboard](https://github.com/plivo-labs/glance/releases/download/assets-pr-analytics/analytics-dashboard.png)

## How it works

- **Views** — the content worker records one page-view per HTML/markdown load (sub-resources excluded), attributed to the **token-bound `userId`**. Because there is no public tier, every view is authenticated → exact unique-viewer counts, no IP hashing. Written via `ctx.waitUntil`, so it never blocks the serving path.
- **CLI usage** — `requireAuth` tags each request `cli|web` (Bearer vs cookie); a `/api/*` middleware records one event per CLI request, bucketed by route. The CLI now sends `User-Agent: glance-cli/<version>` (release stamps the git tag) for version segmentation.
- **Stats** — `GET /api/admin/stats` (superadmin-gated): totals (users, sites, files, storage, comments, views, CLI, unique viewers), a 30-day per-day series, and top sites by views.
- **Dashboard** — new **Overview** tab: stat cards, dependency-free inline SVG sparklines, top-sites table.

FKs are `SET NULL` so deleting a user/site never erases historical counts (same rule as the comments table).

## Data model

New `events` table: `{ type: view|cli, action, userId→SET NULL, siteId→SET NULL, siteLabel, cliVersion, createdAt }` + indexes on `(type,createdAt)`, `(siteId,createdAt)`, `(userId,createdAt)`. Migration `0005`.

## Verification

Unit + **end-to-end against a local workerd runtime** (real `ctx.waitUntil` + real D1 binding, not the test harness):

- Real `glance deploy` → `cli/upload` + `cli/sites` events, `cliVersion=0.1.0` parsed from the real User-Agent.
- Real page fetch through the content worker → one `view/index.html` event, `userId` = the token-bound viewer. A `style.css` fetch (200) produced **no** view — page-vs-subresource gating holds live.
- Cookie-auth requests produced **zero** CLI events → `authKind` classifies web vs cli correctly.
- `/api/admin/stats` + the dashboard (screenshot above) match the seeded data exactly.

13 new tests; full **api (168)** + **cli (8)** suites green; typecheck + biome lint clean across api/cli/web.

## Deploy notes

- Migration `0005` is additive (new table); existing code ignores it. It applies to prod automatically via `deploy.yml` (`wrangler d1 migrations apply --remote`) on merge — no manual step.

## Follow-up (not in this PR)

- `events` grows unbounded; add a cron-trigger rollup to a `daily_stats` table + prune raw rows >90d.

🤖 Generated with [Claude Code](https://claude.com/claude-code)