### PR TITLE
fix(review): refocus the composer textarea on every select/pinpoint

### DIFF
--- a/packages/web/src/components/review/Composer.tsx
+++ b/packages/web/src/components/review/Composer.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 
@@ -10,6 +10,7 @@ export function Composer({
   onSubmit,
   onCancel,
   autoFocus,
+  focusOn,
   className,
 }: {
   placeholder: string
@@ -17,11 +18,20 @@ export function Composer({
   onSubmit: (body: string) => void | Promise<void>
   onCancel?: () => void
   autoFocus?: boolean
+  // Refocus the textarea whenever this value changes identity. `autoFocus` only fires on mount, so
+  // a click that re-anchors an already-open composer would leave focus in the iframe — pass the
+  // pending anchor here so every select/pinpoint puts the caret back in the box.
+  focusOn?: unknown
   className?: string
 }) {
   const [body, setBody] = useState('')
   const [busy, setBusy] = useState(false)
   const trimmed = body.trim()
+
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+  useEffect(() => {
+    if (focusOn !== undefined) textareaRef.current?.focus()
+  }, [focusOn])
 
   async function submit() {
     if (!trimmed || busy) return
@@ -37,6 +47,7 @@ export function Composer({
   return (
     <div className={cn('flex flex-col gap-2', className)}>
       <textarea
+        ref={textareaRef}
         // biome-ignore lint/a11y/noAutofocus: composer is opened by an explicit user action.
         autoFocus={autoFocus}
         value={body}

--- a/packages/web/src/components/review/ReviewRail.tsx
+++ b/packages/web/src/components/review/ReviewRail.tsx
@@ -52,7 +52,7 @@ export function ReviewRail({
               <p className="line-clamp-2 border-primary/40 border-l-2 pl-2 text-muted-foreground text-xs italic">“{composing.quote}”</p>
             )}
           </div>
-          <Composer autoFocus placeholder="Add a comment…" submitLabel="Comment" onSubmit={onCreate} onCancel={onCancelComposer} />
+          <Composer autoFocus focusOn={composing} placeholder="Add a comment…" submitLabel="Comment" onSubmit={onCreate} onCancel={onCancelComposer} />
         </div>
       )}
 


### PR DESCRIPTION
## What

Follow-up to #29. Clicking an element (or selecting text) opened the composer but did not always put the caret in it — `autoFocus` only fires on mount, so re-anchoring an already-open composer left focus in the iframe and you had to click the box before typing.

## How

`Composer` takes an optional `focusOn` value and refocuses its textarea whenever the identity changes; the rail passes the pending anchor, so every select/pinpoint lands the caret in the box. Draft untouched (focus only, no remount). `ThreadCard`'s reply composer is unaffected (no `focusOn`).

![composer focused with draft preserved after re-anchor](https://github.com/plivo-labs/glance/releases/download/assets-pr-oneclick/composer-focus.png)

## Verified

- typecheck / lint / test (286 pass).
- Browser smoke (local vite recipe): first click → `document.activeElement` is the textarea; typed a draft, clicked another element → refocused, draft preserved, chip swapped; drag-selected text → refocused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)