### PR TITLE
fix(audio): native player at recording root URL + recordings default private

### DIFF
--- a/packages/api/src/routes/sites-viewer.test.ts
+++ b/packages/api/src/routes/sites-viewer.test.ts
@@ -124,6 +124,38 @@ describe('GET /api/sites/:space/:site/exists (slug-availability probe)', () => {
   })
 })
 
+describe('GET /api/sites/:space/:site — indexPath (root-file resolution)', () => {
+  test('single audio file → indexPath is that file, so the viewer plays it at the site root', async () => {
+    const { db, kv, app, env } = await setup()
+    await mintUser(db, kv, 'u1')
+    const space = await seedSpace(db, { createdBy: 'u1', slug: 'me' })
+    await seedMember(db, space, 'u1')
+    const site = await seedSite(db, { spaceId: space, ownerId: 'u1', slug: 'take' })
+    await seedFile(db, null, site, { path: 'recording.webm', text: 'b' })
+
+    const body = (await (await view(app, env, 'me', 'take', { Authorization: 'Bearer tok-u1' })).json()) as { indexPath: string }
+    expect(body.indexPath).toBe('recording.webm')
+  })
+
+  test('index.html wins over other files; a multi-file site with no index → empty', async () => {
+    const { db, kv, app, env } = await setup()
+    await mintUser(db, kv, 'u1')
+    const space = await seedSpace(db, { createdBy: 'u1', slug: 'me' })
+    await seedMember(db, space, 'u1')
+    const withIndex = await seedSite(db, { spaceId: space, ownerId: 'u1', slug: 'html' })
+    await seedFile(db, null, withIndex, { path: 'index.html', text: 'b' })
+    await seedFile(db, null, withIndex, { path: 'about.html', text: 'b' })
+    const noIndex = await seedSite(db, { spaceId: space, ownerId: 'u1', slug: 'dir' })
+    await seedFile(db, null, noIndex, { path: 'a.html', text: 'b' })
+    await seedFile(db, null, noIndex, { path: 'b.html', text: 'b' })
+
+    const idx = (await (await view(app, env, 'me', 'html', { Authorization: 'Bearer tok-u1' })).json()) as { indexPath: string }
+    const dir = (await (await view(app, env, 'me', 'dir', { Authorization: 'Bearer tok-u1' })).json()) as { indexPath: string }
+    expect(idx.indexPath).toBe('index.html')
+    expect(dir.indexPath).toBe('')
+  })
+})
+
 describe('GET /api/sites/mine — audio flag (W4-2)', () => {
   test('a pure-audio site is audio:true; a mixed site audio:false', async () => {
     const { db, kv, app, env } = await setup()

--- a/packages/api/src/routes/sites.ts
+++ b/packages/api/src/routes/sites.ts
@@ -9,7 +9,7 @@ import {
   sharedSiteIds,
 } from '../db/repo'
 import type { Visibility } from '../db/schema'
-import { sites as sitesTable, spaces, users } from '../db/schema'
+import { files as filesTable, sites as sitesTable, spaces, users } from '../db/schema'
 import { checkAccess } from '../lib/access'
 import { allAudioSiteIds } from '../lib/site-audio'
 import { readSessionOrBearer } from '../lib/session'
@@ -376,9 +376,13 @@ sites.get('/:spaceSlug/:siteSlug', async (c) => {
   // leaks — running the session read early doesn't change the not-found-before-auth ordering.
   if (!site) return c.json({ error: 'not found' }, 404)
 
-  const [isMember, isShared] = user
-    ? await Promise.all([isSpaceMember(db, site.spaceId, user.id), resolveIsShared(db, site.id, user.id)])
-    : [false, false]
+  const [isMember, isShared, siteFiles] = user
+    ? await Promise.all([
+        isSpaceMember(db, site.spaceId, user.id),
+        resolveIsShared(db, site.id, user.id),
+        db.select({ path: filesTable.path }).from(filesTable).where(eq(filesTable.siteId, site.id)),
+      ])
+    : [false, false, [] as { path: string }[]]
   const access = checkAccess(site, user, isMember, isShared)
   if (!access.ok) return c.json({ error: 'forbidden' }, access.status)
 
@@ -402,8 +406,19 @@ sites.get('/:spaceSlug/:siteSlug', async (c) => {
     status: site.status,
     isOwner: user?.id === site.ownerId,
     contentUrl,
+    indexPath: resolveIndexPath(siteFiles.map((f) => f.path)),
   })
 })
+
+// The file the root URL ('' splat) actually serves, mirroring the content worker's root
+// resolution (content.ts): an explicit index.html wins, else a lone uploaded file is served at
+// the root, else '' (a multi-file site with no index shows the directory listing). The viewer
+// reads this so a single-file audio site picks the native player at its root URL — not just at
+// the explicit `/…/recording.webm` path — and anchors comments to the same resolved path either way.
+function resolveIndexPath(paths: string[]): string {
+  if (paths.includes('index.html')) return 'index.html'
+  return paths.length === 1 ? paths[0] : ''
+}
 
 // GET /api/sites/:spaceSlug/:siteSlug/shares — owner-only: current explicit share lists.
 sites.get('/:spaceSlug/:siteSlug/shares', requireAuth, async (c) => {

--- a/packages/web/src/components/record/RecordDialog.tsx
+++ b/packages/web/src/components/record/RecordDialog.tsx
@@ -96,7 +96,9 @@ export function RecordDialog({
     try {
       const file = new File([rec.blob], fileName, { type: mime })
       const res = await uploadFiles(`/api/upload/${space}/${slug}`, [{ file, path: fileName }], {
-        visibility: 'team',
+        // Recordings start private — a voice note is personal by default; the owner opts into
+        // sharing it with a group or the whole team from the site's visibility control.
+        visibility: 'private',
         title: effectiveTitle,
       })
       toast.success('Recording saved', { description: res.url })
@@ -104,9 +106,9 @@ export function RecordDialog({
       rec.reset()
       setTitle('')
       suffixRef.current = 0
-      // Jump straight to the audio file's own URL — the site root would land in the iframe wrapper,
-      // but the deep file path resolves to the AudioView (isAudioFile). res.url has no trailing slash.
-      navigate(new URL(`${res.url}/${fileName}`).pathname)
+      // Open the recording at its canonical site URL — the viewer resolves the site's lone file
+      // (indexPath) to the AudioView at the root too, so this matches the shared/dashboard link.
+      navigate(new URL(res.url).pathname)
     } catch (err) {
       if (err instanceof UploadError && err.status === 409) {
         suffixRef.current += 1 // next Save targets `${base}-N`

--- a/packages/web/src/lib/types.ts
+++ b/packages/web/src/lib/types.ts
@@ -54,6 +54,9 @@ export interface ViewerSite {
   status: SiteStatus
   isOwner: boolean
   contentUrl: string
+  // The file the root URL serves (single-file site → that file; else 'index.html'; else '').
+  // Lets the viewer pick the audio player at a site's root, not only at its explicit file path.
+  indexPath: string
 }
 
 export interface UserLite {

--- a/packages/web/src/routes/dashboard.tsx
+++ b/packages/web/src/routes/dashboard.tsx
@@ -376,7 +376,7 @@ function InstallDialog({ open, onOpenChange }: { open: boolean; onOpenChange: (o
   const installCmd = `curl -fsSL ${origin}/api/install | sh`
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-lg">
+      <DialogContent className="sm:max-w-2xl">
         <DialogHeader>
           <DialogTitle>Install the glance CLI</DialogTitle>
           <DialogDescription>Deploy from your terminal — and use it as an agent skill.</DialogDescription>

--- a/packages/web/src/routes/dashboard.tsx
+++ b/packages/web/src/routes/dashboard.tsx
@@ -402,7 +402,7 @@ function UploadDialog({
 }) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-2xl">
+      <DialogContent className="sm:max-w-3xl">
         <DialogHeader>
           <DialogTitle>Upload files</DialogTitle>
           <DialogDescription>Pick a destination, then drop your files.</DialogDescription>

--- a/packages/web/src/routes/viewer.tsx
+++ b/packages/web/src/routes/viewer.tsx
@@ -58,11 +58,15 @@ function Viewer() {
   const lastReadyPathRef = useRef<string | null>(null)
   const contentOrigin = useMemo(() => new URL(site.contentUrl).origin, [site.contentUrl])
   const src = useMemo(() => withAnnotate(appendPath(site.contentUrl, sitePath)), [site.contentUrl, sitePath])
+  // At the site root the splat is '' but the content worker still resolves it to a concrete file
+  // (a lone upload, e.g. recording.webm) — `indexPath` is that resolved file, so audio detection,
+  // the player src, and comment anchoring all work at the root URL, not just at `/…/recording.webm`.
+  const entryPath = sitePath || site.indexPath
   // Audio has no HTML document to frame — it gets a native player instead of the sandboxed
   // iframe, and (unlike the iframe src) no ?glance_annotate param: that flag only triggers the
   // HTML-injection transform in content.ts, which never applies to audio.
-  const isAudio = useMemo(() => isAudioFile(sitePath), [sitePath])
-  const audioSrc = useMemo(() => appendPath(site.contentUrl, sitePath), [site.contentUrl, sitePath])
+  const isAudio = useMemo(() => isAudioFile(entryPath), [entryPath])
+  const audioSrc = useMemo(() => appendPath(site.contentUrl, entryPath), [site.contentUrl, entryPath])
 
   const [review, setReview] = useState(false)
   // Within review, Read = normal browsing + text-select-to-comment; Annotate = also hover/click an
@@ -75,7 +79,7 @@ function Viewer() {
   // (never fires for non-HTML) — `filePath` below is what the rest of the viewer (comments,
   // rail) actually reads; for audio there's no message to wait for, so it's the splat itself.
   const [resolvedFilePath, setResolvedFilePath] = useState<string | null>(null)
-  const filePath = isAudio ? sitePath : resolvedFilePath
+  const filePath = isAudio ? entryPath : resolvedFilePath
   const [threads, setThreads] = useState<Thread[]>([])
   const [composing, setComposing] = useState<PendingAnchor | null>(null)
   const [sidebarOpen, setSidebarOpen] = useState(false)
@@ -299,7 +303,7 @@ function Viewer() {
         <div className="relative flex min-h-0 min-w-0 flex-1 justify-center bg-muted/20">
           <div className={cn('relative h-full w-full', WIDTH_CLASS[width])}>
             {isAudio ? (
-              <AudioView src={audioSrc} fileName={sitePath.split('/').pop() ?? sitePath} audioRef={audioRef} />
+              <AudioView src={audioSrc} fileName={entryPath.split('/').pop() ?? entryPath} audioRef={audioRef} />
             ) : (
               <iframe
                 ref={iframeRef}


### PR DESCRIPTION
## What

Follow-up fixes on the merged audio feature, found during a live check.

### 1. Audio player didn't render at a recording's root URL (the bug)
`glance.plivo.com/<space>/recording-…` showed the **browser's default `<audio>`** (an iframe framing the raw `.webm`), while only the explicit `/…/recording.webm` path rendered the branded AudioView.

Root cause: the viewer keyed `isAudio` off the route splat, which is `''` at the root, so it fell back to the sandboxed iframe — and the content worker serves the lone `.webm` directly there.

Fix: the viewer loader now returns `indexPath` — the file the content worker resolves the root to (a lone upload → that file; else `index.html`; else `''`), mirroring `content.ts`. The viewer derives audio detection, player `src`, filename, and **comment anchoring** from `sitePath || indexPath`, so the root and the deep file path behave identically (and comment threads no longer split between the two URLs). The record-flow navigation now opens the canonical root URL — it was previously deep-linking to the file path purely to dodge this bug.

### 2. Recordings default to private
Was `team`. A voice note is personal by default; the owner opts into sharing with a group or the team from the site's visibility control.

### 3. Widen the "Install the glance CLI" modal
`sm:max-w-lg → sm:max-w-2xl` so the install command isn't truncated.

## Tests
- New `indexPath` resolution tests (single audio file → that file; `index.html` wins; multi-file no-index → `''`).
- Full gate green: web 71/71, api 354/354, both typechecks clean, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)