### PR TITLE
feat(api): read-policy v2 — viewer create, shared-* collections, owner read_all

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,10 +99,12 @@ TOKEN=$(curl -s -X POST -H "Authorization: Bearer $GLANCE_CLI_TOKEN" \
 curl -H "Authorization: Bearer $TOKEN" "$GLANCE_API_URL/api/_data/notes"
 ```
 
-Rules: docs are JSON objects ≤100KB in named collections · writes need the site **owner** (viewers
-get read-only tokens) · reads return only **your own** documents ("public within site" is a
-planned opt-in) · every request re-checks live site access, so revoking a share cuts data access
-immediately. Design + threat model: [SHARED_BACKEND.md](SHARED_BACKEND.md).
+Rules: docs are JSON objects ≤100KB in named collections · every viewer can **create**
+(submissions are attributed to them) and read **their own** docs · collections named `shared-*`
+are readable by every viewer of the site (polls, boards) · the site **owner** additionally reads
+everything and can update/delete (moderation) — viewers can never modify existing docs · every
+request re-checks live site access, so revoking a share cuts data access immediately. Design +
+threat model: [SHARED_BACKEND.md](SHARED_BACKEND.md).
 
 ## Advanced
 

--- a/SHARED_BACKEND.md
+++ b/SHARED_BACKEND.md
@@ -37,8 +37,8 @@ first commit — not retrofitted.
 | 1 Confused deputy | Parent-frame broker: hosted pages get a MessagePort, never a token; parent validates origin+source+shape and binds every request to the viewed site | `dbBroker.test.ts` (spoofed origin/source, op smuggling, token never crosses) |
 | 2 Token type confusion | Separate secret + `aud`/caps inside the MAC; content token can't verify as data token | `data-token.test.ts` (content-token, aud, widened-caps, tamper) |
 | 3 CORS / CSRF boundary | ACAO pinned to `CONTENT_URL`, no `Allow-Credentials`, cookie ignored on the data plane | `data.test.ts` CORS; live curl (cookie-only → 401) |
-| 4 Write ≠ view | `dataCapsFor` grants write to owner/superadmin only; routes gate on the `write` cap | `data.test.ts` (dataCapsFor + read-only-token → 403) |
-| 5 Per-document read policy | `get`/`list` filtered by `createdBy = token.viewerId` (default per-creator) | `data.test.ts` cross-viewer isolation |
+| 4 Modify ≠ view | Every viewer gets `read`+`create` (attributed submissions); `write` (put/delete) is owner/superadmin-only — a viewer cannot touch any existing document | `data.test.ts` (dataCapsFor + viewer put/delete → 403) |
+| 5 Per-document read policy | Default `createdBy = token.viewerId`; opt-outs: `shared-*` collections (all viewers) and `read_all` tokens (owner sees + moderates everything) | `data.test.ts` (policy v2 block) |
 | 6 Tenant isolation (IDOR) | Every query ANDs `siteId = token.siteId`; siteId never from the body | `data.test.ts` (B's siteB token can't reach siteA) |
 | 7 Mass assignment | `siteId`/`createdBy`/timestamps set from the token, never spread from the body | `data.test.ts` (spoofed body keys ignored) |
 | 8 Stored-XSS amplification | No credential in the untrusted page realm (SDK runs on the trusted app origin only until the broker) | design/scope |
@@ -52,7 +52,8 @@ first commit — not retrofitted.
   for now.
 - **`glance.fs` / `glance.ai`** (Phase 2/3) — with serve-time non-exec fs serving + AI quotas;
   both ride the same broker channel.
-- **`glance.config.json` capability manifest** + "public-within-site" read opt-in.
+- **`glance.config.json` capability manifest** (the `shared-*` naming convention covers the
+  read opt-in for now); resolving `createdBy` ids to display names.
 - **Per-site quotas / rate-limits** (abuse controls).
 - Arbitrary `list()` filters (only ship behind bound JSON paths + a field allowlist).
 

--- a/glance-cli/SKILL.md
+++ b/glance-cli/SKILL.md
@@ -136,10 +136,13 @@ curl -H "Authorization: Bearer $TOKEN" -X POST -d '{"text":"hi"}' \
 # also: GET /api/_data/notes (list) · GET/PUT/DELETE /api/_data/notes/<id>
 ```
 
-Rules of thumb: documents are JSON objects up to 100KB, grouped into named collections · only
-the site's **owner** can write; other viewers get read-only · you only ever see documents you
-created yourself · access follows the site's sharing — lose access to the site, lose access to
-its data. If it errors with "not enabled", ask your Glance admin to turn the feature on.
+Rules of thumb: documents are JSON objects up to 100KB, grouped into named collections ·
+**anyone viewing the site can add** documents (attributed to them) — so forms and surveys just
+work · by default you only see documents **you** created; name a collection `shared-…` and every
+viewer sees all of it (polls, boards) · the site **owner** sees everything and can edit/delete
+any document (moderation); other viewers can never change existing documents · access follows
+the site's sharing — lose access to the site, lose access to its data. If it errors with "not
+enabled", ask your Glance admin to turn the feature on.
 
 ## Gotchas
 - Commands other than `login`/`logout` require a saved token; run `glance login` first.

--- a/packages/api/src/lib/data-token.ts
+++ b/packages/api/src/lib/data-token.ts
@@ -10,7 +10,12 @@ import { b64urlDecode, b64urlEncode, hmacSign, hmacVerify } from './hmac'
 //      have its capabilities widened without invalidating the signature (P0: token forgery).
 // Wire format: base64url(JSON(claims)) '.' base64url(hmac(body)).
 
-export type DataCapability = 'read' | 'write'
+// read     — read your own documents (and any `shared-*` collection)
+// create   — add new documents, always attributed to you (every authorized viewer gets this)
+// write    — update/delete documents (scoped to your own; owner-only)
+// read_all — read every document in the site regardless of creator; with write, also delete
+//            any document (owner/superadmin moderation)
+export type DataCapability = 'read' | 'create' | 'write' | 'read_all'
 
 export interface DataClaims {
   aud: 'data'
@@ -23,7 +28,7 @@ export interface DataClaims {
 const enc = new TextEncoder()
 const dec = new TextDecoder()
 
-const CAPS: ReadonlySet<string> = new Set<DataCapability>(['read', 'write'])
+const CAPS: ReadonlySet<string> = new Set<DataCapability>(['read', 'create', 'write', 'read_all'])
 
 /** Mint a data token binding the viewer to a single site + capability set for `ttlSec`. */
 export async function signDataToken(

--- a/packages/api/src/routes/data.test.ts
+++ b/packages/api/src/routes/data.test.ts
@@ -36,14 +36,19 @@ async function scenario() {
   await seedSite(db, { id: 'siteB', spaceId: sp2, ownerId: 'userB', slug: 'bobsite', visibility: 'team' })
 
   const app = mount(db)
+  const OWNER_CAPS: Parameters<typeof signDataToken>[1]['caps'] = ['read', 'create', 'write', 'read_all']
   const tokens = {
-    ownerA: await signDataToken(HMAC_A, { siteId: 'siteA', viewerId: 'userA', caps: ['read', 'write'] }),
+    ownerA: await signDataToken(HMAC_A, { siteId: 'siteA', viewerId: 'userA', caps: OWNER_CAPS }),
+    // What the mint actually issues a viewer: read (own rows + shared-*) and create.
+    viewerB: await signDataToken(HMAC_A, { siteId: 'siteA', viewerId: 'userB', caps: ['read', 'create'] }),
+    // Legacy pre-policy-v2 read-only token — still verifies, still read-only.
     viewerB_read: await signDataToken(HMAC_A, { siteId: 'siteA', viewerId: 'userB', caps: ['read'] }),
     // Over-privileged B token for siteA (simulates a compromised mint) — used to prove that even
-    // WITH write+read caps, B still cannot reach A's rows (createdBy scoping is independent of caps).
-    viewerB_write: await signDataToken(HMAC_A, { siteId: 'siteA', viewerId: 'userB', caps: ['read', 'write'] }),
+    // WITH write caps (but no read_all), B still cannot reach A's rows (createdBy scoping is
+    // independent of write caps).
+    viewerB_write: await signDataToken(HMAC_A, { siteId: 'siteA', viewerId: 'userB', caps: ['read', 'create', 'write'] }),
     // B's legitimate token for their OWN site — used to prove cross-tenant reach is impossible.
-    B_siteB: await signDataToken(HMAC_A, { siteId: 'siteB', viewerId: 'userB', caps: ['read', 'write'] }),
+    B_siteB: await signDataToken(HMAC_A, { siteId: 'siteB', viewerId: 'userB', caps: OWNER_CAPS }),
   }
   return { db, app, tokens }
 }
@@ -88,18 +93,25 @@ describe('glance.db data plane — happy path', () => {
   })
 })
 
-describe('P0-4/P0-3: write authority is distinct from view authority', () => {
-  test('dataCapsFor: owner + superadmin get write; a mere viewer gets read-only', () => {
-    expect(dataCapsFor({ id: 'userA', role: 'member' }, { ownerId: 'userA' })).toEqual(['read', 'write'])
-    expect(dataCapsFor({ id: 'root', role: 'superadmin' }, { ownerId: 'userA' })).toEqual(['read', 'write'])
-    expect(dataCapsFor({ id: 'userB', role: 'member' }, { ownerId: 'userA' })).toEqual(['read'])
+describe('P0-4/P0-3: modify authority is distinct from view authority', () => {
+  test('dataCapsFor: owner + superadmin get write/read_all; a viewer gets read+create only', () => {
+    expect(dataCapsFor({ id: 'userA', role: 'member' }, { ownerId: 'userA' })).toEqual(['read', 'create', 'write', 'read_all'])
+    expect(dataCapsFor({ id: 'root', role: 'superadmin' }, { ownerId: 'userA' })).toEqual(['read', 'create', 'write', 'read_all'])
+    expect(dataCapsFor({ id: 'userB', role: 'member' }, { ownerId: 'userA' })).toEqual(['read', 'create'])
   })
 
-  test('ATTACK: a read-only token cannot write (create/put/delete → 403)', async () => {
+  test('ATTACK: a viewer token cannot modify — put/delete → 403; legacy read-only also blocked from create', async () => {
     const { app, tokens } = await scenario()
+    expect((await req(app, tokens.viewerB, 'PUT', '/posts/x', { x: 1 })).status).toBe(403)
+    expect((await req(app, tokens.viewerB, 'DELETE', '/posts/x')).status).toBe(403)
     expect((await req(app, tokens.viewerB_read, 'POST', '/posts', { x: 1 })).status).toBe(403)
-    expect((await req(app, tokens.viewerB_read, 'PUT', '/posts/x', { x: 1 })).status).toBe(403)
-    expect((await req(app, tokens.viewerB_read, 'DELETE', '/posts/x')).status).toBe(403)
+  })
+
+  test('a viewer CAN create — the submission is attributed to them, not the owner', async () => {
+    const { db, app, tokens } = await scenario()
+    const id = await create(app, tokens.viewerB, 'feedback', { msg: 'from B' })
+    const row = (await db.select().from(documents).where(eq(documents.docId, id)))[0]
+    expect(row.createdBy).toBe('userB')
   })
 })
 
@@ -114,6 +126,50 @@ describe('P0-6: per-document read policy (cross-viewer isolation)', () => {
     expect((await req(app, tokens.viewerB_read, 'GET', `/secrets/${id}`)).status).toBe(404)
     // ...not even with a write-capable token (caps do not widen the read scope).
     expect((await req(app, tokens.viewerB_write, 'GET', `/secrets/${id}`)).status).toBe(404)
+  })
+})
+
+describe('policy v2: owner read_all + shared-* collections', () => {
+  test("owner sees viewers' submissions (read_all) — the feedback-form story", async () => {
+    const { app, tokens } = await scenario()
+    const id = await create(app, tokens.viewerB, 'feedback', { msg: 'B says hi' })
+    const items = (await (await req(app, tokens.ownerA, 'GET', '/feedback')).json()).items
+    expect(items).toHaveLength(1)
+    expect(items[0].createdBy).toBe('userB')
+    expect((await req(app, tokens.ownerA, 'GET', `/feedback/${id}`)).status).toBe(200)
+  })
+
+  test('shared-* collection: every viewer reads every row; modification stays locked', async () => {
+    const { app, tokens } = await scenario()
+    const id = await create(app, tokens.ownerA, 'shared-votes', { v: 'A' })
+    await create(app, tokens.viewerB, 'shared-votes', { v: 'B' })
+    // B sees both rows (and who wrote them)...
+    const items = (await (await req(app, tokens.viewerB, 'GET', '/shared-votes')).json()).items
+    expect(items).toHaveLength(2)
+    expect(new Set(items.map((d: { createdBy: string }) => d.createdBy))).toEqual(new Set(['userA', 'userB']))
+    expect((await req(app, tokens.viewerB, 'GET', `/shared-votes/${id}`)).status).toBe(200)
+    // ...but ATTACK: shared visibility must not widen write reach — B cannot touch A's row.
+    expect((await req(app, tokens.viewerB, 'PUT', `/shared-votes/${id}`, { v: 'hacked' })).status).toBe(403)
+    expect((await req(app, tokens.viewerB, 'DELETE', `/shared-votes/${id}`)).status).toBe(403)
+    expect((await req(app, tokens.viewerB_write, 'DELETE', `/shared-votes/${id}`)).status).toBe(204) // scoped: removes 0 rows
+    expect((await req(app, tokens.ownerA, 'GET', `/shared-votes/${id}`)).status).toBe(200)
+  })
+
+  test('owner can delete ANY document in their site (moderation), and only in their site', async () => {
+    const { app, tokens } = await scenario()
+    const spam = await create(app, tokens.viewerB, 'feedback', { msg: 'spam' })
+    expect((await req(app, tokens.ownerA, 'DELETE', `/feedback/${spam}`)).status).toBe(204)
+    expect((await req(app, tokens.ownerA, 'GET', `/feedback/${spam}`)).status).toBe(404)
+    // Cross-tenant: B's owner-tier token for siteB cannot moderate siteA's rows.
+    const keep = await create(app, tokens.viewerB, 'feedback', { msg: 'keep' })
+    expect((await req(app, tokens.B_siteB, 'DELETE', `/feedback/${keep}`)).status).toBe(204) // siteB-scoped: removes 0 rows
+    expect((await req(app, tokens.ownerA, 'GET', `/feedback/${keep}`)).status).toBe(200)
+  })
+
+  test('non-shared collections stay per-creator for viewers (unchanged default)', async () => {
+    const { app, tokens } = await scenario()
+    await create(app, tokens.ownerA, 'notes', { private: 'A only' })
+    expect((await (await req(app, tokens.viewerB, 'GET', '/notes')).json()).items).toHaveLength(0)
   })
 })
 

--- a/packages/api/src/routes/data.ts
+++ b/packages/api/src/routes/data.ts
@@ -22,6 +22,11 @@ const MAX_JSON_BYTES = 100_000
 const DEFAULT_LIMIT = 50
 const MAX_LIMIT = 200
 const DATA_TOKEN_TTL_SEC = 300
+// Read-policy opt-in by naming convention: documents in a `shared-*` collection are readable by
+// EVERY authorized viewer of the site (polls, boards, tallies). Writes are unaffected — put and
+// delete stay creator-scoped, so a shared collection is many-writers-of-their-own-rows, never a
+// free-for-all.
+const SHARED_PREFIX = 'shared-'
 
 // `db` is optional: production runs no middleware that sets it, so getDb() falls back to a
 // per-request client from the D1 binding; tests inject the in-memory harness db via c.set('db')
@@ -85,8 +90,9 @@ dataApi.use('*', async (c, next) => {
 })
 
 // Method → required capability, enforced structurally for every current AND future route on
-// this surface — a new endpoint cannot ship without a capability check.
-const METHOD_CAP: Record<string, DataCapability> = { GET: 'read', HEAD: 'read', POST: 'write', PUT: 'write', DELETE: 'write' }
+// this surface — a new endpoint cannot ship without a capability check. POST maps to `create`
+// (every viewer may submit attributed documents); PUT/DELETE stay behind `write` (owner-only).
+const METHOD_CAP: Record<string, DataCapability> = { GET: 'read', HEAD: 'read', POST: 'create', PUT: 'write', DELETE: 'write' }
 dataApi.use('*', async (c, next) => {
   const cap = METHOD_CAP[c.req.method]
   if (!cap || !hasCap(c.get('claims'), cap)) return c.json({ error: 'forbidden' }, 403)
@@ -117,7 +123,8 @@ dataApi.post('/:collection', async (c) => {
   return c.json({ id: docId, data: parsed.value, createdAt: now, updatedAt: now }, 201)
 })
 
-// Read one document. Scoped to the token's site + the caller's own rows.
+// Read one document. Default: the caller's own rows; site-wide when the collection is
+// `shared-*` or the token carries `read_all` (owner/superadmin).
 dataApi.get('/:collection/:docId', async (c) => {
   const claims = c.get('claims')
   const collection = c.req.param('collection')
@@ -127,15 +134,15 @@ dataApi.get('/:collection/:docId', async (c) => {
     await getDb(c)
       .select()
       .from(documents)
-      .where(scoped(claims, collection, docId))
+      .where(and(...docWhere(claims, collection, docId), ...readCreatorWhere(claims, collection)))
       .limit(1)
   )[0]
   if (!row) return c.json({ error: 'not found' }, 404)
   return c.json(toDoc(row))
 })
 
-// List documents in a collection, newest first. Returns ONLY the caller's own rows in this
-// site+collection (default per-creator read policy — "public within site" is a future opt-in).
+// List documents in a collection, newest first. Default: ONLY the caller's own rows; the whole
+// site's rows for `shared-*` collections (any viewer) or a `read_all` token (owner/superadmin).
 dataApi.get('/:collection', async (c) => {
   const claims = c.get('claims')
   const collection = c.req.param('collection')
@@ -147,7 +154,7 @@ dataApi.get('/:collection', async (c) => {
       and(
         eq(documents.siteId, claims.siteId),
         eq(documents.collection, collection),
-        eq(documents.createdBy, claims.viewerId),
+        ...readCreatorWhere(claims, collection),
       ),
     )
     .orderBy(desc(documents.createdAt))
@@ -206,18 +213,38 @@ dataApi.put('/:collection/:docId', async (c) => {
   return c.json({ id: docId, data: parsed.value, createdAt: now, updatedAt: now }, 201)
 })
 
-// Delete a document. Scoped to the token's site + the caller's own rows.
+// Delete a document. Creator-scoped by default; a `read_all` token (owner/superadmin — always
+// paired with `write` at mint) deletes ANY document in the site: that is the moderation story
+// for viewer-submitted content (spam in a feedback form, a hostile poll entry).
 dataApi.delete('/:collection/:docId', async (c) => {
   const claims = c.get('claims')
   const collection = c.req.param('collection')
   const docId = c.req.param('docId')
   if (!COLLECTION_RE.test(collection) || !DOCID_RE.test(docId)) return c.json({ error: 'not found' }, 404)
-  await getDb(c).delete(documents).where(scoped(claims, collection, docId))
+  const where = hasCap(claims, 'read_all')
+    ? and(...docWhere(claims, collection, docId))
+    : scoped(claims, collection, docId)
+  await getDb(c).delete(documents).where(where)
   return c.body(null, 204)
 })
 
-// Every single-doc query is scoped by (token siteId + collection + docId + token viewer) so a
-// docId from another site or another viewer can never be reached (tenant + creator isolation).
+// Tenant wall for a single doc: token siteId + collection + docId. NEVER used without either
+// the creator wall or an owner-tier cap on top.
+function docWhere(claims: DataClaims, collection: string, docId: string) {
+  return [eq(documents.siteId, claims.siteId), eq(documents.collection, collection), eq(documents.docId, docId)]
+}
+
+// The creator wall for READS, dropped only for `shared-*` collections (opt-in by name, visible
+// to every viewer) or a `read_all` token. Returned as a spreadable list so callers AND it in.
+function readCreatorWhere(claims: DataClaims, collection: string) {
+  return collection.startsWith(SHARED_PREFIX) || hasCap(claims, 'read_all')
+    ? []
+    : [eq(documents.createdBy, claims.viewerId)]
+}
+
+// Every single-doc WRITE query is scoped by (token siteId + collection + docId + token viewer)
+// so a docId from another site or another viewer can never be touched (tenant + creator
+// isolation) — shared-* read visibility never widens write reach.
 function scoped(claims: DataClaims, collection: string, docId: string) {
   return and(
     eq(documents.siteId, claims.siteId),
@@ -258,17 +285,24 @@ function clampLimit(q: string | undefined): number {
   return Math.min(Math.floor(n), MAX_LIMIT)
 }
 
+// createdBy is exposed (an opaque user id): shared collections and owner reads need to group
+// and attribute rows — resolving ids to names stays a follow-up.
 function toDoc(row: DocumentRow) {
-  return { id: row.docId, data: row.json, createdAt: row.createdAt, updatedAt: row.updatedAt }
+  return { id: row.docId, data: row.json, createdBy: row.createdBy, createdAt: row.createdAt, updatedAt: row.updatedAt }
 }
 
 // --- Session-authenticated mint (trusted app origin) ---
 
-// The single source of truth for "who gets write". WRITE is the site owner (or a superadmin)
-// ONLY; everyone else who can access the site gets READ. Pure + exported so the write≠view
-// invariant is unit-tested directly, independent of the request/session plumbing.
+// The single source of truth for capability bundles. Every authorized viewer may READ (their
+// own rows + shared-* collections) and CREATE (attributed submissions — this is what makes
+// forms/polls possible). Only the site owner or a superadmin gets WRITE (update/delete) and
+// READ_ALL (see + moderate every row). "Can view" still never implies "can modify": a viewer
+// cannot touch any existing document, not even their own. Pure + exported so the invariant is
+// unit-tested directly, independent of the request/session plumbing.
 export function dataCapsFor(user: Pick<SessionUser, 'id' | 'role'>, site: Pick<Site, 'ownerId'>): DataCapability[] {
-  return user.role === 'superadmin' || site.ownerId === user.id ? ['read', 'write'] : ['read']
+  return user.role === 'superadmin' || site.ownerId === user.id
+    ? ['read', 'create', 'write', 'read_all']
+    : ['read', 'create']
 }
 
 export const dataToken = new Hono<AppEnv>()


### PR DESCRIPTION
Unlocks forms, surveys, polls, and boards on the glance.db data plane — pure policy change, no new infra, no migration.

## Policy
| | before | after |
|---|---|---|
| viewer caps | `read` (own docs only; could not submit anything) | `read` + `create` — submissions attributed via `createdBy` |
| owner caps | `read`+`write` (but reads still per-creator — couldn't see submissions) | `read`+`create`+`write`+`read_all` — sees everything, deletes anything in their site (moderation) |
| shared data | impossible | collections named `shared-*` readable by every site viewer (opt-in by name, zero config) |
| modification | owner-only | unchanged: PUT/DELETE stay behind `write`; a viewer can never touch an existing doc — shared visibility never widens write reach |

`toDoc` now exposes `createdBy` (opaque id) so shared/owner reads can attribute rows; id→name resolution stays a follow-up.

## Tests
+7 policy tests including attacks: shared-* must not widen write reach (viewer PUT/DELETE on another's shared row → 403/no-op), cross-tenant moderation (owner-tier token for site B deletes nothing in site A), attribution under viewer create, legacy read-only tokens still valid. **205 api green**, typecheck + biome lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)