### PR TITLE
refactor(viewer): recents show one row per site, site name only

### DIFF
--- a/packages/web/src/components/CommandPalette.tsx
+++ b/packages/web/src/components/CommandPalette.tsx
@@ -12,7 +12,7 @@ import {
 } from '@/components/ui/command'
 import { toggleTheme } from '@/components/theme'
 import { api } from '@/lib/api'
-import { entryLabel, useRecents, visibleEntries } from '@/lib/recents'
+import { siteName, useRecents, visibleEntries } from '@/lib/recents'
 import type { Me, SiteSummary, SpaceSummary } from '@/lib/types'
 
 const SEARCH_DEBOUNCE_MS = 200
@@ -40,7 +40,7 @@ export function CommandPalette({
 
   // Same store the viewer's recents sidebar reads — shown only in the empty (no-search) state,
   // like the sites/spaces search results it'd otherwise compete with. Entries are already
-  // most-recent-first, one row per visited page after the root-row collapse (see recents.ts).
+  // most-recent-first, one row per site (see recents.ts).
   const recentEntries = useRecents(user?.id ?? null)
   const recentRows = useMemo(() => visibleEntries(recentEntries).slice(0, 5), [recentEntries])
 
@@ -115,21 +115,18 @@ export function CommandPalette({
         {!term && recentRows.length > 0 && (
           <CommandGroup heading="Recent">
             {recentRows.map((e) => {
-              const { primary, secondary } = entryLabel(e)
+              const name = siteName(e)
               const href = e.filePath
                 ? `/${e.spaceSlug}/${e.siteSlug}/${e.filePath.split('/').map(encodeURIComponent).join('/')}`
                 : `/${e.spaceSlug}/${e.siteSlug}`
               return (
                 <CommandItem
-                  key={`${e.spaceSlug}/${e.siteSlug}/${e.filePath}`}
-                  value={`recent ${e.spaceSlug}/${e.siteSlug}/${e.filePath} ${primary} ${secondary ?? ''}`}
+                  key={`${e.spaceSlug}/${e.siteSlug}`}
+                  value={`recent ${e.spaceSlug}/${e.siteSlug} ${name}`}
                   onSelect={() => run(() => navigate(href))}
                 >
                   <History />
-                  <span className="truncate">
-                    {primary}
-                    {secondary ? ` · ${secondary}` : ''}
-                  </span>
+                  <span className="truncate">{name}</span>
                 </CommandItem>
               )
             })}

--- a/packages/web/src/components/ViewerSidebar.tsx
+++ b/packages/web/src/components/ViewerSidebar.tsx
@@ -1,6 +1,6 @@
 import { X } from 'lucide-react'
 import { Link } from 'react-router'
-import { clear, entryLabel, normalizeFilePath, type RecentEntry, removeEntry, useRecents, visibleEntries } from '@/lib/recents'
+import { clear, type RecentEntry, removeEntry, siteName, useRecents, visibleEntries } from '@/lib/recents'
 import { timeAgo } from '@/lib/time'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
@@ -9,27 +9,22 @@ import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from '
 // An overlay Sheet (not a persistent panel) so it never fights the right-hand ReviewRail for
 // width, in the viewer's already-tight full-bleed layout (ViewerTopBar + canvas [+ rail]).
 //
-// Flat, most-recent-first list — one row per visited page (most Glance sites are single-page, so
-// a site→files tree was mostly noise; see `visibleEntries` for the root-row collapse and
-// `entryLabel` for the row-label rules).
+// Flat, most-recent-first list — one row per SITE, labeled by site name only (file paths are
+// deliberately never shown; the row deep-links to the page visited last, see recents.ts).
 export function ViewerSidebar({
   open,
   onOpenChange,
   userId,
   currentSpaceSlug,
   currentSiteSlug,
-  currentFilePath,
 }: {
   open: boolean
   onOpenChange: (open: boolean) => void
   userId: string | null
   currentSpaceSlug: string
   currentSiteSlug: string
-  /** The current in-iframe file (viewer.tsx's `filePath` state); null until the frame reports ready. */
-  currentFilePath: string | null
 }) {
   const entries = visibleEntries(useRecents(userId))
-  const currentPath = normalizeFilePath(currentFilePath ?? '')
 
   const close = () => onOpenChange(false)
 
@@ -39,7 +34,7 @@ export function ViewerSidebar({
         <SheetHeader className="flex-row items-center justify-between gap-2 border-b py-3 pr-10 pl-4">
           <div>
             <SheetTitle className="text-sm">Recently opened</SheetTitle>
-            <SheetDescription className="sr-only">Pages you've opened recently.</SheetDescription>
+            <SheetDescription className="sr-only">Sites you've opened recently.</SheetDescription>
           </div>
           {userId && entries.length > 0 && (
             <Button
@@ -55,20 +50,13 @@ export function ViewerSidebar({
 
         <div className="flex-1 overflow-y-auto py-2">
           {entries.length === 0 ? (
-            <p className="px-4 py-8 text-center text-muted-foreground text-sm">Pages you open will show up here.</p>
+            <p className="px-4 py-8 text-center text-muted-foreground text-sm">Sites you open will show up here.</p>
           ) : (
             entries.map((e) => (
               <Row
-                key={`${e.spaceSlug}/${e.siteSlug}/${e.filePath}`}
+                key={`${e.spaceSlug}/${e.siteSlug}`}
                 entry={e}
-                // Highlight the current PAGE's row: both sides canonicalized so a single-file
-                // site's collapsed row and an index site's root row both match. Before the frame
-                // reports ready (currentFilePath null) this degrades to the root row.
-                current={
-                  e.spaceSlug === currentSpaceSlug &&
-                  e.siteSlug === currentSiteSlug &&
-                  normalizeFilePath(e.filePath) === currentPath
-                }
+                current={e.spaceSlug === currentSpaceSlug && e.siteSlug === currentSiteSlug}
                 userId={userId}
                 onNavigate={close}
               />
@@ -95,7 +83,7 @@ function Row({
   userId: string | null
   onNavigate: () => void
 }) {
-  const { primary, secondary } = entryLabel(entry)
+  const name = siteName(entry)
   return (
     <div className="px-2 py-1">
       <div className={cn('group flex items-center gap-1 rounded-md px-2 py-1.5', current && 'bg-foreground/5')}>
@@ -103,20 +91,19 @@ function Row({
           to={entryHref(entry.spaceSlug, entry.siteSlug, entry.filePath)}
           onClick={onNavigate}
           className="min-w-0 flex-1 truncate text-sm"
-          title={`${entry.spaceSlug}/${entry.siteSlug}${entry.filePath ? `/${entry.filePath}` : ''}`}
+          title={`${entry.spaceSlug}/${entry.siteSlug}`}
         >
           <span className={cn(current ? 'font-medium text-foreground' : 'text-foreground/90 group-hover:text-foreground')}>
-            {primary}
+            {name}
           </span>
-          {secondary && <span className="ml-1.5 truncate text-muted-foreground text-xs">{secondary}</span>}
         </Link>
         <span className="shrink-0 text-[11px] text-muted-foreground">{timeAgo(entry.at)}</span>
         {userId && (
           <button
             type="button"
-            aria-label={`Remove ${primary} from recents`}
+            aria-label={`Remove ${name} from recents`}
             className="shrink-0 rounded-sm p-0.5 text-muted-foreground opacity-0 transition-opacity hover:text-destructive group-hover:opacity-100"
-            onClick={() => removeEntry(userId, { spaceSlug: entry.spaceSlug, siteSlug: entry.siteSlug, filePath: entry.filePath })}
+            onClick={() => removeEntry(userId, { spaceSlug: entry.spaceSlug, siteSlug: entry.siteSlug })}
           >
             <X className="size-3.5" />
           </button>

--- a/packages/web/src/lib/recents.test.ts
+++ b/packages/web/src/lib/recents.test.ts
@@ -3,11 +3,11 @@ import {
   applyRemoveEntry,
   applyVisit,
   clear,
-  entryLabel,
   normalizeFilePath,
   type RecentEntry,
   recordVisit,
   removeEntry,
+  siteName,
   visibleEntries,
 } from './recents'
 
@@ -52,18 +52,11 @@ describe('applyVisit', () => {
     expect(result).toEqual([entry()])
   })
 
-  test('dedupes by (spaceSlug, siteSlug, filePath), refreshing the timestamp in place', () => {
-    const older = entry({ at: '2026-01-01T00:00:00.000Z' })
-    const newer = entry({ at: '2026-01-02T00:00:00.000Z', title: 'Renamed' })
+  test('dedupes by SITE — a fresh visit replaces the old row, its filePath/title/timestamp winning', () => {
+    const older = entry({ filePath: 'docs/intro.html', at: '2026-01-01T00:00:00.000Z' })
+    const newer = entry({ filePath: 'docs/setup.html', at: '2026-01-02T00:00:00.000Z', title: 'Renamed' })
     const result = applyVisit([older], newer)
     expect(result).toEqual([newer])
-  })
-
-  test('a different filePath on the same site is a distinct entry', () => {
-    const root = entry({ filePath: '' })
-    const doc = entry({ filePath: 'docs/page.html', at: '2026-01-02T00:00:00.000Z' })
-    const result = applyVisit([root], doc)
-    expect(result).toEqual([doc, root])
   })
 
   test('most-recent-first: a repeat visit jumps back to the top', () => {
@@ -74,40 +67,31 @@ describe('applyVisit', () => {
     expect(result.map((e) => e.siteSlug)).toEqual(['a', 'b'])
   })
 
-  test('caps at 15 distinct sites, dropping the whole oldest site together', () => {
-    // 15 existing sites, most-recent-first (site-0 newest .. site-14 oldest).
+  test('same slug in a DIFFERENT space is a distinct site', () => {
+    const mine = entry({ spaceSlug: 'sam' })
+    const theirs = entry({ spaceSlug: 'ana', at: '2026-01-02T00:00:00.000Z' })
+    const result = applyVisit([mine], theirs)
+    expect(result).toEqual([theirs, mine])
+  })
+
+  test('caps at 15 sites, dropping the oldest', () => {
     const existing = Array.from({ length: 15 }, (_, i) => entry({ siteSlug: `site-${i}`, at: `2026-01-${String(30 - i).padStart(2, '0')}T00:00:00.000Z` }))
     const fresh = entry({ siteSlug: 'newcomer', at: '2026-02-01T00:00:00.000Z' })
     const result = applyVisit(existing, fresh)
     const slugs = result.map((e) => e.siteSlug)
     expect(slugs).toContain('newcomer')
-    expect(slugs).not.toContain('site-14') // the oldest site was bumped out entirely
-    expect(new Set(slugs).size).toBe(15)
+    expect(slugs).not.toContain('site-14') // the oldest site was bumped out
+    expect(slugs.length).toBe(15)
   })
 
-  test('caps at 100 total entries even within the site limit', () => {
-    const existing = Array.from({ length: 100 }, (_, i) =>
-      entry({ filePath: `file-${i}.html`, at: `2026-01-01T00:00:${String(99 - i).padStart(2, '0')}.000Z` }),
-    )
-    const fresh = entry({ filePath: 'file-100.html', at: '2026-01-01T00:01:00.000Z' })
-    const result = applyVisit(existing, fresh)
-    expect(result.length).toBe(100)
-    expect(result[0]).toEqual(fresh)
-    expect(result.some((e) => e.filePath === 'file-99.html')).toBe(false) // oldest row dropped
+  test('canonicalizes top-level index.html to "" so the root href stays /{space}/{site}', () => {
+    const result = applyVisit([], entry({ filePath: 'index.html' }))
+    expect(result).toEqual([entry({ filePath: '' })])
   })
 
-  test('canonicalizes top-level index.html to "" before dedupe, so the site-open row and the iframe-ready row for the same root page collapse into one', () => {
-    const siteOpen = entry({ filePath: '', at: '2026-01-01T00:00:00.000Z' })
-    const iframeReady = entry({ filePath: 'index.html', at: '2026-01-02T00:00:00.000Z', title: 'Renamed' })
-    const result = applyVisit([siteOpen], iframeReady)
-    expect(result).toEqual([{ ...iframeReady, filePath: '' }])
-  })
-
-  test('a NESTED index.html (docs/index.html) is not normalized — stays a distinct row', () => {
-    const root = entry({ filePath: '', at: '2026-01-01T00:00:00.000Z' })
-    const nested = entry({ filePath: 'docs/index.html', at: '2026-01-02T00:00:00.000Z' })
-    const result = applyVisit([root], nested)
-    expect(result).toEqual([nested, root])
+  test('a NESTED index.html (docs/index.html) is not normalized', () => {
+    const result = applyVisit([], entry({ filePath: 'docs/index.html' }))
+    expect(result[0].filePath).toBe('docs/index.html')
   })
 })
 
@@ -127,18 +111,10 @@ describe('normalizeFilePath', () => {
 })
 
 describe('applyRemoveEntry', () => {
-  test('filePath given (including "") removes just that one row', () => {
-    const root = entry({ filePath: '' })
-    const doc = entry({ filePath: 'docs/page.html' })
-    const result = applyRemoveEntry([root, doc], { spaceSlug: 'sam', siteSlug: 'demo', filePath: '' })
-    expect(result).toEqual([doc])
-  })
-
-  test('filePath omitted removes every row for that site', () => {
-    const root = entry({ filePath: '' })
-    const doc = entry({ filePath: 'docs/page.html' })
+  test('removes the matching site', () => {
+    const demo = entry()
     const other = entry({ siteSlug: 'other' })
-    const result = applyRemoveEntry([root, doc, other], { spaceSlug: 'sam', siteSlug: 'demo' })
+    const result = applyRemoveEntry([demo, other], { spaceSlug: 'sam', siteSlug: 'demo' })
     expect(result).toEqual([other])
   })
 
@@ -147,76 +123,44 @@ describe('applyRemoveEntry', () => {
     const result = applyRemoveEntry([a], { spaceSlug: 'sam', siteSlug: 'nope' })
     expect(result).toEqual([a])
   })
+
+  test('removes EVERY row of the site (legacy per-page lists)', () => {
+    const root = entry({ filePath: '' })
+    const doc = entry({ filePath: 'docs/page.html' })
+    const other = entry({ siteSlug: 'other' })
+    const result = applyRemoveEntry([root, doc, other], { spaceSlug: 'sam', siteSlug: 'demo' })
+    expect(result).toEqual([other])
+  })
 })
 
 describe('visibleEntries', () => {
-  test("suppresses a site's '' row when the site also has a file row (single-file deploy)", () => {
-    const file = entry({ siteSlug: 'perf-explainer', filePath: 'perf-explainer.html', at: '2026-01-02T00:00:00.000Z' })
-    const root = entry({ siteSlug: 'perf-explainer', filePath: '', at: '2026-01-01T00:00:00.000Z' })
-    expect(visibleEntries([file, root])).toEqual([file])
+  test('collapses a legacy per-page list to one row per site, most recent winning', () => {
+    const newer = entry({ filePath: 'docs/setup.html', at: '2026-01-02T00:00:00.000Z' })
+    const older = entry({ filePath: '', at: '2026-01-01T00:00:00.000Z' })
+    expect(visibleEntries([newer, older])).toEqual([newer])
   })
 
-  test("keeps the '' row when it is the site's only entry", () => {
-    const root = entry({ filePath: '' })
-    expect(visibleEntries([root])).toEqual([root])
+  test('keeps one row per distinct site, order preserved', () => {
+    const a = entry({ siteSlug: 'a', filePath: 'a.html' })
+    const aRoot = entry({ siteSlug: 'a', filePath: '' })
+    const b = entry({ siteSlug: 'b', filePath: '' })
+    expect(visibleEntries([a, aRoot, b])).toEqual([a, b])
   })
 
-  test("suppression is per-site: another site's lone '' row survives", () => {
-    const file = entry({ siteSlug: 'a', filePath: 'a.html' })
-    const rootA = entry({ siteSlug: 'a', filePath: '' })
-    const rootB = entry({ siteSlug: 'b', filePath: '' })
-    expect(visibleEntries([file, rootA, rootB])).toEqual([file, rootB])
-  })
-
-  test('preserves order and keeps every file row of a multi-file site', () => {
-    const f1 = entry({ filePath: 'docs/setup.html', at: '2026-01-03T00:00:00.000Z' })
-    const f2 = entry({ filePath: 'docs/api.html', at: '2026-01-02T00:00:00.000Z' })
-    const root = entry({ filePath: '', at: '2026-01-01T00:00:00.000Z' })
-    expect(visibleEntries([f1, f2, root])).toEqual([f1, f2])
+  test('passes an already-per-site list through unchanged', () => {
+    const a = entry({ siteSlug: 'a' })
+    const b = entry({ siteSlug: 'b' })
+    expect(visibleEntries([a, b])).toEqual([a, b])
   })
 })
 
-describe('entryLabel', () => {
-  test('root row (filePath "") shows the site title as primary, no secondary', () => {
-    const label = entryLabel(entry({ filePath: '', title: 'Design Review' }))
-    expect(label).toEqual({ primary: 'Design Review', secondary: null })
+describe('siteName', () => {
+  test('uses the site title', () => {
+    expect(siteName(entry({ title: 'Design Review' }))).toBe('Design Review')
   })
 
-  test('root row falls back to the site slug when title is null', () => {
-    const label = entryLabel(entry({ filePath: '', title: null, siteSlug: 'demo' }))
-    expect(label).toEqual({ primary: 'demo', secondary: null })
-  })
-
-  test('deep page shows the extension-stripped path as primary, site title as secondary', () => {
-    const label = entryLabel(entry({ filePath: 'docs/setup.html', title: 'Docs Site' }))
-    expect(label).toEqual({ primary: 'docs/setup', secondary: 'Docs Site' })
-  })
-
-  test('deep page falls back to the site slug as secondary when title is null', () => {
-    const label = entryLabel(entry({ filePath: 'docs/setup.html', title: null, siteSlug: 'docs-v2' }))
-    expect(label).toEqual({ primary: 'docs/setup', secondary: 'docs-v2' })
-  })
-
-  test('single-file deploy: no secondary when the site name matches the primary label', () => {
-    // `glance deploy perf-explainer.html` → slug defaults to the filename sans extension.
-    const label = entryLabel(entry({ filePath: 'perf-explainer.html', title: null, siteSlug: 'perf-explainer' }))
-    expect(label).toEqual({ primary: 'perf-explainer', secondary: null })
-  })
-
-  test('site-name-vs-primary comparison is case-insensitive', () => {
-    const label = entryLabel(entry({ filePath: 'perf-explainer.html', title: 'Perf-Explainer', siteSlug: 'x' }))
-    expect(label).toEqual({ primary: 'perf-explainer', secondary: null })
-  })
-
-  test('strips .html, .htm and .md but no other extension', () => {
-    expect(entryLabel(entry({ filePath: 'a.html' })).primary).toBe('a')
-    expect(entryLabel(entry({ filePath: 'a.htm' })).primary).toBe('a')
-    expect(entryLabel(entry({ filePath: 'a.md' })).primary).toBe('a')
-    expect(entryLabel(entry({ filePath: 'report.pdf' })).primary).toBe('report.pdf')
-  })
-
-  test('a path with no extension is shown as-is', () => {
-    expect(entryLabel(entry({ filePath: 'docs/readme' })).primary).toBe('docs/readme')
+  test('falls back to the site slug when title is null', () => {
+    expect(siteName(entry({ title: null, siteSlug: 'demo' }))).toBe('demo')
   })
 })
 
@@ -243,11 +187,10 @@ describe('recordVisit / removeEntry / clear (localStorage-backed, per-user)', ()
     expect(readStored('u3').map((e) => e.siteSlug)).toEqual(['a', 'b'])
   })
 
-  test('removeEntry(filePath) drops one row; removeEntry(no filePath) drops the whole site', () => {
+  test('a later visit to a page within the site keeps one row, deep-linking to that page', () => {
     recordVisit('u4', { spaceSlug: 'sam', siteSlug: 'demo', title: null, filePath: '' })
     recordVisit('u4', { spaceSlug: 'sam', siteSlug: 'demo', title: null, filePath: 'a.html' })
-    removeEntry('u4', { spaceSlug: 'sam', siteSlug: 'demo', filePath: 'a.html' })
-    expect(readStored('u4').map((e) => e.filePath)).toEqual([''])
+    expect(readStored('u4').map((e) => e.filePath)).toEqual(['a.html'])
     removeEntry('u4', { spaceSlug: 'sam', siteSlug: 'demo' })
     expect(readStored('u4')).toEqual([])
   })

--- a/packages/web/src/lib/recents.ts
+++ b/packages/web/src/lib/recents.ts
@@ -1,27 +1,27 @@
 import { useSyncExternalStore } from 'react'
 
-// Recently-opened sites/files, for the viewer's left sidebar (and the command palette) so a user
-// can jump back. Namespaced by user id (`glance:recents:<userId>`) — a shared machine must not
-// leak another user's history, so every call site skips recording until Me has resolved.
+// Recently-opened sites, for the viewer's left sidebar (and the command palette) so a user can
+// jump back. Namespaced by user id (`glance:recents:<userId>`) — a shared machine must not leak
+// another user's history, so every call site skips recording until Me has resolved.
 //
-// The module is split in two: PURE list logic (canonicalize/dedupe/cap/ordering/labeling —
-// unit-tested below, no DOM needed) and a thin localStorage + custom-window-event wrapper
-// mirroring `theme.ts` (untested here, browser-only; `useRecents` subscribes via
-// useSyncExternalStore, not useEffect). The sidebar/palette render a FLAT most-recent-first list —
-// one row per visited page — so there's no grouping step, just `entryLabel` per row.
+// The module is split in two: PURE list logic (canonicalize/dedupe/cap/ordering — unit-tested
+// below, no DOM needed) and a thin localStorage + custom-window-event wrapper mirroring `theme.ts`
+// (untested here, browser-only; `useRecents` subscribes via useSyncExternalStore, not useEffect).
+//
+// ONE row per SITE, labeled by site name (`siteName`), most-recent-first. `filePath` is never
+// shown — it's kept only so the row deep-links back to the page visited last within that site.
 
 export interface RecentEntry {
   spaceSlug: string
   siteSlug: string
   title: string | null
-  /** '' = the site itself (no specific file yet); non-empty = an in-site file path. */
+  /** '' = the site root; non-empty = the in-site page visited last. Never shown, href only. */
   filePath: string
   /** ISO timestamp of the visit. */
   at: string
 }
 
 const EVENT = 'glance:recents'
-const MAX_ENTRIES = 100
 const MAX_SITES = 15
 
 function storageKey(userId: string): string {
@@ -34,80 +34,38 @@ function siteKey(e: { spaceSlug: string; siteSlug: string }): string {
 
 // --- Pure logic (unit-tested; no localStorage/window) ------------------------------------------
 
-// The site-open entry (filePath '') and the iframe-ready entry for the same root page are really
-// one visit — canonicalize the exact top-level `index.html` down to '' so they dedupe into a
-// single row. A NESTED index.html (e.g. `docs/index.html`) is a distinct page and stays as-is.
+// The exact top-level `index.html` IS the site root — canonicalize it to '' so the href stays the
+// clean `/{space}/{site}` form. A NESTED index.html (e.g. `docs/index.html`) stays as-is.
 export function normalizeFilePath(filePath: string): string {
   return filePath === 'index.html' ? '' : filePath
 }
 
-// Insert/refresh `entry` most-recent-first, dedup'd by (spaceSlug, siteSlug, filePath), then cap.
+// Insert/refresh the site most-recent-first — dedup'd by (spaceSlug, siteSlug), the fresh visit's
+// filePath/title replacing the old row's — then cap to MAX_SITES.
 export function applyVisit(entries: RecentEntry[], entry: RecentEntry): RecentEntry[] {
   const normalized = { ...entry, filePath: normalizeFilePath(entry.filePath) }
-  const withoutDup = entries.filter(
-    (e) => !(e.spaceSlug === normalized.spaceSlug && e.siteSlug === normalized.siteSlug && e.filePath === normalized.filePath),
-  )
-  return capEntries([normalized, ...withoutDup])
+  const withoutDup = entries.filter((e) => siteKey(e) !== siteKey(normalized))
+  return [normalized, ...withoutDup].slice(0, MAX_SITES)
 }
 
-// `filePath` omitted → drop the whole site (every entry, site-level + files). `filePath` given
-// (including '') → drop just that one row.
-export function applyRemoveEntry(
-  entries: RecentEntry[],
-  match: { spaceSlug: string; siteSlug: string; filePath?: string },
-): RecentEntry[] {
+export function applyRemoveEntry(entries: RecentEntry[], match: { spaceSlug: string; siteSlug: string }): RecentEntry[] {
+  return entries.filter((e) => siteKey(e) !== siteKey(match))
+}
+
+// One row per site, first (= most recent) occurrence wins. `applyVisit` already keeps storage to
+// one row per site; this exists for lists persisted before that, which held one row per PAGE.
+export function visibleEntries(entries: RecentEntry[]): RecentEntry[] {
+  const seen = new Set<string>()
   return entries.filter((e) => {
-    if (e.spaceSlug !== match.spaceSlug || e.siteSlug !== match.siteSlug) return true
-    return match.filePath !== undefined && e.filePath !== match.filePath
+    const k = siteKey(e)
+    if (seen.has(k)) return false
+    seen.add(k)
+    return true
   })
 }
 
-// Caps to MAX_SITES distinct sites (a whole site's rows drop together once bumped out by newer
-// sites) then MAX_ENTRIES total rows. Robust to unsorted input: the FIRST occurrence of a site in
-// iteration order decides whether it's kept, so callers should pass most-recent-first lists.
-function capEntries(entries: RecentEntry[]): RecentEntry[] {
-  const keptSites = new Set<string>()
-  for (const e of entries) {
-    const k = siteKey(e)
-    if (keptSites.has(k) || keptSites.size < MAX_SITES) keptSites.add(k)
-  }
-  return entries.filter((e) => keptSites.has(siteKey(e))).slice(0, MAX_ENTRIES)
-}
-
-// Most sites come from `glance deploy <file.html>` — a single file kept under its OWN name (not
-// index.html) and served at the site root. Opening one records TWO entries for one document: ''
-// (site-level, from the loader) and the real filename (from the iframe 'ready'). Collapse that at
-// the VIEW level: suppress a site's '' row whenever the site also has a file row. The '' row only
-// shows when it's the site's only entry (directory listing, or an index site whose 'ready' was
-// canonicalized to '' at record time). Recording stays unchanged.
-export function visibleEntries(entries: RecentEntry[]): RecentEntry[] {
-  const sitesWithFiles = new Set(entries.filter((e) => e.filePath !== '').map(siteKey))
-  return entries.filter((e) => e.filePath !== '' || !sitesWithFiles.has(siteKey(e)))
-}
-
-const STRIPPED_EXTENSIONS = ['.html', '.htm', '.md']
-
-function stripKnownExtension(path: string): string {
-  const ext = STRIPPED_EXTENSIONS.find((e) => path.endsWith(e))
-  return ext ? path.slice(0, path.length - ext.length) : path
-}
-
-export interface EntryLabel {
-  primary: string
-  /** Muted secondary text — the site title (fallback slug), shown on a file row only when it
-   *  ADDS information, i.e. differs from the primary label (case-insensitive). A single-file
-   *  deploy's slug is the filename sans extension, so its one row stays clean; `docs/setup`
-   *  inside site `handbook` does get the secondary label. */
-  secondary: string | null
-}
-
-// Flat-list row label. The list itself needs no grouping helper: entries are already
-// most-recent-first (see `applyVisit`/`readEntries`), one row per visited page.
-export function entryLabel(entry: RecentEntry): EntryLabel {
-  const siteName = entry.title ?? entry.siteSlug
-  if (entry.filePath === '') return { primary: siteName, secondary: null }
-  const primary = stripKnownExtension(entry.filePath)
-  return { primary, secondary: siteName.toLowerCase() === primary.toLowerCase() ? null : siteName }
+export function siteName(entry: RecentEntry): string {
+  return entry.title ?? entry.siteSlug
 }
 
 // --- Browser-facing store (localStorage + custom window event) --------------------------------
@@ -155,7 +113,7 @@ export function recordVisit(userId: string, entry: Omit<RecentEntry, 'at'>): voi
   writeEntries(userId, applyVisit(readEntries(userId), { ...entry, at: new Date().toISOString() }))
 }
 
-export function removeEntry(userId: string, match: { spaceSlug: string; siteSlug: string; filePath?: string }): void {
+export function removeEntry(userId: string, match: { spaceSlug: string; siteSlug: string }): void {
   writeEntries(userId, applyRemoveEntry(readEntries(userId), match))
 }
 

--- a/packages/web/src/routes/viewer.tsx
+++ b/packages/web/src/routes/viewer.tsx
@@ -248,7 +248,6 @@ function Viewer() {
         userId={me?.id ?? null}
         currentSpaceSlug={site.spaceSlug}
         currentSiteSlug={site.siteSlug}
-        currentFilePath={filePath}
       />
 
       <div className="flex min-h-0 flex-1 flex-col md:flex-row">


### PR DESCRIPTION
Follow-up to #24. Recents dedupe by site instead of (site, file): a fresh visit replaces the site's row, and the last-visited page's filePath is kept only as the deep-link href — never displayed. Removes file-path labels, extension stripping, per-page rows and the 100-entry cap; the row X always removes the whole site.

51/51 web tests pass (recents suite rewritten for the per-site model), tsc + biome lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)