### PR TITLE
fix(api): element (pinpoint) comments 400 — route read wrong request key

### DIFF
--- a/packages/api/src/routes/comments.test.ts
+++ b/packages/api/src/routes/comments.test.ts
@@ -150,7 +150,7 @@ describe('comments routes — element (pinpoint) anchors', () => {
         filePath: 'index.html',
         body: 'this chart is off',
         anchorType: 'element',
-        anchor: { selector: '#chart', tag: 'div', preview: 'Bar chart', textFallback: 'Revenue' },
+        element: { selector: '#chart', tag: 'div', preview: 'Bar chart', textFallback: 'Revenue' },
       }),
       env,
     )
@@ -165,7 +165,7 @@ describe('comments routes — element (pinpoint) anchors', () => {
     const { app, env, db, r2, kv } = await setup()
     const owner = await mintUser(db, kv, { id: 'owner' })
     await seedSiteWithFile(db, r2, owner)
-    const res = await app.request(url(), post(auth(owner), { filePath: 'index.html', body: 'x', anchorType: 'element', anchor: { tag: 'div' } }), env)
+    const res = await app.request(url(), post(auth(owner), { filePath: 'index.html', body: 'x', anchorType: 'element', element: { tag: 'div' } }), env)
     expect(res.status).toBe(400)
   })
 
@@ -173,7 +173,7 @@ describe('comments routes — element (pinpoint) anchors', () => {
     const { app, env, db, r2, kv } = await setup()
     const owner = await mintUser(db, kv, { id: 'owner' })
     await seedSiteWithFile(db, r2, owner)
-    const res = await app.request(url(), post(auth(owner), { filePath: 'index.html', body: 'x', anchorType: 'element', anchor: { selector: 'a'.repeat(2000) } }), env)
+    const res = await app.request(url(), post(auth(owner), { filePath: 'index.html', body: 'x', anchorType: 'element', element: { selector: 'a'.repeat(2000) } }), env)
     expect(res.status).toBe(400)
   })
 

--- a/packages/api/src/routes/comments.ts
+++ b/packages/api/src/routes/comments.ts
@@ -94,7 +94,7 @@ comments.post('/:space/:site/comments', async (c) => {
   // a 400 (element without a selector must NOT silently coerce to text).
   let anchor: ElementAnchor | undefined
   if (anchorType === 'element') {
-    const parsed = parseElementAnchor(raw.anchor)
+    const parsed = parseElementAnchor(raw.element)
     if ('error' in parsed) return c.json({ error: parsed.error }, 400)
     anchor = parsed.anchor
   }


### PR DESCRIPTION
## Bug
Selecting an element in Annotate/Pinpoint mode and commenting fails with `400 Bad Request` → `element anchor requires a selector`, even though the request carries a valid selector.

## Root cause
Client/server request-body key mismatch:
- Web client posts the anchor under **`element`** (`packages/web/src/lib/comments.ts` `pendingToInput`: `{ anchorType: 'element', element: pending.anchor }`).
- The `POST /comments` route read **`raw.anchor`** → `parseElementAnchor(undefined)` → fails the selector check → 400.

Route tests used `anchor` too, so they matched the buggy server and never caught it (route-test-vs-real-contract gap).

## Fix
- Route reads `raw.element`.
- Updated the 3 element route tests to send the real client key (`element`) so they'd catch this regression.
- Response/storage field stays `anchor` (unchanged).

## Verification
- `element-create-and-readback` test drives the exact browser payload → 201 + correct readback.
- Typecheck, lint, full suite (224 api + 19 web) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)