### PR TITLE
feat(cli): self-updating binary — background check, atomic swap, upgrade/version commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,12 +57,18 @@ The installer bakes in your instance URL (so `glance login` targets it immediate
 | `list` | your sites, with visibility + URL |
 | `delete <space/slug>` | confirms, then deletes |
 | `move <space/slug> <new-space>` | moves a site (keeps files/comments/shares; URL changes) |
+| `upgrade` | updates the CLI to the latest release now |
+| `version` | prints the CLI version |
 | `logout` | revokes session, removes local token |
 
 Defaults: `--space` = your personal space · `--name` = file/folder name slugified · `--visibility` = `team`.
 Visibility: `team` · `public` · `private` · `members` (own space only).
 
 Point at another instance any time with `GLANCE_API_URL=https://… glance <cmd>`.
+
+The CLI keeps itself current: at most once a day it checks for a new release in the background,
+swaps the binary in place, and mentions it on the next run. Opt out with `GLANCE_NO_UPDATE=1`
+(checks are also skipped in CI).
 
 ## Security model
 

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -6,6 +6,7 @@ import { basename, join, relative, resolve, sep } from 'node:path'
 import { createInterface } from 'node:readline/promises'
 import pkg from './package.json'
 import { SKILL_MD, SKILL_NAME } from './skill-content'
+import { announceUpdate, maybeAutoUpdate, upgradeCmd } from './upgrade'
 
 // Sent as the User-Agent on every authenticated request so the server can attribute CLI usage
 // (and segment by version) in its analytics. Static JSON import → inlined into the compiled
@@ -14,7 +15,7 @@ import { SKILL_MD, SKILL_NAME } from './skill-content'
 const USER_AGENT = `glance-cli/${pkg.version}`
 
 // Glance CLI — deploy folders to Glance from the terminal.
-//   glance login | deploy <path> --space <s> --name <s> [--visibility v] | list | delete <space/slug> | move <space/slug> <new-space> | comments <space/slug> | read <space/slug> | logout
+//   glance login | deploy <path> --space <s> --name <s> [--visibility v] | list | delete <space/slug> | move <space/slug> <new-space> | comments <space/slug> | read <space/slug> | upgrade | version | logout
 
 const CONFIG_DIR = join(homedir(), '.glance')
 const CONFIG_PATH = join(CONFIG_DIR, 'config.json')
@@ -402,7 +403,8 @@ async function read(argv: string[]): Promise<void> {
 }
 
 if (import.meta.main) {
-  const [cmd, ...rest] = process.argv.slice(2)
+  const [raw, ...rest] = process.argv.slice(2)
+  const cmd = raw === '--version' ? 'version' : raw
   const commands: Record<string, () => Promise<void>> = {
     login,
     deploy: () => deploy(rest),
@@ -412,7 +414,16 @@ if (import.meta.main) {
     comments: () => comments(rest),
     read: () => read(rest),
     skill: async () => skillCmd(rest),
+    upgrade: () => upgradeCmd(rest),
+    version: async () => console.log(pkg.version),
     logout,
+  }
+  // Self-update hooks, skipped for machine-invoked commands: `upgrade` IS the updater, and `skill`
+  // is run by install.sh and by the post-swap refresh child — which would otherwise consume the
+  // pending "auto-updated" notice before the user ever sees it.
+  if (cmd !== 'upgrade' && cmd !== 'skill') {
+    announceUpdate()
+    maybeAutoUpdate()
   }
   const run = commands[cmd ?? '']
   if (!run) {
@@ -425,6 +436,8 @@ if (import.meta.main) {
     console.log('  glance comments <space/slug> [--file <path>] [--open] [--json]')
     console.log('  glance read <space/slug> [--file <path>]')
     console.log('  glance skill install')
+    console.log('  glance upgrade')
+    console.log('  glance version')
     console.log('  glance logout')
     process.exit(cmd ? 1 : 0)
   }

--- a/packages/cli/upgrade.e2e.test.ts
+++ b/packages/cli/upgrade.e2e.test.ts
@@ -1,0 +1,228 @@
+import { afterAll, beforeAll, describe, expect, setDefaultTimeout, test } from 'bun:test'
+import { spawnSync } from 'node:child_process'
+import { createHash } from 'node:crypto'
+import {
+  chmodSync,
+  cpSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { gzipSync } from 'node:zlib'
+import { SKILL_NAME } from './skill-content'
+import { assetName } from './upgrade.ts'
+
+// End-to-end proof of the self-update loop on REAL compiled binaries: an old binary must discover
+// a release on a (fake, GitHub-shaped) host, background-download it, atomically swap itself, and
+// announce once — plus every guard rail (checksum, opt-out, CI, read-only dir, TTL).
+// Compiles two binaries in beforeAll (~seconds); network is loopback-only.
+
+setDefaultTimeout(180_000)
+
+const OLD = '0.0.1'
+const NEW = '0.0.2'
+const ASSET = assetName(process.platform, process.arch)!
+
+let e2eRoot: string
+let oldBinary: string // pristine 0.0.1 — copied into a fresh "install" per scenario
+let newGz: Buffer
+let newSha: string
+let base: string
+let badSha = false
+let latestHits = 0
+let server: ReturnType<typeof Bun.serve>
+
+// Compile the CLI exactly as release.yml does: stamp a version into package.json, then
+// `bun build --compile`. process.execPath is the bun running this test.
+function compile(version: string, outfile: string): void {
+  const src = mkdtempSync(join(e2eRoot, 'src-'))
+  for (const f of ['index.ts', 'upgrade.ts', 'skill-content.ts']) cpSync(join(import.meta.dir, f), join(src, f))
+  const pkg = JSON.parse(readFileSync(join(import.meta.dir, 'package.json'), 'utf8'))
+  pkg.version = version
+  writeFileSync(join(src, 'package.json'), JSON.stringify(pkg))
+  const res = spawnSync(process.execPath, ['build', '--compile', './index.ts', '--outfile', outfile], {
+    cwd: src,
+    stdio: 'pipe',
+    encoding: 'utf8',
+  })
+  if (res.status !== 0) throw new Error(`compile ${version} failed: ${res.stderr}`)
+}
+
+// A fresh, isolated "installation": its own bin dir holding the OLD binary and its own $HOME,
+// so ~/.glance state and ~/.claude skills never leak between scenarios (or into the real user's).
+function freshInstall(): { glance: string; bin: string; home: string; env: Record<string, string> } {
+  const dir = mkdtempSync(join(e2eRoot, 'install-'))
+  const bin = join(dir, 'bin')
+  const home = join(dir, 'home')
+  mkdirSync(bin)
+  mkdirSync(home)
+  const glance = join(bin, 'glance')
+  cpSync(oldBinary, glance)
+  chmodSync(glance, 0o755)
+  // Full env replacement (not a merge) so the outer CI/GLANCE_NO_UPDATE can't leak in.
+  return { glance, bin, home, env: { HOME: home, PATH: process.env.PATH ?? '', GLANCE_RELEASE_BASE: base } }
+}
+
+// MUST be async (never spawnSync): the fake release server lives in THIS process, and a sync wait
+// would freeze its event loop — the child's fetch would deadlock until its abort timeout.
+async function run(bin: string, args: string[], env: Record<string, string>) {
+  const proc = Bun.spawn([bin, ...args], { env, stdout: 'pipe', stderr: 'pipe', timeout: 30_000 })
+  const [stdout, stderr, status] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ])
+  return { stdout, stderr, status }
+}
+
+function sha256(path: string): string {
+  return createHash('sha256').update(readFileSync(path)).digest('hex')
+}
+
+function readState(home: string): Record<string, unknown> {
+  try {
+    return JSON.parse(readFileSync(join(home, '.glance', 'update.json'), 'utf8'))
+  } catch {
+    return {}
+  }
+}
+
+async function until(cond: () => boolean, ms = 30_000): Promise<boolean> {
+  const t0 = Date.now()
+  while (Date.now() - t0 < ms) {
+    if (cond()) return true
+    await Bun.sleep(100)
+  }
+  return cond()
+}
+
+beforeAll(() => {
+  e2eRoot = mkdtempSync(join(tmpdir(), 'glance-upgrade-e2e-'))
+  oldBinary = join(e2eRoot, `glance-${OLD}`)
+  const newBinary = join(e2eRoot, `glance-${NEW}`)
+  compile(OLD, oldBinary)
+  compile(NEW, newBinary)
+  const newBytes = readFileSync(newBinary)
+  newGz = gzipSync(newBytes, { level: 1 })
+  newSha = createHash('sha256').update(newBytes).digest('hex')
+
+  server = Bun.serve({
+    port: 0,
+    hostname: '127.0.0.1',
+    fetch(req) {
+      const path = new URL(req.url).pathname
+      if (path === '/releases/latest') {
+        latestHits++
+        return Response.redirect(`${base}/tag/v${NEW}`, 302)
+      }
+      if (path === `/releases/tag/v${NEW}`) return new Response('tag page')
+      if (path === `/releases/download/v${NEW}/${ASSET}.gz`) return new Response(newGz)
+      if (path === `/releases/download/v${NEW}/${ASSET}.sha256`)
+        // shasum-style "hex  filename" line — the updater must take the first token.
+        return new Response(`${badSha ? '0'.repeat(64) : newSha}  ${ASSET}\n`)
+      return new Response('not found', { status: 404 })
+    },
+  })
+  base = `http://127.0.0.1:${server.port}/releases`
+})
+
+afterAll(() => {
+  server?.stop(true)
+  rmSync(e2eRoot, { recursive: true, force: true })
+})
+
+describe('auto-update e2e', () => {
+  test('background-swap-announce-once-then-ttl-quiet', async () => {
+    const { glance, home, env } = freshInstall()
+    const hitsBefore = latestHits
+
+    const first = await run(glance, ['version'], env)
+    expect(first.status).toBe(0)
+    expect(first.stdout.trim()).toBe(OLD)
+    // The TTL is stamped by the parent BEFORE the detached checker runs.
+    expect(readState(home).lastCheckedAt).toBeNumber()
+
+    // The detached child downloads, verifies, and rename(2)s over the binary, then records the swap.
+    expect(await until(() => sha256(glance) === newSha)).toBe(true)
+    expect(await until(() => readState(home).updatedTo === NEW)).toBe(true)
+    // Post-swap refresh: the NEW binary re-installed the agent skill into this $HOME.
+    expect(existsSync(join(home, '.claude', 'skills', SKILL_NAME, 'SKILL.md'))).toBe(true)
+
+    // Next invocation IS the new version and announces exactly once, on stderr.
+    const second = await run(glance, ['version'], env)
+    expect(second.stdout.trim()).toBe(NEW)
+    expect(second.stderr).toContain(`auto-updated to ${NEW}`)
+    const third = await run(glance, ['version'], env)
+    expect(third.stderr).not.toContain('auto-updated')
+
+    // All of the above rode ONE release check — later runs sat inside the 24h TTL.
+    await Bun.sleep(300)
+    expect(latestHits - hitsBefore).toBe(1)
+  })
+
+  test('opt-out-and-ci-never-check', async () => {
+    const { glance, home, env } = freshInstall()
+    expect((await run(glance, ['version'], { ...env, GLANCE_NO_UPDATE: '1' })).stdout.trim()).toBe(OLD)
+    expect((await run(glance, ['version'], { ...env, CI: 'true' })).stdout.trim()).toBe(OLD)
+    await Bun.sleep(400)
+    // No TTL stamp, no checker spawned, binary untouched.
+    expect(existsSync(join(home, '.glance', 'update.json'))).toBe(false)
+    expect(sha256(glance)).not.toBe(newSha)
+  })
+
+  test('foreground-upgrade-loud-and-no-later-notice', async () => {
+    const { glance, env } = freshInstall()
+    const up = await run(glance, ['upgrade'], env)
+    expect(up.status).toBe(0)
+    expect(up.stdout).toContain(`${OLD} → ${NEW}`)
+    expect(sha256(glance)).toBe(newSha)
+    // The user watched this one — no queued announcement.
+    const next = await run(glance, ['version'], env)
+    expect(next.stdout.trim()).toBe(NEW)
+    expect(next.stderr).not.toContain('auto-updated')
+    // Already latest → idempotent.
+    expect((await run(glance, ['upgrade'], env)).stdout).toContain('up to date')
+  })
+
+  test('checksum-mismatch-rejects-loud-in-foreground-silent-in-background', async () => {
+    badSha = true
+    try {
+      const fg = freshInstall()
+      const up = await run(fg.glance, ['upgrade'], fg.env)
+      expect(up.status).toBe(1)
+      expect(up.stderr).toContain('checksum mismatch')
+      expect(sha256(fg.glance)).not.toBe(newSha) // binary untouched
+      expect(readdirSync(fg.bin)).toEqual(['glance']) // no temp file left behind
+
+      const bg = freshInstall()
+      await run(bg.glance, ['version'], bg.env)
+      await Bun.sleep(1500)
+      expect(sha256(bg.glance)).not.toBe(newSha)
+      expect(readState(bg.home).updatedTo).toBeUndefined()
+      expect((await run(bg.glance, ['version'], bg.env)).stderr).toBe('') // failure never surfaces
+    } finally {
+      badSha = false
+    }
+  })
+
+  test('readonly-install-dir-notifies-instead-of-swapping', async () => {
+    const { glance, bin, home, env } = freshInstall()
+    chmodSync(bin, 0o555)
+    try {
+      await run(glance, ['version'], env)
+      expect(await until(() => readState(home).available === NEW)).toBe(true)
+      expect(sha256(glance)).not.toBe(newSha)
+      // Nag exactly once per version.
+      expect((await run(glance, ['version'], env)).stderr).toContain(`${NEW} is available`)
+      expect((await run(glance, ['version'], env)).stderr).not.toContain('available')
+    } finally {
+      chmodSync(bin, 0o755)
+    }
+  })
+})

--- a/packages/cli/upgrade.test.ts
+++ b/packages/cli/upgrade.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  assetName,
+  compareVersions,
+  parseLatestTag,
+  planAnnouncement,
+  shouldCheck,
+  type UpdateState,
+} from './upgrade.ts'
+
+describe('compareVersions', () => {
+  test('compare-orders-numerically', () => {
+    expect(compareVersions('0.5.0', '0.4.9')).toBeGreaterThan(0)
+    expect(compareVersions('0.4.0', '0.4.0')).toBe(0)
+    expect(compareVersions('0.4', '0.4.1')).toBeLessThan(0) // missing parts count as 0
+    expect(compareVersions('1.0.0', '0.99.99')).toBeGreaterThan(0) // numeric, not lexicographic
+  })
+
+  test('compare-malformed-tag-never-newer', () => {
+    // A non-CLI release tag (e.g. `ui-screens`) must never look like an upgrade target.
+    expect(compareVersions('ui-screens', '0.0.0')).toBe(0)
+    expect(compareVersions('ui-screens', '0.4.0')).toBeLessThan(0)
+  })
+})
+
+describe('parseLatestTag', () => {
+  test('parse-tag-from-release-url', () => {
+    expect(parseLatestTag('https://github.com/plivo-labs/glance/releases/tag/v0.4.0')).toBe('v0.4.0')
+    expect(parseLatestTag('http://127.0.0.1:8080/releases/tag/v9.9.9?x=1#top')).toBe('v9.9.9')
+    expect(parseLatestTag('https://github.com/plivo-labs/glance/releases/tag/v0.4.0-rc%2B1')).toBe('v0.4.0-rc+1')
+  })
+
+  test('parse-no-tag-returns-null', () => {
+    // No releases → /releases/latest does not redirect; the final URL has no /tag/ segment.
+    expect(parseLatestTag('https://github.com/plivo-labs/glance/releases/latest')).toBeNull()
+    expect(parseLatestTag('https://github.com/plivo-labs/glance/releases/tag/')).toBeNull()
+  })
+})
+
+describe('assetName', () => {
+  test('asset-matches-release-artifacts', () => {
+    // Must match release.yml's artifact names exactly.
+    expect(assetName('darwin', 'arm64')).toBe('glance-arm64-darwin')
+    expect(assetName('linux', 'x64')).toBe('glance-x64-linux')
+  })
+
+  test('asset-unsupported-returns-null', () => {
+    expect(assetName('win32', 'x64')).toBeNull()
+    expect(assetName('linux', 'ia32')).toBeNull()
+  })
+})
+
+describe('shouldCheck', () => {
+  const DAY = 24 * 60 * 60 * 1000
+  test('should-check-ttl-gate', () => {
+    expect(shouldCheck({}, 1000)).toBe(true) // never checked
+    expect(shouldCheck({ lastCheckedAt: 1000 }, 1000 + DAY - 1)).toBe(false) // within window
+    expect(shouldCheck({ lastCheckedAt: 1000 }, 1000 + DAY + 1)).toBe(true) // window expired
+  })
+})
+
+describe('planAnnouncement', () => {
+  test('announce-after-swap-once', () => {
+    const state: UpdateState = { lastCheckedAt: 1, updatedTo: '0.5.0' }
+    const { message, next } = planAnnouncement(state, '0.5.0')
+    expect(message).toContain('0.5.0')
+    expect(next.updatedTo).toBeUndefined()
+    expect(next.lastCheckedAt).toBe(1) // unrelated state survives
+    // The cleared state announces nothing on the following run.
+    expect(planAnnouncement(next, '0.5.0').message).toBeNull()
+  })
+
+  test('announce-stale-swap-clears-silently', () => {
+    // A manual reinstall raced the background swap — never claim a version we're not running.
+    const { message, next } = planAnnouncement({ updatedTo: '0.5.0' }, '0.6.0')
+    expect(message).toBeNull()
+    expect(next.updatedTo).toBeUndefined()
+  })
+
+  test('announce-available-nags-once-per-version', () => {
+    const first = planAnnouncement({ available: '0.5.0' }, '0.4.0')
+    expect(first.message).toContain('glance upgrade')
+    expect(first.next.notifiedAvailable).toBe('0.5.0')
+    // Same version again → silent; a NEWER available version → nags again.
+    expect(planAnnouncement(first.next, '0.4.0').message).toBeNull()
+    expect(planAnnouncement({ ...first.next, available: '0.6.0' }, '0.4.0').message).toContain('0.6.0')
+  })
+
+  test('announce-available-cleared-once-caught-up', () => {
+    const { message, next } = planAnnouncement({ available: '0.5.0', notifiedAvailable: '0.5.0' }, '0.5.0')
+    expect(message).toBeNull()
+    expect(next.available).toBeUndefined()
+    expect(next.notifiedAvailable).toBeUndefined()
+  })
+
+  test('announce-noop-returns-same-reference', () => {
+    // Callers skip the state write when nothing changed — identity is the contract.
+    const state: UpdateState = { lastCheckedAt: 1 }
+    expect(planAnnouncement(state, '0.4.0').next).toBe(state)
+  })
+})

--- a/packages/cli/upgrade.ts
+++ b/packages/cli/upgrade.ts
@@ -1,0 +1,221 @@
+import { spawn, spawnSync } from 'node:child_process'
+import { createHash } from 'node:crypto'
+import { accessSync, constants, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { gunzipSync } from 'node:zlib'
+import pkg from './package.json'
+
+// Self-update — three entry points sharing one code path:
+//   `glance upgrade`          manual, foreground, loud
+//   `glance upgrade --quiet`  the detached background pass spawned by maybeAutoUpdate()
+//   announceUpdate()          one-line stderr notice on the run AFTER a background swap
+//
+// There is no staged "apply on next run" step: the CLI ships darwin/linux only, where rename(2)
+// over a running binary is safe (the running process keeps its inode) — the background pass swaps
+// in place, and the next invocation simply IS the new version.
+
+const CONFIG_DIR = join(homedir(), '.glance')
+const STATE_PATH = join(CONFIG_DIR, 'update.json')
+const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000
+
+// Overridable so tests (and forks) can point at a fake release host. The URL shapes below mirror
+// GitHub's: `<base>/latest` (redirects to …/releases/tag/<tag>) and `<base>/download/<tag>/<asset>`.
+function releaseBase(): string {
+  return process.env.GLANCE_RELEASE_BASE?.trim() || 'https://github.com/plivo-labs/glance/releases'
+}
+
+export interface UpdateState {
+  lastCheckedAt?: number
+  updatedTo?: string // a background swap landed; notice pending
+  available?: string // newer release exists but the install dir isn't writable
+  notifiedAvailable?: string // version already nagged about (once per version)
+}
+
+function readState(): UpdateState {
+  try {
+    return JSON.parse(readFileSync(STATE_PATH, 'utf8')) as UpdateState
+  } catch {
+    return {}
+  }
+}
+
+// Update machinery must never break the CLI proper — state writes are best-effort.
+function saveState(state: UpdateState): void {
+  try {
+    mkdirSync(CONFIG_DIR, { recursive: true })
+    writeFileSync(STATE_PATH, JSON.stringify(state, null, 2))
+  } catch {
+    /* ignore */
+  }
+}
+
+// Numeric dotted-part compare (release tags are plain vX.Y.Z). Non-numeric parts count as 0, so a
+// malformed or non-CLI tag (e.g. a screenshots release) never compares newer and never triggers a swap.
+export function compareVersions(a: string, b: string): number {
+  const parse = (v: string) => v.split('.').map((part) => Number.parseInt(part, 10) || 0)
+  const [pa, pb] = [parse(a), parse(b)]
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const d = (pa[i] ?? 0) - (pb[i] ?? 0)
+    if (d !== 0) return d
+  }
+  return 0
+}
+
+// `<base>/latest` resolves (via redirect) to `…/releases/tag/<tag>` — the tag rides in the final URL.
+export function parseLatestTag(url: string): string | null {
+  const m = url.match(/\/tag\/([^/?#]+)/)
+  return m?.[1] ? decodeURIComponent(m[1]) : null
+}
+
+// Release asset naming — must match release.yml: glance-<arm64|x64>-<darwin|linux>.
+export function assetName(platform: string, arch: string): string | null {
+  const os = platform === 'darwin' || platform === 'linux' ? platform : null
+  const cpu = arch === 'arm64' || arch === 'x64' ? arch : null
+  return os && cpu ? `glance-${cpu}-${os}` : null
+}
+
+export function shouldCheck(state: UpdateState, now: number): boolean {
+  return !state.lastCheckedAt || now - state.lastCheckedAt > CHECK_INTERVAL_MS
+}
+
+// What (if anything) to tell the user this run, and the state to persist after saying it. PURE —
+// returns the SAME state reference when nothing changes so the caller can skip the write.
+export function planAnnouncement(state: UpdateState, current: string): { message: string | null; next: UpdateState } {
+  if (state.updatedTo) {
+    // Only claim the update if we're actually running it (a manual reinstall may have raced us).
+    const message = state.updatedTo === current ? `✓ glance auto-updated to ${current}` : null
+    return { message, next: { ...state, updatedTo: undefined } }
+  }
+  if (state.available) {
+    if (compareVersions(state.available, current) <= 0)
+      return { message: null, next: { ...state, available: undefined, notifiedAvailable: undefined } }
+    if (state.notifiedAvailable !== state.available)
+      return {
+        message: `glance ${state.available} is available — run \`glance upgrade\``,
+        next: { ...state, notifiedAvailable: state.available },
+      }
+  }
+  return { message: null, next: state }
+}
+
+// Compiled executables run their sources from Bun's embedded virtual FS ($bunfs), where
+// process.execPath is the installed binary. Under `bun index.ts` import.meta.url is a real on-disk
+// path — and execPath is the bun runtime, which must NEVER be swapped. Every update path gates on this.
+export function isCompiledBinary(): boolean {
+  return import.meta.url.includes('/$bunfs/')
+}
+
+function dirWritable(dir: string): boolean {
+  try {
+    accessSync(dir, constants.W_OK)
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function fetchLatestTag(base: string): Promise<string | null> {
+  const res = await fetch(`${base}/latest`, {
+    signal: AbortSignal.timeout(15_000),
+    headers: { 'User-Agent': `glance-cli/${pkg.version}` },
+  })
+  return parseLatestTag(res.url)
+}
+
+// Same contract as install.sh: gzipped binary + sha256 of the UNCOMPRESSED bytes. The verified
+// binary is written next to the install target (same filesystem) then rename(2)d over it, so a
+// crash or a concurrent updater can never leave a torn binary at the install path.
+async function downloadAndSwap(base: string, tag: string, execPath: string): Promise<void> {
+  const asset = assetName(process.platform, process.arch)
+  if (!asset) throw new Error(`unsupported platform: ${process.platform}/${process.arch}`)
+  const url = `${base}/download/${tag}/${asset}`
+  const timeout = { signal: AbortSignal.timeout(120_000) }
+  const [gz, sum] = await Promise.all([fetch(`${url}.gz`, timeout), fetch(`${url}.sha256`, timeout)])
+  if (!gz.ok || !sum.ok) throw new Error(`release ${tag} is missing the ${asset} asset`)
+  const binary = gunzipSync(Buffer.from(await gz.arrayBuffer()))
+  const expected = (await sum.text()).trim().split(/\s+/)[0]
+  const actual = createHash('sha256').update(binary).digest('hex')
+  if (actual !== expected) throw new Error(`checksum mismatch for ${asset} (${tag})`)
+  const tmp = join(dirname(execPath), `.glance-update-${process.pid}`)
+  try {
+    writeFileSync(tmp, binary, { mode: 0o755 })
+    renameSync(tmp, execPath)
+  } catch (err) {
+    rmSync(tmp, { force: true })
+    throw err
+  }
+}
+
+// The new binary embeds a matching SKILL.md — refresh it so agent docs track the CLI. Runs the
+// swapped binary, so `skill` must stay excluded from the startup hooks (see index.ts) or this
+// child would consume the pending updatedTo notice before the user ever sees it.
+function refreshSkill(execPath: string): void {
+  try {
+    spawnSync(execPath, ['skill', 'install'], { stdio: 'ignore', timeout: 10_000 })
+  } catch {
+    /* non-fatal — the binary is what matters */
+  }
+}
+
+export async function upgradeCmd(argv: string[]): Promise<void> {
+  const background = argv.includes('--quiet')
+  const fail = (msg: string): never => {
+    console.error(`✗ ${msg}`)
+    process.exit(1)
+  }
+  try {
+    if (!isCompiledBinary()) {
+      if (background) return
+      return fail('upgrade works on the installed standalone binary only (dev checkout: git pull)')
+    }
+    const base = releaseBase()
+    const tag = await fetchLatestTag(base)
+    if (!tag) throw new Error('could not resolve the latest release')
+    const latest = tag.replace(/^v/, '')
+    if (compareVersions(latest, pkg.version) <= 0) {
+      if (!background) console.log(`✓ glance ${pkg.version} is up to date.`)
+      return
+    }
+    const dir = dirname(process.execPath)
+    if (!dirWritable(dir)) {
+      if (background) return saveState({ ...readState(), available: latest })
+      return fail(`cannot write to ${dir} — re-run the installer, or: sudo glance upgrade`)
+    }
+    await downloadAndSwap(base, tag, process.execPath)
+    refreshSkill(process.execPath)
+    if (background) saveState({ ...readState(), updatedTo: latest, available: undefined, notifiedAvailable: undefined })
+    else console.log(`✓ Updated glance ${pkg.version} → ${latest}`)
+  } catch (err) {
+    if (background) return // background failures are silent by design — next TTL expiry retries
+    fail(`upgrade failed: ${err instanceof Error ? err.message : String(err)}`)
+  }
+}
+
+// Fire-and-forget: stamp the TTL, then hand off to a detached `upgrade --quiet` and return
+// immediately — the user's command never waits on the network. Stamping BEFORE spawning means
+// concurrent invocations within the window don't pile on; a rare simultaneous pair is harmless
+// anyway (both download verified bytes, rename is atomic, last one wins).
+export function maybeAutoUpdate(): void {
+  if (process.env.GLANCE_NO_UPDATE || process.env.CI) return
+  if (!isCompiledBinary()) return
+  const state = readState()
+  if (!shouldCheck(state, Date.now())) return
+  saveState({ ...state, lastCheckedAt: Date.now() })
+  try {
+    const child = spawn(process.execPath, ['upgrade', '--quiet'], { detached: true, stdio: 'ignore' })
+    child.on('error', () => {}) // a spawn failure must never surface into the user's command
+    child.unref()
+  } catch {
+    /* ignore */
+  }
+}
+
+// One line on stderr — never stdout, which gets piped (`read`, `comments --json`) — the first run
+// after a background swap, or once per version when an update exists but the install dir is read-only.
+export function announceUpdate(): void {
+  const state = readState()
+  const { message, next } = planAnnouncement(state, pkg.version)
+  if (message) console.error(message)
+  if (next !== state) saveState(next)
+}


### PR DESCRIPTION
Auto-update for the installed CLI binary, so the next reinstall is the last manual one.

- Every invocation (except `upgrade`/`skill`) forks a detached `upgrade --quiet` at most once per 24h (state in `~/.glance/update.json`)
- Resolves latest from the `releases/latest` redirect URL (no GitHub API, no rate limit), downloads the asset, verifies `.sha256`, atomically rename(2)s over the running binary — next run announces once on stderr
- No staged apply-on-next-run step: darwin/linux only, where renaming over a running binary is safe
- Guards: compiled-binary-only ($bunfs check — dev `bun index.ts` can never clobber the bun runtime), `GLANCE_NO_UPDATE=1`, `CI`, read-only install dir → once-per-version "run `glance upgrade`" nag
- New commands: `glance upgrade` (manual/forced), `glance version` / `--version`
- Post-swap, the new binary re-runs `skill install` so the embedded agent skill stays in sync
- Non-CLI tags at Latest (e.g. `assets-pr-analytics`) parse non-numeric → never newer → safe no-op

Verified by 12 unit tests + 5 e2e scenarios that compile real 0.0.1/0.0.2 binaries and prove the live background swap, checksum rejection, TTL, opt-outs, and read-only fallback against a fake GitHub-shaped release host (`GLANCE_RELEASE_BASE` seam).

Tag `v0.6.0` (this commit) is already building.

🤖 Generated with [Claude Code](https://claude.com/claude-code)