### PR TITLE
feat(viewer): command palette + Search on the preview page

### DIFF
--- a/packages/web/src/components/ViewerTopBar.tsx
+++ b/packages/web/src/components/ViewerTopBar.tsx
@@ -1,4 +1,4 @@
-import { Check, ChevronRight, History, MessageSquare } from 'lucide-react'
+import { Check, ChevronRight, Command, History, MessageSquare } from 'lucide-react'
 import { Link } from 'react-router'
 import type { ViewerSite } from '@/lib/types'
 import { cn } from '@/lib/utils'
@@ -37,6 +37,7 @@ export function ViewerTopBar({
   onReview,
   onExit,
   onToggleSidebar,
+  onSearch,
 }: {
   site: ViewerSite
   sitePath: string
@@ -49,6 +50,7 @@ export function ViewerTopBar({
   onReview: () => void
   onExit: () => void
   onToggleSidebar: () => void
+  onSearch: () => void
 }) {
   return (
     <header className="flex h-12 shrink-0 items-center gap-3 border-b bg-background px-3">
@@ -75,6 +77,19 @@ export function ViewerTopBar({
       </nav>
 
       <div className="ml-auto flex shrink-0 items-center gap-2">
+        <Button
+          variant="outline"
+          size="sm"
+          className="gap-2 text-muted-foreground"
+          onClick={onSearch}
+          title="Search sites or run a command"
+        >
+          <Command className="size-3.5" />
+          <span className="hidden lg:inline">Search</span>
+          <kbd className="hidden rounded border bg-muted px-1.5 py-px font-mono text-[10px] text-muted-foreground lg:inline">
+            ⌘K
+          </kbd>
+        </Button>
         <Segmented value={width} options={WIDTHS} onChange={onWidth} />
         {review ? (
           <>

--- a/packages/web/src/routes/viewer.tsx
+++ b/packages/web/src/routes/viewer.tsx
@@ -10,6 +10,7 @@ import { type Intent, parseIntent } from '@/lib/parseIntent'
 import { recordVisit } from '@/lib/recents'
 import type { Me, ViewerSite } from '@/lib/types'
 import { Spinner } from '@/components/states'
+import { CommandPalette } from '@/components/CommandPalette'
 import { type CanvasWidth, ViewerTopBar } from '@/components/ViewerTopBar'
 import { ReviewRail, type ReviewMode } from '@/components/review/ReviewRail'
 import { ViewerSidebar } from '@/components/ViewerSidebar'
@@ -66,6 +67,7 @@ function Viewer() {
   const [threads, setThreads] = useState<Thread[]>([])
   const [composing, setComposing] = useState<PendingAnchor | null>(null)
   const [sidebarOpen, setSidebarOpen] = useState(false)
+  const [cmdOpen, setCmdOpen] = useState(false)
 
   // Paint anchors back into the iframe via the trusted parent→child channel — only while reviewing;
   // leaving review repaints with [] so highlights/overlays clear. Text anchors re-find their quote
@@ -185,6 +187,20 @@ function Viewer() {
   useEffect(postMode, [postMode])
   useEffect(postPending, [postPending])
 
+  // ⌘K / Ctrl-K opens the command palette here too, mirroring the AppShell dashboard chrome.
+  // (Keydown only reaches the parent when focus is outside the sandboxed iframe; the header
+  // Search button is the always-available fallback.)
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+        e.preventDefault()
+        setCmdOpen((o) => !o)
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [])
+
   // Focus an anchor in the iframe: element → scroll its selector into view; text → its quote.
   const focusAnchor = useCallback(
     (thread: Thread) => {
@@ -227,7 +243,10 @@ function Viewer() {
         onReview={() => setReview(true)}
         onExit={exitReview}
         onToggleSidebar={() => setSidebarOpen((o) => !o)}
+        onSearch={() => setCmdOpen(true)}
       />
+
+      <CommandPalette open={cmdOpen} onOpenChange={setCmdOpen} user={me} />
 
       <ViewerSidebar
         open={sidebarOpen}


### PR DESCRIPTION
## What

The preview/viewer route (`/:space/:site/*`) is full-bleed and lives outside `AppShell`, so it carried neither the `⌘K` command palette nor the header Search entry the dashboard chrome has. This wires both into the viewer.

- **`viewer.tsx`** — `cmdOpen` state + a `⌘K`/`Ctrl-K` keydown listener (the route's `useEffect` idiom), rendering the existing `CommandPalette` with the already-fetched `me`. No new component — reuses the dashboard palette as-is.
- **`ViewerTopBar`** — an `onSearch` prop + a Search button (`⌘` icon + `⌘K` kbd badge) as the first right-aligned action, styled to match the `AppShell` header.

## Screenshots

Search button in the viewer top bar (top right):

![Search button in viewer top bar](https://github.com/plivo-labs/glance/releases/download/assets-pr-preview-palette/preview-searchbtn.png)

Palette open on the preview page (via button and `⌘K`):

![Command palette open on preview page](https://github.com/plivo-labs/glance/releases/download/assets-pr-preview-palette/preview-palette-open.png)

## Verification

- `bun run typecheck` + `bun run lint` — green.
- Local browser smoke (vite :5173): Search button renders top-right; both the button click **and** the `⌘K` hotkey open the palette (Recent / Navigate / Spaces groups).

## Notes

- `⌘K` keydown only reaches the parent SPA when focus is outside the sandboxed iframe (inherent iframe behavior) — the header Search button is the always-available fallback.
- The palette's Sign-out / Spaces rows depend on `me`, which the viewer resolves async, so they're absent for the first moment after load (same as the route's existing behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)