### PR TITLE
docs(readme): add landing hero + dashboard/admin screenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Self-hostable static-file hosting on Cloudflare's free tier. Drop a folder of HTML/markdown/assets → get a URL. $0/month.
 
+<p align="center">
+  <img src="https://github.com/plivo-labs/glance/releases/download/assets-readme/landing.png" alt="Glance — ship static sites instantly, no build step" width="900">
+</p>
+
 Stack: Cloudflare Workers + Hono · React Router v7 · D1 · R2 · KV.
 
 ## Deploy in one command
@@ -31,6 +35,20 @@ bun run dev           # main :8787 + content :8788 + vite :5173
 ```
 
 Open http://localhost:5173.
+
+## The app
+
+Pick a space, drop a folder, and your sites are live behind private/members/team visibility:
+
+<p align="center">
+  <img src="https://github.com/plivo-labs/glance/releases/download/assets-readme/dashboard.png" alt="Glance dashboard — deploy panel and your sites" width="900">
+</p>
+
+Superadmins get usage at a glance — users, sites, storage, page views, comments, and CLI activity:
+
+<p align="center">
+  <img src="https://github.com/plivo-labs/glance/releases/download/assets-readme/admin.png" alt="Glance admin — usage overview with stat tiles and 30-day activity" width="900">
+</p>
 
 ## Layout
 


### PR DESCRIPTION
## What

The README was all text. Add visuals captured from the **live** `glance.plivo.com`:

- **Landing hero** under the title (shows the real `curl https://glance.plivo.com/api/install | sh`).
- A new **"The app"** section with the **dashboard** (deploy panel + your sites) and the **admin** usage overview (stat tiles + 30-day activity).

## Hosting

Images live on the **non-latest** `assets-readme` release and are referenced by download URL. This keeps `v0.8.0` marked `Latest` (verified) so the `install.sh` one-liner (`releases/latest`) doesn't 404.

## Preview

![landing](https://github.com/plivo-labs/glance/releases/download/assets-readme/landing.png)
![dashboard](https://github.com/plivo-labs/glance/releases/download/assets-readme/dashboard.png)
![admin](https://github.com/plivo-labs/glance/releases/download/assets-readme/admin.png)

Docs-only change — no code, no deploy impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)