### PR TITLE
Editor-share: let a named person redeploy a site's content

### DIFF
--- a/glance-cli/SKILL.md
+++ b/glance-cli/SKILL.md
@@ -134,7 +134,17 @@ glance deploy ./api-reference                            # redeploys to the SAME
 - A later `glance deploy <dir>` reads that marker to target the same site automatically (no need to re-type `--space`/`--name`) and passes the pulled version so a stale redeploy is safely refused instead of clobbering someone else's newer change.
 - Needs edit rights: `--pull` works for a site you **own** or have been given **edit** access to. A view-only share can't pull the source.
 
-**Editor round-trip** — if someone shared a site with you as an *editor*, this is the whole loop with no browser and no git: `glance read <their-space>/<site> --pull ./site` → edit `./site` → `glance deploy ./site`. You can update that site's content even though you don't own it and aren't in its space.
+**Editor round-trip** — if someone shared a site with you as an *editor*, this is the whole loop with no browser and no git:
+
+```
+glance read alice/roadmap --pull ./roadmap   # pull the source (records version, e.g. 7)
+# …add or remove content sections in ./roadmap…
+glance deploy ./roadmap                       # redeploys to the same site, sends the pulled version
+```
+
+You can update that site's content even though you don't own it and aren't in its space. If someone else redeployed since your pull, the deploy is refused as stale (409) — re-run the `--pull` to get the current version, reapply your change, and deploy again.
+
+**Editing etiquette — content, not chrome.** As an editor you own the *content*, not the site's look. Add or remove sections, update copy, correct data — but keep the owner's styling and layout intact: don't restyle, re-theme, change the CSS/structure, or re-lay-out the page. The owner set the design; an editor fills it in. (Renaming, moving, deleting, changing visibility, or editing the title aren't yours to do at all — those stay with the owner.)
 
 ## Visibility values
 `team` (default) · `private` · `members`.

--- a/glance-cli/SKILL.md
+++ b/glance-cli/SKILL.md
@@ -36,7 +36,7 @@ Put it in your shell profile to make it permanent. Token + URL are saved to `~/.
 | `glance move <space/slug> <new-space>` | moves a site to another space you belong to (keeps its files, comments, shares) |
 | `glance comments <space/slug> [--file <path>] [--open] [--json]` | prints a site's review comments as a markdown digest (or raw JSON) |
 | `glance reply <space/slug> <threadId> [message] [--tag <label>\|--no-tag]` | posts a reply to a comment thread (get the `threadId` from `glance comments`) |
-| `glance read <space/slug> [--file <path>]` | prints a deployed file's raw contents to stdout (HTML as stored) |
+| `glance read <space/slug> [--file <path>] [--pull <dir>]` | prints a file to stdout, or `--pull` downloads the whole site's source into a folder to edit + redeploy |
 | `glance logout` | revokes the server session and removes the local token |
 
 ### login
@@ -114,12 +114,27 @@ glance reply docs/api-reference k3f9q2 "typo fixed" --no-tag
 ```
 
 ### read
-Prints a deployed file's **raw contents** to stdout — the bytes as stored (HTML stays HTML; markdown stays markdown source, NOT the server-rendered HTML).
+Prints a deployed file's contents to stdout.
 
 - `<space/slug>` is required and must contain the slash (e.g. `docs/api-reference`).
 - `--file <path>` selects a file within the site (e.g. `--file guide.html`); omit it for the site root (a single-file site serves its lone file there).
 - Output is the file body only — no headers, no trailing newline — so it pipes cleanly: `glance read docs/api-reference --file index.html > index.html`.
+- **A single `read` of a `.md` file returns the server-RENDERED HTML, not the markdown source.** To get the exact source back (for editing and redeploying), use `--pull` below.
 - Every tier is access-gated (there is no anonymous tier), so `read` works only on sites you can view; a tier you can't access fails with the server's status. Errors print the HTTP status + a truncated server message.
+
+**`--pull <dir>`** — download the whole site's **source** into a local folder so you can edit it and redeploy:
+
+```
+glance read docs/api-reference --pull ./api-reference   # writes every file (source, not rendered) into ./api-reference
+# …edit the files…
+glance deploy ./api-reference                            # redeploys to the SAME site (remembers where it came from)
+```
+
+- Writes every file of the site — markdown as its true source, dotfiles included — into `<dir>`, plus a small `.glance/pull.json` marker that records the site and the version you pulled.
+- A later `glance deploy <dir>` reads that marker to target the same site automatically (no need to re-type `--space`/`--name`) and passes the pulled version so a stale redeploy is safely refused instead of clobbering someone else's newer change.
+- Needs edit rights: `--pull` works for a site you **own** or have been given **edit** access to. A view-only share can't pull the source.
+
+**Editor round-trip** — if someone shared a site with you as an *editor*, this is the whole loop with no browser and no git: `glance read <their-space>/<site> --pull ./site` → edit `./site` → `glance deploy ./site`. You can update that site's content even though you don't own it and aren't in its space.
 
 ## Visibility values
 `team` (default) · `private` · `members`.

--- a/packages/api/drizzle/0009_editor_share.sql
+++ b/packages/api/drizzle/0009_editor_share.sql
@@ -1,0 +1,10 @@
+-- editor-share: a named user may content-replace-redeploy a site (not the whole team).
+-- Three plain ADD COLUMNs (no table rebuild; text/integer, no CHECK):
+--   site_user_shares.role  — 'viewer' (default, = today's read-only share) | 'editor'. Every
+--     existing share row backfills to 'viewer', so behavior is unchanged until a role is set.
+--   sites.contentVersion   — monotonic revision counter (default 0), bumped on REPLACE. Editor
+--     replaces CAS on it (UPDATE … WHERE contentVersion=?) → 409 on a stale redeploy.
+--   sites.lastReplacedBy   — nullable provenance: who last swapped the bytes.
+ALTER TABLE `site_user_shares` ADD `role` text DEFAULT 'viewer' NOT NULL;--> statement-breakpoint
+ALTER TABLE `sites` ADD `contentVersion` integer DEFAULT 0 NOT NULL;--> statement-breakpoint
+ALTER TABLE `sites` ADD `lastReplacedBy` text;

--- a/packages/api/drizzle/meta/_journal.json
+++ b/packages/api/drizzle/meta/_journal.json
@@ -57,6 +57,20 @@
       "when": 1783100000000,
       "tag": "0007_add_indexes",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "6",
+      "when": 1783200000000,
+      "tag": "0008_comment_audio_key",
+      "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "6",
+      "when": 1783300000000,
+      "tag": "0009_editor_share",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/src/content-raw.test.ts
+++ b/packages/api/src/content-raw.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from 'bun:test'
+import { Hono } from 'hono'
+import contentApp from './content'
+import { signToken } from './lib/token'
+import { makeDb, makeR2, seedFile, seedSite, seedSpace, seedUser } from './test/harness'
+
+// Phase 3 / S12 — raw source mode. `glance read --pull` needs the .md SOURCE to round-trip a site,
+// but a bare GET of a .md renders it to HTML. On the gated path, ?raw=1 streams the stored bytes
+// verbatim (no markdown render, no annotate injection).
+
+const secret = 'ct-secret'
+const MD = '# about\n\nsome *source* text\n'
+
+function setup() {
+  const db = makeDb()
+  const r2 = makeR2()
+  const app = new Hono()
+  app.use('*', async (c, next) => {
+    c.set('db', db)
+    await next()
+  })
+  app.route('/', contentApp)
+  return { app, db, r2, env: { APP_URL: 'https://glance.example.com', CONTENT_TOKEN_SECRET: secret, GLANCE_FILES: r2 } }
+}
+
+async function gatedMd(db: ReturnType<typeof makeDb>, r2: ReturnType<typeof makeR2>) {
+  const uid = await seedUser(db, { id: 'u1' })
+  const sp = await seedSpace(db, { createdBy: uid, slug: 'sam' })
+  const siteId = await seedSite(db, { spaceId: sp, ownerId: uid, slug: 'site', visibility: 'team' })
+  await seedFile(db, r2, siteId, { path: 'about.md', text: MD, mimeType: 'text/markdown' })
+  const token = await signToken(secret, uid, 'sam/site', 300)
+  return token
+}
+
+describe('content ?raw=1 — raw markdown source', () => {
+  test('content.raw.md.source: GET .md?raw=1 streams the raw bytes, not rendered HTML', async () => {
+    const { app, db, r2, env } = setup()
+    const token = await gatedMd(db, r2)
+    const res = await app.request(`/_t/${token}/sam/site/about.md?raw=1`, {}, env)
+    expect(res.status).toBe(200)
+    const body = await res.text()
+    expect(body).toBe(MD)
+    expect(body).not.toContain('<h1>')
+  })
+
+  test('content.md.rendered.pin: GET .md WITHOUT raw still renders to HTML (unchanged)', async () => {
+    const { app, db, r2, env } = setup()
+    const token = await gatedMd(db, r2)
+    const res = await app.request(`/_t/${token}/sam/site/about.md`, {}, env)
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toContain('text/html')
+    const body = await res.text()
+    expect(body).toContain('<h1>about</h1>')
+  })
+})

--- a/packages/api/src/content.ts
+++ b/packages/api/src/content.ts
@@ -126,6 +126,21 @@ async function serve(c: Ctx, spaceSlug: string, siteSlug: string, rest: string, 
   const object = await c.env.GLANCE_FILES.get(file.storageKey)
   if (!object) return notFound(c)
 
+  // Raw source mode (`glance read --pull`): stream the stored bytes verbatim — NO markdown render, NO
+  // annotate injection, NOT counted as a view. The pull needs the exact `.md` source (the default
+  // path renders it to HTML) so a pull → deploy round-trip is byte-identical. Already token-gated
+  // above; served as text/plain + nosniff so a browser can't be tricked into executing pulled bytes.
+  if (c.req.query('raw') === '1') {
+    return new Response(object.body, {
+      status: 200,
+      headers: {
+        'content-type': 'text/plain; charset=utf-8',
+        'x-content-type-options': 'nosniff',
+        'cache-control': 'no-store',
+      },
+    })
+  }
+
   // Usage analytics: count this as a viewer hit only for actual page loads (HTML + rendered
   // markdown), not every CSS/JS/image sub-resource — otherwise one navigation inflates to many.
   // userId is guaranteed non-null here (anonymous requests 403'd above), so every view is

--- a/packages/api/src/db/repo.ts
+++ b/packages/api/src/db/repo.ts
@@ -151,6 +151,25 @@ export async function resolveIsShared(db: DrizzleD1Database, siteId: string, use
   return direct.length > 0 || viaGroup.length > 0
 }
 
+/**
+ * The user's DIRECT-share role on a site, or null if they have no direct share.
+ * Only direct `site_user_shares` rows carry a role — a group share (`site_group_shares`) is never
+ * an editor grant, so a group-only reacher resolves to null even though `resolveIsShared` is true.
+ * This is the edit-capability oracle: 'editor' → may content-replace; 'viewer'/null → may not.
+ */
+export async function resolveShareRole(
+  db: DrizzleD1Database,
+  siteId: string,
+  userId: string,
+): Promise<'viewer' | 'editor' | null> {
+  const row = await db
+    .select({ role: siteUserShares.role })
+    .from(siteUserShares)
+    .where(and(eq(siteUserShares.siteId, siteId), eq(siteUserShares.userId, userId)))
+    .limit(1)
+  return row[0]?.role ?? null
+}
+
 /** Set of space ids the user is a member of (mirrors `sharedSiteIds` for the search candidate query). */
 export async function memberSpaceIds(db: DrizzleD1Database, userId: string): Promise<Set<string>> {
   const rows = await db
@@ -173,30 +192,44 @@ export async function sharedSiteIds(db: DrizzleD1Database, userId: string): Prom
   return new Set([...direct, ...viaGroup].map((r) => r.siteId))
 }
 
-/** Current explicit share lists for a site. */
+/** A per-user share as stored: the user id plus their grant tier. */
+export type ShareUser = { userId: string; role: 'viewer' | 'editor' }
+
+/**
+ * Current explicit share lists for a site. Returns BOTH the role-aware `users` list (new callers)
+ * and the flat `userIds`/`groupIds` (the legacy shape the live web dialog still reads) — a superset,
+ * so no existing consumer breaks. Groups are always view-only (no role column on site_group_shares).
+ */
 export async function listSiteShares(
   db: DrizzleD1Database,
   siteId: string,
-): Promise<{ userIds: string[]; groupIds: string[] }> {
-  const u = await db.select({ id: siteUserShares.userId }).from(siteUserShares).where(eq(siteUserShares.siteId, siteId))
+): Promise<{ userIds: string[]; groupIds: string[]; users: ShareUser[] }> {
+  const u = await db
+    .select({ id: siteUserShares.userId, role: siteUserShares.role })
+    .from(siteUserShares)
+    .where(eq(siteUserShares.siteId, siteId))
   const g = await db
     .select({ id: siteGroupShares.spaceId })
     .from(siteGroupShares)
     .where(eq(siteGroupShares.siteId, siteId))
-  return { userIds: u.map((r) => r.id), groupIds: g.map((r) => r.id) }
+  return {
+    userIds: u.map((r) => r.id),
+    groupIds: g.map((r) => r.id),
+    users: u.map((r) => ({ userId: r.id, role: r.role })),
+  }
 }
 
-/** Replace a site's entire share set atomically (clear both tables, then re-insert). */
+/** Replace a site's entire share set atomically (clear both tables, then re-insert with roles). */
 export async function replaceSiteShares(
   db: DrizzleD1Database,
   siteId: string,
-  userIds: string[],
+  users: ShareUser[],
   groupIds: string[],
 ): Promise<void> {
   const ops = [
     db.delete(siteUserShares).where(eq(siteUserShares.siteId, siteId)),
     db.delete(siteGroupShares).where(eq(siteGroupShares.siteId, siteId)),
-    ...userIds.map((userId) => db.insert(siteUserShares).values({ siteId, userId })),
+    ...users.map(({ userId, role }) => db.insert(siteUserShares).values({ siteId, userId, role })),
     ...groupIds.map((spaceId) => db.insert(siteGroupShares).values({ siteId, spaceId })),
   ]
   // D1 runs the batch in a single atomic transaction.

--- a/packages/api/src/db/schema.ts
+++ b/packages/api/src/db/schema.ts
@@ -42,6 +42,12 @@ export const sites = sqliteTable(
       .default('team'),
     status: text('status', { enum: ['active', 'archived'] }).notNull().default('active'),
     ownerId: text('ownerId').notNull().references(() => users.id, { onDelete: 'cascade' }),
+    // Monotonic content-revision counter, bumped on every REPLACE. Editor replaces MUST pass the
+    // version they pulled (CAS: UPDATE … WHERE contentVersion=?) so a stale redeploy 409s instead
+    // of clobbering a newer one; owner replaces treat it as advisory. lastReplacedBy records who
+    // last swapped the bytes (owner id or an editor's user id) — read-only provenance today.
+    contentVersion: integer('contentVersion').notNull().default(0),
+    lastReplacedBy: text('lastReplacedBy'),
     createdAt: text('createdAt').notNull().$defaultFn(() => new Date().toISOString()),
   },
   (t) => [unique('sites_space_slug_unq').on(t.spaceId, t.slug), index('sites_owner').on(t.ownerId)],
@@ -76,6 +82,10 @@ export const siteUserShares = sqliteTable(
   {
     siteId: text('siteId').notNull().references(() => sites.id, { onDelete: 'cascade' }),
     userId: text('userId').notNull().references(() => users.id, { onDelete: 'cascade' }),
+    // Grant tier for THIS user on THIS site. 'viewer' = read-only (the long-standing share
+    // semantics, hence the default). 'editor' = may content-replace-redeploy (never rename/move/
+    // delete/visibility). Group shares stay view-only — there is no editor row on siteGroupShares.
+    role: text('role', { enum: ['viewer', 'editor'] }).notNull().default('viewer'),
   },
   (t) => [primaryKey({ columns: [t.siteId, t.userId] }), index('site_user_shares_user').on(t.userId)],
 )

--- a/packages/api/src/db/shares.test.ts
+++ b/packages/api/src/db/shares.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  makeDb,
+  seedGroupShare,
+  seedMember,
+  seedSite,
+  seedSpace,
+  seedUser,
+  seedUserShare,
+} from '../test/harness'
+import { resolveShareRole } from './repo'
+
+// resolveShareRole is the direct-share role reader that gates editor replace, /exists, and manifest.
+// It reads ONLY the direct siteUserShares.role — a group share is never an editor grant, and a user
+// with no direct share resolves to null (they might still READ via a group/tier, but they can't edit).
+describe('resolveShareRole — direct-share editor capability', () => {
+  async function fixture() {
+    const db = makeDb()
+    await seedUser(db, { id: 'owner', email: 'owner@example.com' })
+    await seedUser(db, { id: 'ed', email: 'ed@example.com' })
+    await seedUser(db, { id: 'vw', email: 'vw@example.com' })
+    await seedUser(db, { id: 'grp', email: 'grp@example.com' })
+    await seedUser(db, { id: 'stranger', email: 'stranger@example.com' })
+    const sp = await seedSpace(db, { id: 'sp', slug: 'acme', createdBy: 'owner' })
+    const other = await seedSpace(db, { id: 'other', slug: 'other', createdBy: 'grp' })
+    await seedMember(db, other, 'grp')
+    const site = await seedSite(db, { id: 'site', spaceId: sp, ownerId: 'owner' })
+    await seedUserShare(db, site, 'ed', 'editor')
+    await seedUserShare(db, site, 'vw', 'viewer')
+    await seedGroupShare(db, site, other) // grp reaches the site via a group share only
+    return { db, site }
+  }
+
+  test('direct editor share resolves to "editor"', async () => {
+    const { db, site } = await fixture()
+    expect(await resolveShareRole(db, site, 'ed')).toBe('editor')
+  })
+
+  test('direct viewer share resolves to "viewer"', async () => {
+    const { db, site } = await fixture()
+    expect(await resolveShareRole(db, site, 'vw')).toBe('viewer')
+  })
+
+  test('a group-only share is never an editor grant → null', async () => {
+    const { db, site } = await fixture()
+    expect(await resolveShareRole(db, site, 'grp')).toBeNull()
+  })
+
+  test('no share at all → null', async () => {
+    const { db, site } = await fixture()
+    expect(await resolveShareRole(db, site, 'stranger')).toBeNull()
+  })
+})

--- a/packages/api/src/lib/access.ts
+++ b/packages/api/src/lib/access.ts
@@ -43,3 +43,18 @@ export function checkAccess(
       return { ok: false, status: 403 }
   }
 }
+
+/**
+ * Whether a user may CONTENT-REPLACE (redeploy) a site — a strictly narrower capability than
+ * `checkAccess` (which is read/view). Owner or superadmin always; a direct EDITOR share otherwise
+ * (a plain viewer / group share / tier-only reacher may NOT). `shareRole` is the caller's DIRECT
+ * share role (`resolveShareRole`), null when they have none. Single source of truth for the upload
+ * gate, `/exists` canReplace, and the meta-route manifest gate — do NOT re-inline the predicate.
+ */
+export function canReplace(
+  user: Pick<SessionUser, 'id' | 'role'>,
+  site: Pick<Site, 'ownerId'>,
+  shareRole: 'viewer' | 'editor' | null,
+): boolean {
+  return user.role === 'superadmin' || site.ownerId === user.id || shareRole === 'editor'
+}

--- a/packages/api/src/lib/site-access.ts
+++ b/packages/api/src/lib/site-access.ts
@@ -18,6 +18,7 @@ export type ResolvedSite = {
   visibility: Visibility
   status: 'active' | 'archived'
   ownerId: string
+  contentVersion: number
   createdAt: string
 }
 
@@ -36,6 +37,7 @@ export async function resolveSite(
       visibility: sitesTable.visibility,
       status: sitesTable.status,
       ownerId: sitesTable.ownerId,
+      contentVersion: sitesTable.contentVersion,
       createdAt: sitesTable.createdAt,
     })
     .from(sitesTable)

--- a/packages/api/src/routes/data.test.ts
+++ b/packages/api/src/routes/data.test.ts
@@ -116,6 +116,15 @@ describe('P0-4/P0-3: modify authority is distinct from view authority', () => {
     expect(dataCapsFor({ id: 'userB', role: 'member' }, { ownerId: 'userA' })).toEqual(['read', 'create'])
   })
 
+  // editor-share residual-risk pin (confused-deputy, S9): dataCapsFor keys on ownerId ONLY, so a
+  // designated editor of someone else's site is indistinguishable from any other non-owner viewer —
+  // it can never mint write/read_all. This is the guard: if a future change threads share-role into
+  // cap minting, an editor could read-all/delete the OWNER's glance.db docs. Owner path unchanged.
+  test('dataCaps.editor.pin: an editor-share grantee still gets read+create only; owner unchanged', () => {
+    expect(dataCapsFor({ id: 'editor', role: 'member' }, { ownerId: 'owner' })).toEqual(['read', 'create'])
+    expect(dataCapsFor({ id: 'owner', role: 'member' }, { ownerId: 'owner' })).toEqual(['read', 'create', 'write', 'read_all'])
+  })
+
   test('ATTACK: a viewer token cannot modify — put/delete → 403; legacy read-only also blocked from create', async () => {
     const { app, tokens } = await scenario()
     expect((await req(app, tokens.viewerB, 'PUT', '/posts/x', { x: 1 })).status).toBe(403)

--- a/packages/api/src/routes/data.ts
+++ b/packages/api/src/routes/data.ts
@@ -321,6 +321,15 @@ function toDoc(row: DocumentRow) {
 // READ_ALL (see + moderate every row). "Can view" still never implies "can modify": a viewer
 // cannot touch any existing document, not even their own. Pure + exported so the invariant is
 // unit-tested directly, independent of the request/session plumbing.
+//
+// SECURITY — editor-share confused-deputy (ACCEPTED residual risk, S9): caps key ONLY on ownerId,
+// so a content EDITOR of this site is indistinguishable from any other non-owner and gets read+create
+// only — they never mint write/read_all. This is deliberate: an editor can plant JS in the site, and
+// when the OWNER opens it that script would run with the owner's caps. Do NOT thread the editor's
+// share-role in here to "grant" them write — that would hand every editor read_all/delete over the
+// owner's glance.db docs. Signed off as accepted (editor = semi-trusted, git-collaborator model);
+// if that changes, gate on sites.lastReplacedBy (downgrade to viewer until the owner re-deploys).
+// `dataCaps.editor.pin` in data.test.ts locks this.
 export function dataCapsFor(user: Pick<SessionUser, 'id' | 'role'>, site: Pick<Site, 'ownerId'>): DataCapability[] {
   return user.role === 'superadmin' || site.ownerId === user.id
     ? ['read', 'create', 'write', 'read_all']

--- a/packages/api/src/routes/sites-manifest.test.ts
+++ b/packages/api/src/routes/sites-manifest.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from 'bun:test'
+import { Hono } from 'hono'
+import { requireSameOrigin } from '../middleware/auth'
+import { makeDb, makeKv, makeR2, seedFile, seedMember, seedSite, seedSpace, seedUser, seedUserShare } from '../test/harness'
+import type { AppEnv } from '../types'
+import { sites } from './sites'
+
+// Phase 3 — read-side endpoints. The site meta route exposes the file MANIFEST + contentVersion +
+// canReplace ONLY to owner/editor/superadmin (a plain viewer sees none of it); /exists recognizes a
+// non-member editor as authorized-with-canReplace so the CLI takes the REPLACE path, not CREATE.
+
+const APP_URL = 'https://glance.example.com'
+
+async function setup() {
+  const db = makeDb()
+  const kv = makeKv()
+  const r2 = makeR2()
+  const env = { APP_URL, SESSION_SECRET: 's', CONTENT_URL: 'https://content.example.com', CONTENT_TOKEN_SECRET: 'ct', GLANCE_SESSIONS: kv, GLANCE_FILES: r2 } as unknown as AppEnv['Bindings']
+  const app = new Hono<AppEnv>()
+  app.use('/api/*', requireSameOrigin)
+  app.use('/api/*', async (c, next) => {
+    c.set('db', db)
+    await next()
+  })
+  app.route('/api/sites', sites)
+
+  await seedUser(db, { id: 'owner', email: 'owner@e.com' })
+  await seedSpace(db, { id: 'acme', slug: 'acme', createdBy: 'owner' })
+  await seedMember(db, 'acme', 'owner')
+  const site = await seedSite(db, { id: 'site', spaceId: 'acme', ownerId: 'owner', slug: 'doc', visibility: 'team' })
+  await seedFile(db, r2, site, { path: 'index.html', text: '<h1>hi</h1>' })
+  await seedFile(db, r2, site, { path: 'about.md', text: '# about' })
+  for (const [id, role] of [['ed', 'editor'], ['vw', 'viewer']] as const) {
+    await seedUser(db, { id, email: `${id}@e.com` })
+    await seedUserShare(db, site, id, role) // ed/vw are NOT space members
+  }
+  await seedUser(db, { id: 'mem', email: 'mem@e.com' })
+  await seedMember(db, 'acme', 'mem') // plain member: read via team tier, no share
+  await seedUser(db, { id: 'st', email: 'st@e.com' })
+  for (const id of ['owner', 'ed', 'vw', 'mem', 'st'])
+    await kv.put(`cli:tok-${id}`, JSON.stringify({ id, email: `${id}@e.com`, name: null, role: 'member' }))
+  return { db, app, env }
+}
+
+const auth = (id: string) => ({ Authorization: `Bearer tok-${id}`, Origin: APP_URL })
+const exists = (app: Hono<AppEnv>, env: AppEnv['Bindings'], id: string) =>
+  app.request('/api/sites/acme/doc/exists', { headers: auth(id) }, env).then((r) => r.json())
+const meta = (app: Hono<AppEnv>, env: AppEnv['Bindings'], id: string) =>
+  app.request('/api/sites/acme/doc', { headers: auth(id) }, env).then((r) => r.json())
+
+describe('GET /exists — editor recognition + canReplace', () => {
+  test('exists.nonmember.editor.true: a non-member editor gets exists:true, canReplace:true', async () => {
+    const { app, env } = await setup()
+    expect(await exists(app, env, 'ed')).toMatchObject({ exists: true, canReplace: true, contentVersion: 0 })
+  })
+  test('owner canReplace:true; a plain member canReplace:false; a stranger exists:false (unchanged)', async () => {
+    const { app, env } = await setup()
+    expect(await exists(app, env, 'owner')).toMatchObject({ exists: true, canReplace: true })
+    expect(await exists(app, env, 'mem')).toMatchObject({ exists: true, canReplace: false })
+    expect(await exists(app, env, 'st')).toMatchObject({ exists: false })
+  })
+})
+
+describe('GET meta — gated manifest', () => {
+  test('manifest.owner.includesFiles: owner meta returns files[] + contentVersion + canReplace:true', async () => {
+    const { app, env } = await setup()
+    const body = (await meta(app, env, 'owner')) as { files?: string[]; contentVersion?: number; canReplace?: boolean }
+    expect(body.canReplace).toBe(true)
+    expect(body.contentVersion).toBe(0)
+    expect(body.files?.sort()).toEqual(['about.md', 'index.html'])
+  })
+  test('manifest.editor.includesFiles: a non-member editor also sees the manifest', async () => {
+    const { app, env } = await setup()
+    const body = (await meta(app, env, 'ed')) as { files?: string[]; canReplace?: boolean; role?: string }
+    expect(body.canReplace).toBe(true)
+    expect(body.role).toBe('editor')
+    expect(body.files?.sort()).toEqual(['about.md', 'index.html'])
+  })
+  test('manifest.viewer.excludesFiles: a plain member gets NO files[] and canReplace:false', async () => {
+    const { app, env } = await setup()
+    const body = (await meta(app, env, 'mem')) as { files?: string[]; canReplace?: boolean }
+    expect(body.canReplace).toBe(false)
+    expect(body.files).toBeUndefined()
+  })
+})

--- a/packages/api/src/routes/sites-shared.test.ts
+++ b/packages/api/src/routes/sites-shared.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from 'bun:test'
+import { Hono } from 'hono'
+import { requireSameOrigin } from '../middleware/auth'
+import { makeDb, makeKv, seedMember, seedSite, seedSpace, seedUser, seedUserShare } from '../test/harness'
+import type { AppEnv } from '../types'
+import { sites } from './sites'
+
+// Phase 5 / S17 — GET /api/sites/shared carries the viewer's direct-share role so the dashboard can
+// badge "You can edit". A group-only reacher (no direct row) is a plain viewer.
+
+const APP_URL = 'https://glance.example.com'
+
+async function setup() {
+  const db = makeDb()
+  const kv = makeKv()
+  const env = { APP_URL, SESSION_SECRET: 's', GLANCE_SESSIONS: kv } as unknown as AppEnv['Bindings']
+  const app = new Hono<AppEnv>()
+  app.use('/api/*', requireSameOrigin)
+  app.use('/api/*', async (c, next) => {
+    c.set('db', db)
+    await next()
+  })
+  app.route('/api/sites', sites)
+  await seedUser(db, { id: 'owner', email: 'owner@e.com' })
+  await seedSpace(db, { id: 'acme', slug: 'acme', createdBy: 'owner' })
+  await seedMember(db, 'acme', 'owner')
+  const site = await seedSite(db, { id: 'site', spaceId: 'acme', ownerId: 'owner', slug: 'doc', visibility: 'private' })
+  for (const [id, role] of [['ed', 'editor'], ['vw', 'viewer']] as const) {
+    await seedUser(db, { id, email: `${id}@e.com` })
+    await seedUserShare(db, site, id, role)
+    await kv.put(`cli:tok-${id}`, JSON.stringify({ id, email: `${id}@e.com`, name: null, role: 'member' }))
+  }
+  return { app, env }
+}
+
+const shared = (app: Hono<AppEnv>, env: AppEnv['Bindings'], id: string) =>
+  app.request('/api/sites/shared', { headers: { Authorization: `Bearer tok-${id}`, Origin: APP_URL } }, env).then((r) => r.json())
+
+describe('GET /api/sites/shared — carries the viewer role', () => {
+  test('shared.response.role: an editor-shared row reports role editor; a viewer-shared row role viewer', async () => {
+    const { app, env } = await setup()
+    const edRows = (await shared(app, env, 'ed')) as { siteSlug: string; role: string }[]
+    expect(edRows).toHaveLength(1)
+    expect(edRows[0]).toMatchObject({ siteSlug: 'doc', role: 'editor' })
+
+    const vwRows = (await shared(app, env, 'vw')) as { siteSlug: string; role: string }[]
+    expect(vwRows[0]).toMatchObject({ siteSlug: 'doc', role: 'viewer' })
+  })
+})

--- a/packages/api/src/routes/sites-shares.test.ts
+++ b/packages/api/src/routes/sites-shares.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from 'bun:test'
+import { Hono } from 'hono'
+import { resolveShareRole } from '../db/repo'
+import { requireSameOrigin } from '../middleware/auth'
+import { makeDb, makeKv, seedSite, seedSpace, seedUser } from '../test/harness'
+import type { AppEnv } from '../types'
+import { parseShareGrants, sites } from './sites'
+
+// PUT/GET /shares is role-aware AND backward-compatible: the live web dialog still PUTs legacy
+// `userIds[]` (→ viewer) while the new dialog PUTs `users:[{id,role}]`. Groups stay view-only —
+// there is no editor row on site_group_shares, so an editor grant on a group is a 400.
+
+const APP_URL = 'https://glance.example.com'
+
+async function setup() {
+  const db = makeDb()
+  const kv = makeKv()
+  const env = { APP_URL, SESSION_SECRET: 's', GLANCE_SESSIONS: kv } as unknown as AppEnv['Bindings']
+  const app = new Hono<AppEnv>()
+  app.use('/api/*', requireSameOrigin)
+  app.use('/api/*', async (c, next) => {
+    c.set('db', db)
+    await next()
+  })
+  app.route('/api/sites', sites)
+  await seedUser(db, { id: 'owner', role: 'member' })
+  await kv.put('cli:tok-owner', JSON.stringify({ id: 'owner', email: 'owner@example.com', name: null, role: 'member' }))
+  await seedUser(db, { id: 'ed', email: 'ed@example.com' })
+  await seedUser(db, { id: 'vw', email: 'vw@example.com' })
+  await seedSpace(db, { id: 'sp', slug: 'mine', createdBy: 'owner' })
+  const grp = await seedSpace(db, { id: 'grp', slug: 'grp', createdBy: 'owner', type: 'group' })
+  const site = await seedSite(db, { id: 'site', spaceId: 'sp', ownerId: 'owner', slug: 'doc' })
+  return { db, app, env, site, grp }
+}
+
+const auth = { Authorization: 'Bearer tok-owner', Origin: APP_URL, 'Content-Type': 'application/json' }
+const put = (app: Hono<AppEnv>, env: AppEnv['Bindings'], body: unknown) =>
+  app.request('/api/sites/mine/doc/shares', { method: 'PUT', headers: auth, body: JSON.stringify(body) }, env)
+const get = (app: Hono<AppEnv>, env: AppEnv['Bindings']) =>
+  app.request('/api/sites/mine/doc/shares', { headers: auth }, env)
+
+describe('parseShareGrants — pure body normalization', () => {
+  test('new users:[{id,role}] shape carries roles; groups view-only', () => {
+    expect(parseShareGrants({ users: [{ id: 'a', role: 'editor' }, { id: 'b' }], groupIds: ['g'] })).toEqual({
+      users: [{ userId: 'a', role: 'editor' }, { userId: 'b', role: 'viewer' }],
+      groupIds: ['g'],
+    })
+  })
+  test('legacy userIds → viewer; users wins on collision; ids dedup', () => {
+    expect(parseShareGrants({ users: [{ id: 'a', role: 'editor' }], userIds: ['a', 'b', 'b'] })).toEqual({
+      users: [{ userId: 'a', role: 'editor' }, { userId: 'b', role: 'viewer' }],
+      groupIds: [],
+    })
+  })
+  test('an editor role on a group is rejected', () => {
+    expect(parseShareGrants({ groups: [{ id: 'g', role: 'editor' }] })).toEqual({ error: 'groups cannot be granted editor' })
+  })
+  test('garbage/empty body → empty grants, never throws', () => {
+    expect(parseShareGrants(null)).toEqual({ users: [], groupIds: [] })
+    expect(parseShareGrants({ users: 'nope', userIds: [1, 2] })).toEqual({ users: [], groupIds: [] })
+  })
+})
+
+describe('PUT/GET /shares — roles + backcompat', () => {
+  test('shares.role.roundtrip: PUT users:[{id,role:editor}] → GET returns role editor, DB agrees', async () => {
+    const { db, app, env, site } = await setup()
+    const res = await put(app, env, { users: [{ id: 'ed', role: 'editor' }, { id: 'vw', role: 'viewer' }] })
+    expect(res.status).toBe(200)
+    const body = (await get(app, env).then((r) => r.json())) as { users: { id: string; role: string }[] }
+    expect(body.users).toContainEqual({ id: 'ed', role: 'editor' })
+    expect(body.users).toContainEqual({ id: 'vw', role: 'viewer' })
+    expect(await resolveShareRole(db, site, 'ed')).toBe('editor')
+  })
+
+  test('shares.backcompat: legacy PUT userIds:[id] still 200, role defaults viewer', async () => {
+    const { db, app, env, site } = await setup()
+    const res = await put(app, env, { userIds: ['ed'], groupIds: [] })
+    expect(res.status).toBe(200)
+    expect(await res.json()).toMatchObject({ ok: true })
+    const body = (await get(app, env).then((r) => r.json())) as { userIds: string[]; users: { id: string; role: string }[] }
+    expect(body.userIds).toContain('ed')
+    expect(body.users).toContainEqual({ id: 'ed', role: 'viewer' })
+    expect(await resolveShareRole(db, site, 'ed')).toBe('viewer')
+  })
+
+  test('shares.group.editor.rejected: a group granted editor → 400, nothing written', async () => {
+    const { db, app, env, site, grp } = await setup()
+    const res = await put(app, env, { groups: [{ id: grp, role: 'editor' }] })
+    expect(res.status).toBe(400)
+    // no direct share smuggled in for the group id
+    expect(await resolveShareRole(db, site, grp)).toBeNull()
+  })
+})

--- a/packages/api/src/routes/sites-viewer.test.ts
+++ b/packages/api/src/routes/sites-viewer.test.ts
@@ -98,14 +98,14 @@ describe('GET /api/sites/:space/:site/exists (slug-availability probe)', () => {
     const { app, env } = await seedProbe()
     const res = await exists(app, env, 'docs', 'report', 'owner')
     expect(res.status).toBe(200)
-    expect(await res.json()).toEqual({ exists: true, owned: true })
+    expect(await res.json()).toEqual({ exists: true, owned: true, canReplace: true, contentVersion: 0 })
   })
 
   test('a space member (non-owner) sees it exists but not owned', async () => {
     const { db, kv, app, env, space } = await seedProbe()
     await mintUser(db, kv, 'mate')
     await seedMember(db, space, 'mate')
-    expect(await (await exists(app, env, 'docs', 'report', 'mate')).json()).toEqual({ exists: true, owned: false })
+    expect(await (await exists(app, env, 'docs', 'report', 'mate')).json()).toEqual({ exists: true, owned: false, canReplace: false, contentVersion: 0 })
   })
 
   test('superadmin (non-member) sees it exists', async () => {

--- a/packages/api/src/routes/sites.ts
+++ b/packages/api/src/routes/sites.ts
@@ -1,6 +1,7 @@
 import { and, desc, eq, inArray, or, sql } from 'drizzle-orm'
 import { Hono } from 'hono'
 import {
+  type ShareUser,
   isSpaceMember,
   listSiteShares,
   memberSpaceIds,
@@ -420,6 +421,30 @@ function resolveIndexPath(paths: string[]): string {
   return paths.length === 1 ? paths[0] : ''
 }
 
+// Normalize a PUT /shares body into role-aware user grants + view-only group ids. Pure (no DB), so
+// it's unit-testable and keeps every cast out of the request path. Accepts the new `users:[{id,role}]`
+// shape and the legacy `userIds:[id]` list (defaulted to viewer; `users` wins on a collision). Groups
+// arrive as `groupIds:[id]` or `groups:[{id}]` and are ALWAYS view-only — an editor role on a group is
+// a client error (there is no role column on site_group_shares), surfaced as `{ error }`.
+export function parseShareGrants(body: unknown): { users: ShareUser[]; groupIds: string[] } | { error: string } {
+  const b = (body ?? {}) as Record<string, unknown>
+  const asIds = (v: unknown) =>
+    Array.isArray(v) ? [...new Set(v.filter((x): x is string => typeof x === 'string'))] : []
+  const groupObjs = Array.isArray(b.groups) ? (b.groups as { id?: unknown; role?: unknown }[]) : []
+  if (groupObjs.some((g) => g?.role === 'editor')) return { error: 'groups cannot be granted editor' }
+
+  const roles = new Map<string, 'viewer' | 'editor'>()
+  if (Array.isArray(b.users)) {
+    for (const u of b.users as { id?: unknown; role?: unknown }[]) {
+      if (typeof u?.id === 'string') roles.set(u.id, u.role === 'editor' ? 'editor' : 'viewer')
+    }
+  }
+  for (const id of asIds(b.userIds)) if (!roles.has(id)) roles.set(id, 'viewer')
+
+  const groupIds = [...new Set([...asIds(b.groupIds), ...asIds(groupObjs.map((g) => g?.id))])]
+  return { users: [...roles].map(([userId, role]) => ({ userId, role })), groupIds }
+}
+
 // GET /api/sites/:spaceSlug/:siteSlug/shares — owner-only: current explicit share lists.
 sites.get('/:spaceSlug/:siteSlug/shares', requireAuth, async (c) => {
   const user = c.get('user')
@@ -428,7 +453,14 @@ sites.get('/:spaceSlug/:siteSlug/shares', requireAuth, async (c) => {
   const site = await resolveSite(db, spaceSlug, siteSlug)
   if (!site) return c.json({ error: 'not found' }, 404)
   if (site.ownerId !== user.id && user.role !== 'superadmin') return c.json({ error: 'forbidden' }, 403)
-  return c.json(await listSiteShares(db, site.id))
+  const shares = await listSiteShares(db, site.id)
+  // Boundary shape: expose users as {id, role} (mirrors the PUT input); keep flat userIds/groupIds
+  // for the legacy web dialog.
+  return c.json({
+    userIds: shares.userIds,
+    groupIds: shares.groupIds,
+    users: shares.users.map((u) => ({ id: u.userId, role: u.role })),
+  })
 })
 
 // PUT /api/sites/:spaceSlug/:siteSlug/shares — owner-only: replace the whole share set.
@@ -440,28 +472,32 @@ sites.put('/:spaceSlug/:siteSlug/shares', requireAuth, async (c) => {
   if (!site) return c.json({ error: 'not found' }, 404)
   if (site.ownerId !== user.id && user.role !== 'superadmin') return c.json({ error: 'forbidden' }, 403)
 
-  const body = await c.req.json().catch(() => null)
-  const asIds = (v: unknown) =>
-    Array.isArray(v) ? [...new Set(v.filter((x): x is string => typeof x === 'string'))] : []
-  const wantUsers = asIds(body?.userIds)
-  const wantGroups = asIds(body?.groupIds)
+  const grants = parseShareGrants(await c.req.json().catch(() => null))
+  if ('error' in grants) return c.json({ error: grants.error }, 400)
 
-  // Keep only ids that exist (real users; group-type spaces) so a stale id can't fail the
-  // batch insert on an FK violation.
-  const validUsers = wantUsers.length
-    ? (await db.select({ id: users.id }).from(users).where(inArray(users.id, wantUsers))).map((r) => r.id)
-    : []
-  const validGroups = wantGroups.length
+  // Keep only ids that exist (real users; group-type spaces) so a stale id can't fail the batch
+  // insert on an FK violation.
+  const wantUsers = grants.users.map((u) => u.userId)
+  const present = wantUsers.length
+    ? new Set((await db.select({ id: users.id }).from(users).where(inArray(users.id, wantUsers))).map((r) => r.id))
+    : new Set<string>()
+  const validUsers = grants.users.filter((u) => present.has(u.userId))
+  const validGroups = grants.groupIds.length
     ? (
         await db
           .select({ id: spaces.id })
           .from(spaces)
-          .where(and(inArray(spaces.id, wantGroups), eq(spaces.type, 'group')))
+          .where(and(inArray(spaces.id, grants.groupIds), eq(spaces.type, 'group')))
       ).map((r) => r.id)
     : []
 
   await replaceSiteShares(db, site.id, validUsers, validGroups)
-  return c.json({ ok: true, userIds: validUsers, groupIds: validGroups })
+  return c.json({
+    ok: true,
+    userIds: validUsers.map((u) => u.userId),
+    groupIds: validGroups,
+    users: validUsers.map((u) => ({ id: u.userId, role: u.role })),
+  })
 })
 
 // PATCH /api/sites/:spaceSlug/:siteSlug — owner-only update of visibility/title.

--- a/packages/api/src/routes/sites.ts
+++ b/packages/api/src/routes/sites.ts
@@ -7,11 +7,12 @@ import {
   memberSpaceIds,
   replaceSiteShares,
   resolveIsShared,
+  resolveShareRole,
   sharedSiteIds,
 } from '../db/repo'
 import type { Visibility } from '../db/schema'
 import { files as filesTable, sites as sitesTable, spaces, users } from '../db/schema'
-import { checkAccess } from '../lib/access'
+import { canReplace, checkAccess } from '../lib/access'
 import { allAudioSiteIds } from '../lib/site-audio'
 import { readSessionOrBearer } from '../lib/session'
 import { resolveSite } from '../lib/site-access'
@@ -355,12 +356,16 @@ sites.get('/:spaceSlug/:siteSlug/exists', requireAuth, async (c) => {
   const site = await resolveSite(db, spaceSlug, siteSlug)
   if (!site) return c.json({ exists: false })
   // Existence is disclosed only to someone who could legitimately act on it — the site's space
-  // members (slug availability is per-space), its owner, or a superadmin. Anyone else gets the
-  // same not-found shape so an unauthorized caller can't probe cross-space for a site's existence.
-  const authorized =
-    user.role === 'superadmin' || site.ownerId === user.id || (await isSpaceMember(db, site.spaceId, user.id))
+  // members (slug availability is per-space), its owner, a superadmin, OR a direct editor grantee
+  // (typically NOT a space member — without this a non-member editor gets exists:false, the CLI
+  // then tries CREATE and 403s). Anyone else gets the same not-found shape so an unauthorized caller
+  // can't probe cross-space for a site's existence.
+  const isOwner = site.ownerId === user.id
+  const role = isOwner || user.role === 'superadmin' ? null : await resolveShareRole(db, site.id, user.id)
+  const replaceable = canReplace(user, site, role)
+  const authorized = replaceable || (await isSpaceMember(db, site.spaceId, user.id))
   if (!authorized) return c.json({ exists: false })
-  return c.json({ exists: true, owned: site.ownerId === user.id })
+  return c.json({ exists: true, owned: isOwner, canReplace: replaceable, contentVersion: site.contentVersion })
 })
 
 // GET /api/sites/:spaceSlug/:siteSlug — viewer metadata + a token-gated content URL.
@@ -377,13 +382,14 @@ sites.get('/:spaceSlug/:siteSlug', async (c) => {
   // leaks — running the session read early doesn't change the not-found-before-auth ordering.
   if (!site) return c.json({ error: 'not found' }, 404)
 
-  const [isMember, isShared, siteFiles] = user
+  const [isMember, isShared, role, siteFiles] = user
     ? await Promise.all([
         isSpaceMember(db, site.spaceId, user.id),
         resolveIsShared(db, site.id, user.id),
+        resolveShareRole(db, site.id, user.id),
         db.select({ path: filesTable.path }).from(filesTable).where(eq(filesTable.siteId, site.id)),
       ])
-    : [false, false, [] as { path: string }[]]
+    : [false, false, null, [] as { path: string }[]]
   const access = checkAccess(site, user, isMember, isShared)
   if (!access.ok) return c.json({ error: 'forbidden' }, access.status)
 
@@ -398,6 +404,10 @@ sites.get('/:spaceSlug/:siteSlug', async (c) => {
     CONTENT_TOKEN_TTL,
   )}/${spaceSlug}/${siteSlug}/`
 
+  // Manifest gate: only someone who can REPLACE the content (owner / superadmin / editor) gets the
+  // file list + contentVersion — the pull-and-redeploy payload. A plain viewer sees their canReplace:
+  // false and no manifest, so they can't enumerate the site's files.
+  const replaceable = canReplace(user, site, role)
   return c.json({
     id: site.id,
     spaceSlug,
@@ -405,9 +415,12 @@ sites.get('/:spaceSlug/:siteSlug', async (c) => {
     title: site.title,
     visibility: site.visibility,
     status: site.status,
-    isOwner: user?.id === site.ownerId,
+    isOwner: user.id === site.ownerId,
+    canReplace: replaceable,
+    ...(role ? { role } : {}),
     contentUrl,
     indexPath: resolveIndexPath(siteFiles.map((f) => f.path)),
+    ...(replaceable ? { files: siteFiles.map((f) => f.path), contentVersion: site.contentVersion } : {}),
   })
 })
 

--- a/packages/api/src/routes/sites.ts
+++ b/packages/api/src/routes/sites.ts
@@ -11,7 +11,7 @@ import {
   sharedSiteIds,
 } from '../db/repo'
 import type { Visibility } from '../db/schema'
-import { files as filesTable, sites as sitesTable, spaces, users } from '../db/schema'
+import { files as filesTable, siteUserShares, sites as sitesTable, spaces, users } from '../db/schema'
 import { canReplace, checkAccess } from '../lib/access'
 import { allAudioSiteIds } from '../lib/site-audio'
 import { readSessionOrBearer } from '../lib/session'
@@ -268,7 +268,21 @@ sites.get('/shared', requireAuth, async (c) => {
   )
   const rows = batches.flat().sort(byCreatedAtDesc)
   const visible = rows.filter((r) => r.status === 'active' && r.ownerId !== user.id)
-  const audioSet = await allAudioSiteIds(db, visible.map((r) => r.id))
+  const visibleIds = visible.map((r) => r.id)
+  // Direct-share role per site so the dashboard can badge "You can edit". A site reached only via a
+  // group share has no direct row → treated as viewer (groups are never editor grants).
+  const roleRows = (
+    await Promise.all(
+      chunk(visibleIds, D1_MAX_IN).map((batch) =>
+        db
+          .select({ siteId: siteUserShares.siteId, role: siteUserShares.role })
+          .from(siteUserShares)
+          .where(and(eq(siteUserShares.userId, user.id), inArray(siteUserShares.siteId, batch))),
+      ),
+    )
+  ).flat()
+  const roleBySite = new Map(roleRows.map((r) => [r.siteId, r.role]))
+  const audioSet = await allAudioSiteIds(db, visibleIds)
   return c.json(
     visible.map((r) => ({
       id: r.id,
@@ -278,6 +292,7 @@ sites.get('/shared', requireAuth, async (c) => {
       visibility: r.visibility,
       status: r.status,
       audio: audioSet.has(r.id),
+      role: roleBySite.get(r.id) ?? 'viewer',
       url: `${c.env.APP_URL}/${r.spaceSlug}/${r.slug}`,
       createdAt: r.createdAt,
     })),

--- a/packages/api/src/routes/upload-editor.test.ts
+++ b/packages/api/src/routes/upload-editor.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, test } from 'bun:test'
+import { eq } from 'drizzle-orm'
+import { Hono } from 'hono'
+import { files, sites } from '../db/schema'
+import { makeDb, makeKv, makeR2, seedFile, seedMember, seedSite, seedSpace, seedUser, seedUserShare } from '../test/harness'
+import type { AppEnv } from '../types'
+import { upload } from './upload'
+
+// Phase 2 — editor-share enforcement. An 'editor' direct-share may content-replace a site they
+// neither own nor are a space member of; a plain 'viewer' or a stranger may not. Editor replaces are
+// content-only (no visibility change), blocked on archived sites, and CAS-guarded on contentVersion.
+
+const APP_URL = 'https://glance.example.com'
+const html = (s: string) => new File([s], 'index.html', { type: 'text/html' })
+
+async function fx() {
+  const db = makeDb()
+  const kv = makeKv()
+  const r2 = makeR2()
+  const owner = await seedUser(db, { id: 'owner', email: 'owner@e.com' })
+  const sp = await seedSpace(db, { id: 'acme', slug: 'acme', createdBy: owner })
+  await seedMember(db, sp, owner)
+  for (const id of ['owner', 'ed', 'vw', 'st']) {
+    await seedUser(db, { id, email: `${id}@e.com` }).catch(() => {}) // owner already seeded
+    await kv.put(`cli:${id}`, JSON.stringify({ id, email: `${id}@e.com`, name: null, role: 'member' }))
+  }
+  const site = await seedSite(db, { id: 'site', spaceId: 'acme', ownerId: 'owner', slug: 'doc', visibility: 'team' })
+  const oldKey = await seedFile(db, r2, site, { path: 'index.html', text: '<html>old</html>' })
+  await seedUserShare(db, site, 'ed', 'editor')
+  await seedUserShare(db, site, 'vw', 'viewer')
+
+  const env = { APP_URL, SESSION_SECRET: 's', GLANCE_SESSIONS: kv, GLANCE_FILES: r2 } as unknown as AppEnv['Bindings']
+  const app = new Hono<AppEnv>()
+  app.use('*', async (c, next) => {
+    c.set('db', db)
+    await next()
+  })
+  app.route('/api/upload', upload)
+  return { db, app, env, site, oldKey }
+}
+
+type Opts = { slug?: string; replace?: boolean; visibility?: string; expectedVersion?: number }
+function post(app: Hono<AppEnv>, env: AppEnv['Bindings'], token: string, opts: Opts = {}) {
+  const fd = new FormData()
+  fd.append('files', html('<html>new</html>'))
+  if (opts.visibility !== undefined) fd.append('visibility', opts.visibility)
+  if (opts.expectedVersion !== undefined) fd.append('expectedVersion', String(opts.expectedVersion))
+  const q = opts.replace ? '?replace=true' : ''
+  return app.request(`/api/upload/acme/${opts.slug ?? 'doc'}${q}`, { method: 'POST', headers: { Authorization: `Bearer ${token}` }, body: fd }, env)
+}
+
+const siteRow = (db: Awaited<ReturnType<typeof fx>>['db']) =>
+  db.select().from(sites).where(eq(sites.id, 'site')).limit(1).then((r) => r[0])
+const fileKeys = (db: Awaited<ReturnType<typeof fx>>['db']) =>
+  db.select({ k: files.storageKey }).from(files).where(eq(files.siteId, 'site')).then((r) => r.map((x) => x.k))
+
+describe('upload — editor-share enforcement', () => {
+  test('upload.editor.replace.200: a non-member editor replaces another owner’s site', async () => {
+    const { app, env } = await fx()
+    expect((await post(app, env, 'ed', { replace: true, expectedVersion: 0 })).status).toBe(200)
+  })
+
+  test('upload.viewer.replace.403: a viewer-share replace is forbidden', async () => {
+    const { app, env } = await fx()
+    expect((await post(app, env, 'vw', { replace: true, expectedVersion: 0 })).status).toBe(403)
+  })
+
+  test('upload.stranger.replace.403 / create.nonmember.403: unchanged denials', async () => {
+    const { app, env } = await fx()
+    expect((await post(app, env, 'st', { replace: true, expectedVersion: 0 })).status).toBe(403)
+    expect((await post(app, env, 'st', { slug: 'brandnew' })).status).toBe(403) // create in a space they’re not in
+  })
+
+  test('upload.editor.visibility.ignored: an editor replace cannot change visibility', async () => {
+    const { db, app, env } = await fx()
+    expect((await post(app, env, 'ed', { replace: true, expectedVersion: 0, visibility: 'private' })).status).toBe(200)
+    expect((await siteRow(db)).visibility).toBe('team')
+  })
+
+  test('upload.owner.visibility.applied: an owner replace with visibility changes it', async () => {
+    const { db, app, env } = await fx()
+    expect((await post(app, env, 'owner', { replace: true, visibility: 'private' })).status).toBe(200)
+    expect((await siteRow(db)).visibility).toBe('private')
+  })
+
+  test('upload.editor.archived.403: an editor cannot replace an archived site', async () => {
+    const { db, app, env } = await fx()
+    await db.update(sites).set({ status: 'archived' }).where(eq(sites.id, 'site'))
+    expect((await post(app, env, 'ed', { replace: true, expectedVersion: 0 })).status).toBe(403)
+  })
+
+  test('upload.editor.absentVersion.400: an editor replace without expectedVersion is rejected', async () => {
+    const { app, env } = await fx()
+    expect((await post(app, env, 'ed', { replace: true })).status).toBe(400)
+  })
+
+  test('upload.editor.staleVersion.409: a stale expectedVersion conflicts and leaves files untouched', async () => {
+    const { db, app, env, oldKey } = await fx()
+    expect((await post(app, env, 'ed', { replace: true, expectedVersion: 99 })).status).toBe(409)
+    expect(await fileKeys(db)).toEqual([oldKey])
+  })
+
+  test('upload.editor.freshVersion.200: correct version bumps contentVersion + records lastReplacedBy', async () => {
+    const { db, app, env } = await fx()
+    const res = await post(app, env, 'ed', { replace: true, expectedVersion: 0 })
+    expect(res.status).toBe(200)
+    expect(await res.json()).toMatchObject({ contentVersion: 1 })
+    const row = await siteRow(db)
+    expect(row.contentVersion).toBe(1)
+    expect(row.lastReplacedBy).toBe('ed')
+  })
+
+  test('upload.cas.concurrent: two editor replaces at the same version → exactly one 200, one 409', async () => {
+    const { app, env } = await fx()
+    const [a, b] = await Promise.all([
+      post(app, env, 'ed', { replace: true, expectedVersion: 0 }),
+      post(app, env, 'ed', { replace: true, expectedVersion: 0 }),
+    ])
+    expect([a.status, b.status].sort()).toEqual([200, 409])
+  })
+
+  test('upload.owner.absentVersion.200: an owner replace without a version still succeeds (advisory)', async () => {
+    const { db, app, env } = await fx()
+    expect((await post(app, env, 'owner', { replace: true })).status).toBe(200)
+    expect((await siteRow(db)).contentVersion).toBe(1) // owner replace bumps advisorily
+  })
+})

--- a/packages/api/src/routes/upload.ts
+++ b/packages/api/src/routes/upload.ts
@@ -1,6 +1,6 @@
-import { and, eq } from 'drizzle-orm'
+import { and, eq, sql } from 'drizzle-orm'
 import { Hono } from 'hono'
-import { isSpaceMember } from '../db/repo'
+import { isSpaceMember, resolveShareRole } from '../db/repo'
 import type { NewFileRow } from '../db/schema'
 import { files, sites, spaces } from '../db/schema'
 import { fireAndForget } from '../lib/events'
@@ -50,6 +50,14 @@ upload.post('/:spaceSlug/:siteSlug', requireAuth, async (c) => {
   // a re-upload/record must never silently rename an existing site). Trimmed + capped; empty → null.
   const rawTitle = form.get('title')
   const title = typeof rawTitle === 'string' ? rawTitle.trim().slice(0, 200) || null : null
+  // Optimistic-concurrency token for a REPLACE: the contentVersion the caller last pulled. REQUIRED
+  // for an editor replace (CAS below), advisory/ignored for an owner. Parsed to a non-negative int or
+  // null (absent/blank/non-numeric).
+  const rawExpected = form.get('expectedVersion')
+  const expectedVersion =
+    typeof rawExpected === 'string' && rawExpected.trim() !== '' && Number.isInteger(Number(rawExpected))
+      ? Number(rawExpected)
+      : null
   const uploaded = form.getAll('files').filter((f): f is File => f instanceof File)
 
   // Build (path, file) pairs, dropping empty paths; validate per-file size before storing.
@@ -74,35 +82,51 @@ upload.post('/:spaceSlug/:siteSlug', requireAuth, async (c) => {
     seenPaths.add(path)
   }
 
-  // Resolve space + require membership.
+  // Resolve space.
   const space = (
     await db.select({ id: spaces.id }).from(spaces).where(eq(spaces.slug, spaceSlug)).limit(1)
   )[0]
   if (!space) return c.json({ error: 'space not found' }, 404)
-  // Superadmin moderates any space (create/replace) — consistent with the owner|superadmin gates on
-  // the sites routes (move/delete/visibility/shares). Everyone else must be a member of the space.
   const isAdmin = user.role === 'superadmin'
-  if (!isAdmin && !(await isSpaceMember(db, space.id, user.id))) return c.json({ error: 'forbidden' }, 403)
 
-  // Resolve existing site by (spaceId, siteSlug).
+  // Resolve the existing site (if any) BEFORE authorizing — CREATE and REPLACE have DIFFERENT gates:
+  // creating needs space membership; replacing is open to the owner, a superadmin, or a direct EDITOR
+  // grantee (who is typically NOT a space member, so the old membership-first gate 403'd them). Load
+  // contentVersion + status too: the editor CAS + archived guard need them.
   const existing = (
     await db
-      .select({ id: sites.id, ownerId: sites.ownerId })
+      .select({ id: sites.id, ownerId: sites.ownerId, contentVersion: sites.contentVersion, status: sites.status })
       .from(sites)
       .where(and(eq(sites.spaceId, space.id), eq(sites.slug, siteSlug)))
       .limit(1)
   )[0]
 
   const replace = c.req.query('replace') === 'true'
+  const isCreate = !existing
   let siteId: string
   let oldKeys: string[] = []
-  const isCreate = !existing
+  // True when the actor is exercising an EDITOR grant (not the owner, not a superadmin). Editors are
+  // content-only: no visibility change, no archived-site edit, and every replace is version-CAS'd.
+  let actingAsEditor = false
 
   if (!existing) {
+    // CREATE: space member or superadmin only. An editor grant confers no create right.
+    if (!isAdmin && !(await isSpaceMember(db, space.id, user.id))) return c.json({ error: 'forbidden' }, 403)
     if (!isValidSlug(siteSlug)) return c.json({ error: 'invalid siteSlug' }, 400)
     siteId = crypto.randomUUID()
   } else {
-    if (existing.ownerId !== user.id && !isAdmin) return c.json({ error: 'forbidden' }, 403)
+    // REPLACE: owner, superadmin, or a direct editor share.
+    const isOwner = existing.ownerId === user.id
+    actingAsEditor = !isOwner && !isAdmin && (await resolveShareRole(db, existing.id, user.id)) === 'editor'
+    if (!isOwner && !isAdmin && !actingAsEditor) return c.json({ error: 'forbidden' }, 403)
+
+    if (actingAsEditor) {
+      if (existing.status === 'archived') return c.json({ error: 'site archived' }, 403)
+      // The CAS below reads expectedVersion; require it up front so a versionless editor redeploy
+      // can't silently clobber a newer one.
+      if (expectedVersion === null) return c.json({ error: 'expectedVersion required' }, 400)
+    }
+
     siteId = existing.id
     const existingFiles = await db
       .select({ storageKey: files.storageKey })
@@ -158,6 +182,9 @@ upload.post('/:spaceSlug/:siteSlug', requireAuth, async (c) => {
   const newRows = plan.map((p) => p.row)
   const insertRows = newRows.map((r) => db.insert(files).values(r))
   const newKeys = newRows.map((r) => r.storageKey)
+  // The revision this upload publishes: CREATE starts at 0; every REPLACE bumps by one (advisory for
+  // owner/superadmin, CAS-enforced for an editor).
+  const newVersion = existing ? existing.contentVersion + 1 : 0
 
   try {
     if (isCreate) {
@@ -173,17 +200,41 @@ upload.post('/:spaceSlug/:siteSlug', requireAuth, async (c) => {
         }),
         ...insertRows,
       ])
+    } else if (actingAsEditor) {
+      // EDITOR REPLACE — CAS: atomically claim the revision via a conditional bump. A stale
+      // expectedVersion changes 0 rows (returning() is empty), so we 409 with the files left
+      // completely untouched (nothing swapped; the just-written R2 objects reclaimed). No TOCTOU
+      // read-compare-write, and no visibility change — an editor edits content only. On success the
+      // version is already bumped + lastReplacedBy recorded, so the swap batch only moves file rows.
+      // (The bump and swap are two statements: if the swap throws after a winning CAS, the version is
+      // ahead of the content until the next replace re-syncs it — a rare, self-healing window, and the
+      // price of leaving files untouched on a stale 409, which a single atomic batch cannot express.)
+      const claimed = await db
+        .update(sites)
+        .set({ contentVersion: sql`${sites.contentVersion} + 1`, lastReplacedBy: user.id })
+        .where(and(eq(sites.id, siteId), eq(sites.contentVersion, expectedVersion as number)))
+        .returning({ id: sites.id })
+      if (claimed.length === 0) {
+        await deleteKeys(c.env.GLANCE_FILES, newKeys)
+        return c.json({ error: 'version conflict', conflict: true }, 409)
+      }
+      await db.batch([db.delete(files).where(eq(files.siteId, siteId)), ...insertRows])
     } else {
-      // REPLACE: atomically swap file rows (delete old + insert new) in one D1 batch so the serving
-      // worker never sees a half-updated site. Update visibility in the SAME batch when the caller
-      // explicitly sent one — otherwise a re-upload that picks 'private' would 200 while the site
-      // stayed team-visible. Absent → keep the existing tier (replace's long-standing default).
+      // OWNER / SUPERADMIN REPLACE: atomically swap file rows, bump the version advisorily + record
+      // lastReplacedBy, and apply visibility only when the caller explicitly sent one (absent → keep
+      // the existing tier — replace's long-standing default). One D1 batch so the serving worker
+      // never sees a half-updated site.
       await db.batch([
         db.delete(files).where(eq(files.siteId, siteId)),
         ...insertRows,
-        ...(hasVisibility && isVisibility(visibility)
-          ? [db.update(sites).set({ visibility }).where(eq(sites.id, siteId))]
-          : []),
+        db
+          .update(sites)
+          .set({
+            contentVersion: sql`${sites.contentVersion} + 1`,
+            lastReplacedBy: user.id,
+            ...(hasVisibility && isVisibility(visibility) ? { visibility } : {}),
+          })
+          .where(eq(sites.id, siteId)),
       ])
     }
   } catch (err) {
@@ -202,5 +253,6 @@ upload.post('/:spaceSlug/:siteSlug', requireAuth, async (c) => {
     url: `${c.env.APP_URL}/${spaceSlug}/${siteSlug}`,
     siteSlug,
     fileCount: newRows.length,
+    contentVersion: newVersion,
   })
 })

--- a/packages/api/src/routes/upload.ts
+++ b/packages/api/src/routes/upload.ts
@@ -3,6 +3,7 @@ import { Hono } from 'hono'
 import { isSpaceMember, resolveShareRole } from '../db/repo'
 import type { NewFileRow } from '../db/schema'
 import { files, sites, spaces } from '../db/schema'
+import { canReplace } from '../lib/access'
 import { fireAndForget } from '../lib/events'
 import { isValidSlug } from '../lib/slug'
 import { deleteKeys, MAX_FILE_BYTES, sanitizePath } from '../lib/storage'
@@ -115,10 +116,13 @@ upload.post('/:spaceSlug/:siteSlug', requireAuth, async (c) => {
     if (!isValidSlug(siteSlug)) return c.json({ error: 'invalid siteSlug' }, 400)
     siteId = crypto.randomUUID()
   } else {
-    // REPLACE: owner, superadmin, or a direct editor share.
+    // REPLACE: owner, superadmin, or a direct editor share (canReplace — the single capability
+    // predicate shared with /exists + the manifest gate). An editor grant is only consulted for a
+    // non-owner non-admin, so passing the gate while neither ⇒ acting as the editor.
     const isOwner = existing.ownerId === user.id
-    actingAsEditor = !isOwner && !isAdmin && (await resolveShareRole(db, existing.id, user.id)) === 'editor'
-    if (!isOwner && !isAdmin && !actingAsEditor) return c.json({ error: 'forbidden' }, 403)
+    const shareRole = isOwner || isAdmin ? null : await resolveShareRole(db, existing.id, user.id)
+    if (!canReplace(user, existing, shareRole)) return c.json({ error: 'forbidden' }, 403)
+    actingAsEditor = !isOwner && !isAdmin
 
     if (actingAsEditor) {
       if (existing.status === 'archived') return c.json({ error: 'site archived' }, 403)

--- a/packages/api/src/test/harness.ts
+++ b/packages/api/src/test/harness.ts
@@ -37,6 +37,7 @@ const MIGRATIONS = [
   'drizzle/0006_glance_documents.sql',
   'drizzle/0007_add_indexes.sql',
   'drizzle/0008_comment_audio_key.sql',
+  'drizzle/0009_editor_share.sql',
 ]
 
 /** Fresh in-memory DB with the real schema applied. */
@@ -107,9 +108,14 @@ export async function seedSite(
   return id
 }
 
-/** Grant a user a direct (per-user) share on a site. */
-export async function seedUserShare(db: DrizzleD1Database, siteId: string, userId: string): Promise<void> {
-  await db.insert(siteUserShares).values({ siteId, userId })
+/** Grant a user a direct (per-user) share on a site. Role defaults to 'viewer' (today's semantics). */
+export async function seedUserShare(
+  db: DrizzleD1Database,
+  siteId: string,
+  userId: string,
+  role: 'viewer' | 'editor' = 'viewer',
+): Promise<void> {
+  await db.insert(siteUserShares).values({ siteId, userId, role })
 }
 
 /** Grant every member of a (group) space a share on a site. */

--- a/packages/cli/SKILL.md
+++ b/packages/cli/SKILL.md
@@ -134,7 +134,17 @@ glance deploy ./api-reference                            # redeploys to the SAME
 - A later `glance deploy <dir>` reads that marker to target the same site automatically (no need to re-type `--space`/`--name`) and passes the pulled version so a stale redeploy is safely refused instead of clobbering someone else's newer change.
 - Needs edit rights: `--pull` works for a site you **own** or have been given **edit** access to. A view-only share can't pull the source.
 
-**Editor round-trip** — if someone shared a site with you as an *editor*, this is the whole loop with no browser and no git: `glance read <their-space>/<site> --pull ./site` → edit `./site` → `glance deploy ./site`. You can update that site's content even though you don't own it and aren't in its space.
+**Editor round-trip** — if someone shared a site with you as an *editor*, this is the whole loop with no browser and no git:
+
+```
+glance read alice/roadmap --pull ./roadmap   # pull the source (records version, e.g. 7)
+# …add or remove content sections in ./roadmap…
+glance deploy ./roadmap                       # redeploys to the same site, sends the pulled version
+```
+
+You can update that site's content even though you don't own it and aren't in its space. If someone else redeployed since your pull, the deploy is refused as stale (409) — re-run the `--pull` to get the current version, reapply your change, and deploy again.
+
+**Editing etiquette — content, not chrome.** As an editor you own the *content*, not the site's look. Add or remove sections, update copy, correct data — but keep the owner's styling and layout intact: don't restyle, re-theme, change the CSS/structure, or re-lay-out the page. The owner set the design; an editor fills it in. (Renaming, moving, deleting, changing visibility, or editing the title aren't yours to do at all — those stay with the owner.)
 
 ## Visibility values
 `team` (default) · `private` · `members`.

--- a/packages/cli/SKILL.md
+++ b/packages/cli/SKILL.md
@@ -36,7 +36,7 @@ Put it in your shell profile to make it permanent. Token + URL are saved to `~/.
 | `glance move <space/slug> <new-space>` | moves a site to another space you belong to (keeps its files, comments, shares) |
 | `glance comments <space/slug> [--file <path>] [--open] [--json]` | prints a site's review comments as a markdown digest (or raw JSON) |
 | `glance reply <space/slug> <threadId> [message] [--tag <label>\|--no-tag]` | posts a reply to a comment thread (get the `threadId` from `glance comments`) |
-| `glance read <space/slug> [--file <path>]` | prints a deployed file's raw contents to stdout (HTML as stored) |
+| `glance read <space/slug> [--file <path>] [--pull <dir>]` | prints a file to stdout, or `--pull` downloads the whole site's source into a folder to edit + redeploy |
 | `glance logout` | revokes the server session and removes the local token |
 
 ### login
@@ -114,12 +114,27 @@ glance reply docs/api-reference k3f9q2 "typo fixed" --no-tag
 ```
 
 ### read
-Prints a deployed file's **raw contents** to stdout — the bytes as stored (HTML stays HTML; markdown stays markdown source, NOT the server-rendered HTML).
+Prints a deployed file's contents to stdout.
 
 - `<space/slug>` is required and must contain the slash (e.g. `docs/api-reference`).
 - `--file <path>` selects a file within the site (e.g. `--file guide.html`); omit it for the site root (a single-file site serves its lone file there).
 - Output is the file body only — no headers, no trailing newline — so it pipes cleanly: `glance read docs/api-reference --file index.html > index.html`.
+- **A single `read` of a `.md` file returns the server-RENDERED HTML, not the markdown source.** To get the exact source back (for editing and redeploying), use `--pull` below.
 - Every tier is access-gated (there is no anonymous tier), so `read` works only on sites you can view; a tier you can't access fails with the server's status. Errors print the HTTP status + a truncated server message.
+
+**`--pull <dir>`** — download the whole site's **source** into a local folder so you can edit it and redeploy:
+
+```
+glance read docs/api-reference --pull ./api-reference   # writes every file (source, not rendered) into ./api-reference
+# …edit the files…
+glance deploy ./api-reference                            # redeploys to the SAME site (remembers where it came from)
+```
+
+- Writes every file of the site — markdown as its true source, dotfiles included — into `<dir>`, plus a small `.glance/pull.json` marker that records the site and the version you pulled.
+- A later `glance deploy <dir>` reads that marker to target the same site automatically (no need to re-type `--space`/`--name`) and passes the pulled version so a stale redeploy is safely refused instead of clobbering someone else's newer change.
+- Needs edit rights: `--pull` works for a site you **own** or have been given **edit** access to. A view-only share can't pull the source.
+
+**Editor round-trip** — if someone shared a site with you as an *editor*, this is the whole loop with no browser and no git: `glance read <their-space>/<site> --pull ./site` → edit `./site` → `glance deploy ./site`. You can update that site's content even though you don't own it and aren't in its space.
 
 ## Visibility values
 `team` (default) · `private` · `members`.

--- a/packages/cli/deploy.go
+++ b/packages/cli/deploy.go
@@ -7,6 +7,7 @@ import (
 	"mime/multipart"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 )
 
@@ -27,7 +28,8 @@ func walk(dir string, includeHidden bool) ([]string, error) {
 	var out []string
 	for _, e := range entries {
 		name := e.Name()
-		if name == ".git" || name == "node_modules" || name == ".DS_Store" {
+		// .glance holds the pull.json round-trip marker — internal bookkeeping, never site content.
+		if name == ".git" || name == "node_modules" || name == ".DS_Store" || name == pullMarkerDir {
 			continue
 		}
 		if !includeHidden && strings.HasPrefix(name, ".") {
@@ -118,6 +120,18 @@ func (c *client) deploy(argv []string) error {
 		return fmt.Errorf("No such file or directory: %s", root)
 	}
 
+	// A tree produced by `read --pull` carries a .glance/pull.json marker: redeploy it to the SAME
+	// site, pass the pulled contentVersion as the CAS token (editor replaces require it), and
+	// re-include dotfiles (they were pulled, so they're part of the source). The .glance/ dir itself
+	// is excluded from the walk above.
+	var marker *pullMarker
+	if info.IsDir() {
+		if m, ok := readPullMarker(root); ok {
+			marker = m
+			includeHidden = true
+		}
+	}
+
 	// Accept a single file OR a folder. A lone file uploads under its own name and is served at
 	// the site root (the content worker falls back to the only file).
 	var entries []deployEntry
@@ -141,9 +155,14 @@ func (c *client) deploy(argv []string) error {
 		return fmt.Errorf("No files to upload.")
 	}
 
+	// Name/space default from the pull marker (redeploy targets the same site) before falling back to
+	// the derived name / the caller's personal space — an editor's personal space is NOT where the
+	// owner's site lives, so a pulled redeploy must reuse the recorded target.
 	name := ""
 	if raw, present := flags["name"]; present {
 		name = raw.(string)
+	} else if marker != nil {
+		name = marker.Name
 	} else {
 		name = slugify(derived)
 	}
@@ -154,6 +173,8 @@ func (c *client) deploy(argv []string) error {
 	space := ""
 	if raw, present := flags["space"]; present {
 		space = raw.(string)
+	} else if marker != nil {
+		space = marker.Space
 	} else {
 		s, err := c.personalSpace()
 		if err != nil {
@@ -175,8 +196,9 @@ func (c *client) deploy(argv []string) error {
 		return fmt.Errorf("Could not check whether %s/%s already exists (%d).", space, name, code)
 	}
 	var ex struct {
-		Exists bool `json:"exists"`
-		Owned  bool `json:"owned"`
+		Exists     bool `json:"exists"`
+		Owned      bool `json:"owned"`
+		CanReplace bool `json:"canReplace"`
 	}
 	decErr := json.NewDecoder(exResp.Body).Decode(&ex)
 	exResp.Body.Close()
@@ -185,7 +207,10 @@ func (c *client) deploy(argv []string) error {
 	}
 	replace := false
 	if ex.Exists {
-		if !ex.Owned {
+		// Replace is gated on canReplace (owner / superadmin / editor) — an editor doesn't own the
+		// site but may redeploy its content. `|| Owned` keeps a newer CLI working against an older
+		// server that predates the canReplace field.
+		if !(ex.CanReplace || ex.Owned) {
 			return fmt.Errorf("%s/%s is taken by another user.", space, name)
 		}
 		ans := c.prompt(fmt.Sprintf("Site exists at %s/%s. Replace? (y/N) ", space, name))
@@ -203,6 +228,11 @@ func (c *client) deploy(argv []string) error {
 	// private) site to team on a routine content update. Absent on replace → server keeps the tier.
 	if visibilitySet || !replace {
 		_ = mw.WriteField("visibility", visibility)
+	}
+	// Pulled redeploy: send the version we pulled as the CAS token. The server REQUIRES it for an
+	// editor replace (409 on a stale one) and treats it as advisory for an owner.
+	if replace && marker != nil {
+		_ = mw.WriteField("expectedVersion", strconv.Itoa(marker.ContentVersion))
 	}
 	for _, e := range entries {
 		data, err := os.ReadFile(e.abs)

--- a/packages/cli/deploy_test.go
+++ b/packages/cli/deploy_test.go
@@ -14,13 +14,14 @@ import (
 )
 
 type deployState struct {
-	existsBody    string // response body for the /exists endpoint
-	existsStatus  int    // status for /exists; 0 -> 200
-	spacesMineHit bool
-	uploadPath    string
-	uploadQuery   string
-	visibility    string
-	files         map[string]string // rel filename -> contents (unstripped)
+	existsBody      string // response body for the /exists endpoint
+	existsStatus    int    // status for /exists; 0 -> 200
+	spacesMineHit   bool
+	uploadPath      string
+	uploadQuery     string
+	visibility      string
+	expectedVersion string            // the expectedVersion form field, if sent
+	files           map[string]string // rel filename -> contents (unstripped)
 }
 
 func newDeployServer(t *testing.T) (*httptest.Server, *deployState) {
@@ -54,6 +55,8 @@ func newDeployServer(t *testing.T) (*httptest.Server, *deployState) {
 					st.files[fn] = string(data)
 				} else if p.FormName() == "visibility" {
 					st.visibility = string(data)
+				} else if p.FormName() == "expectedVersion" {
+					st.expectedVersion = string(data)
 				}
 			}
 			io.WriteString(w, `{"url":"https://g`+strings.TrimPrefix(r.URL.Path, "/api/upload")+`"}`)

--- a/packages/cli/deploy_version_test.go
+++ b/packages/cli/deploy_version_test.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Phase 4 / S14 — a deploy from a PULLED tree (has .glance/pull.json) is version-aware: it sends the
+// pulled contentVersion as expectedVersion, targets the recorded site, round-trips dotfiles, and
+// never re-uploads the .glance marker. And the owner-only gate widens to canReplace so an editor
+// (owned:false but canReplace:true) can redeploy.
+
+func writePulledDir(t *testing.T) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), "site")
+	writeFile(t, filepath.Join(dir, "index.html"), "<p>edited</p>")
+	writeFile(t, filepath.Join(dir, ".well-known", "keep"), "secret-but-owned")
+	writeFile(t, filepath.Join(dir, ".glance", "pull.json"), `{"space":"acme","name":"doc","contentVersion":5}`)
+	return dir
+}
+
+func TestDeployVersioned(t *testing.T) {
+	t.Run("cli.deploy.sendsVersion", func(t *testing.T) {
+		dir := writePulledDir(t)
+		srv, st := newDeployServer(t)
+		st.existsBody = `{"exists":true,"owned":true,"canReplace":true,"contentVersion":5}`
+		c, _ := newTestClient(srv.URL, "tok")
+		c.in = strings.NewReader("y\n") // confirm the Replace? prompt
+		if err := c.deploy([]string{dir}); err != nil {
+			t.Fatalf("deploy: %v", err)
+		}
+		// Targets the site from pull.json (not the caller's personal space / the dir name).
+		if st.uploadPath != "/api/upload/acme/doc" || st.uploadQuery != "replace=true" {
+			t.Fatalf("upload target = %q?%q", st.uploadPath, st.uploadQuery)
+		}
+		if st.expectedVersion != "5" {
+			t.Errorf("expectedVersion = %q, want 5", st.expectedVersion)
+		}
+		// Pulled tree round-trips dotfiles (auto --include-hidden) but never re-uploads the marker.
+		if st.files[".well-known/keep"] != "secret-but-owned" {
+			t.Errorf("dotfile not round-tripped: %v", st.files)
+		}
+		if _, leaked := st.files[".glance/pull.json"]; leaked {
+			t.Errorf(".glance/ marker must be excluded from the upload")
+		}
+	})
+
+	t.Run("cli.deploy.editor.canReplace", func(t *testing.T) {
+		dir := writePulledDir(t)
+		srv, st := newDeployServer(t)
+		// Editor: does NOT own the site, but canReplace. Today's `owned` gate aborts here.
+		st.existsBody = `{"exists":true,"owned":false,"canReplace":true,"contentVersion":5}`
+		c, _ := newTestClient(srv.URL, "tok")
+		c.in = strings.NewReader("y\n")
+		if err := c.deploy([]string{dir}); err != nil {
+			t.Fatalf("editor deploy should proceed on canReplace, got: %v", err)
+		}
+		if st.uploadPath != "/api/upload/acme/doc" {
+			t.Fatalf("editor upload did not happen: %q", st.uploadPath)
+		}
+	})
+
+	t.Run("cli.deploy.notReplaceable.aborts", func(t *testing.T) {
+		dir := writePulledDir(t)
+		srv, st := newDeployServer(t)
+		st.existsBody = `{"exists":true,"owned":false,"canReplace":false,"contentVersion":5}`
+		c, _ := newTestClient(srv.URL, "tok")
+		if err := c.deploy([]string{dir}); err == nil {
+			t.Error("a non-owner non-editor must still be refused")
+		}
+		if st.uploadPath != "" {
+			t.Error("no upload should happen when canReplace is false")
+		}
+	})
+}

--- a/packages/cli/main.go
+++ b/packages/cli/main.go
@@ -97,7 +97,7 @@ func printHelp() {
 	fmt.Println("  glance move <space/slug> <new-space>")
 	fmt.Println("  glance comments <space/slug> [--file <path>] [--open] [--json]")
 	fmt.Println("  glance reply <space/slug> <threadId> [message] [--tag <label> | --no-tag]")
-	fmt.Println("  glance read <space/slug> [--file <path>]")
+	fmt.Println("  glance read <space/slug> [--file <path>] [--pull <dir>]")
 	fmt.Println("  glance skill install")
 	fmt.Println("  glance upgrade")
 	fmt.Println("  glance version")

--- a/packages/cli/pull.go
+++ b/packages/cli/pull.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// pullMarker (.glance/pull.json) records where a `read --pull` tree came from, so a later `deploy`
+// of that tree targets the same site and passes the pulled contentVersion as the CAS token.
+type pullMarker struct {
+	Space          string `json:"space"`
+	Name           string `json:"name"`
+	ContentVersion int    `json:"contentVersion"`
+}
+
+const (
+	pullMarkerDir  = ".glance"
+	pullMarkerFile = "pull.json"
+)
+
+// readPullMarker returns the marker a prior --pull wrote under dir, or (nil,false) if absent/unreadable.
+func readPullMarker(dir string) (*pullMarker, bool) {
+	data, err := os.ReadFile(filepath.Join(dir, pullMarkerDir, pullMarkerFile))
+	if err != nil {
+		return nil, false
+	}
+	var m pullMarker
+	if json.Unmarshal(data, &m) != nil {
+		return nil, false
+	}
+	return &m, true
+}
+
+func writePullMarker(dir string, m pullMarker) error {
+	md := filepath.Join(dir, pullMarkerDir)
+	if err := os.MkdirAll(md, 0o755); err != nil {
+		return err
+	}
+	data, _ := json.MarshalIndent(m, "", "  ")
+	return os.WriteFile(filepath.Join(md, pullMarkerFile), data, 0o644)
+}
+
+// encodePath percent-encodes each POSIX path segment for a content-URL fetch (mirrors a browser
+// request), so paths with spaces/unicode resolve.
+func encodePath(file string) string {
+	segs := strings.Split(strings.TrimLeft(file, "/"), "/")
+	for i, s := range segs {
+		segs[i] = encodeURIComponent(s)
+	}
+	return strings.Join(segs, "/")
+}

--- a/packages/cli/pull_test.go
+++ b/packages/cli/pull_test.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// S-E seam: an httptest fake for the meta (manifest) + gated raw-content endpoints that `read --pull`
+// consumes. The raw path returns DIFFERENT bytes for ?raw=1 (source) vs a plain GET (rendered) so a
+// test can prove the pull fetched the source.
+func newPullServer(t *testing.T, files map[string]string, contentVersion int, canReplace bool) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/api/sites/") && !strings.HasSuffix(r.URL.Path, "/exists"):
+			paths := make([]string, 0, len(files))
+			for p := range files {
+				paths = append(paths, p)
+			}
+			resp := map[string]any{
+				"contentUrl": "http://" + r.Host + "/_c/sam/site/",
+				"canReplace": canReplace,
+			}
+			if canReplace { // manifest gated to owner/editor/superadmin
+				resp["files"] = paths
+				resp["contentVersion"] = contentVersion
+			}
+			_ = json.NewEncoder(w).Encode(resp)
+		case strings.HasPrefix(r.URL.Path, "/_c/sam/site/"):
+			rel := strings.TrimPrefix(r.URL.Path, "/_c/sam/site/")
+			if r.URL.Query().Get("raw") == "1" {
+				_, _ = w.Write([]byte(files[rel]))
+			} else {
+				_, _ = w.Write([]byte("<h1>RENDERED " + rel + "</h1>")) // non-raw path renders
+			}
+		default:
+			w.WriteHeader(404)
+		}
+	}))
+}
+
+func TestReadPull(t *testing.T) {
+	t.Run("cli.pull.writesTree", func(t *testing.T) {
+		files := map[string]string{"index.html": "<p>home</p>", "docs/guide.md": "# guide", ".well-known/x": "keep"}
+		srv := newPullServer(t, files, 7, true)
+		c, _ := newTestClient(srv.URL, "tok")
+		dir := t.TempDir()
+		if err := c.read([]string{"sam/site", "--pull", dir}); err != nil {
+			t.Fatalf("pull: %v", err)
+		}
+		for rel, want := range files {
+			got, err := os.ReadFile(filepath.Join(dir, filepath.FromSlash(rel)))
+			if err != nil {
+				t.Fatalf("missing pulled file %s: %v", rel, err)
+			}
+			if string(got) != want {
+				t.Errorf("%s = %q, want %q", rel, got, want)
+			}
+		}
+		// pull marker records space/name/contentVersion for a later versioned redeploy.
+		markerBytes, err := os.ReadFile(filepath.Join(dir, ".glance", "pull.json"))
+		if err != nil {
+			t.Fatalf("no pull.json: %v", err)
+		}
+		var pj struct {
+			Space          string `json:"space"`
+			Name           string `json:"name"`
+			ContentVersion int    `json:"contentVersion"`
+		}
+		if err := json.Unmarshal(markerBytes, &pj); err != nil {
+			t.Fatal(err)
+		}
+		if pj.Space != "sam" || pj.Name != "site" || pj.ContentVersion != 7 {
+			t.Errorf("pull.json = %+v", pj)
+		}
+	})
+
+	t.Run("cli.pull.md.source", func(t *testing.T) {
+		srv := newPullServer(t, map[string]string{"about.md": "# real source"}, 1, true)
+		c, _ := newTestClient(srv.URL, "tok")
+		dir := t.TempDir()
+		if err := c.read([]string{"sam/site", "--pull", dir}); err != nil {
+			t.Fatalf("pull: %v", err)
+		}
+		got, _ := os.ReadFile(filepath.Join(dir, "about.md"))
+		if string(got) != "# real source" {
+			t.Errorf("pulled .md = %q, want the raw source (not rendered HTML)", got)
+		}
+	})
+
+	t.Run("cli.pull.viewer.denied", func(t *testing.T) {
+		srv := newPullServer(t, map[string]string{"index.html": "x"}, 0, false) // canReplace:false → no manifest
+		c, _ := newTestClient(srv.URL, "tok")
+		if err := c.read([]string{"sam/site", "--pull", t.TempDir()}); err == nil {
+			t.Error("a viewer (no manifest) should not be able to --pull")
+		}
+	})
+
+	t.Run("cli.pull.traversal.refused", func(t *testing.T) {
+		// A hostile/buggy manifest path must never write outside the target dir.
+		srv := newPullServer(t, map[string]string{"../escape.txt": "pwned"}, 0, true)
+		c, _ := newTestClient(srv.URL, "tok")
+		dir := t.TempDir()
+		if err := c.read([]string{"sam/site", "--pull", filepath.Join(dir, "site")}); err == nil {
+			t.Error("a path escaping the target dir must be refused")
+		}
+		if _, err := os.Stat(filepath.Join(dir, "escape.txt")); err == nil {
+			t.Error("traversal write landed outside the target dir")
+		}
+	})
+}
+
+func TestReadUnchanged(t *testing.T) {
+	// cli.read.unchanged: a bare `read --file` (no --pull) still prints the served bytes verbatim.
+	t.Run("cli.read.unchanged", func(t *testing.T) {
+		srv := newPullServer(t, map[string]string{"a.txt": "AAA"}, 0, true)
+		c, out := newTestClient(srv.URL, "tok")
+		if err := c.read([]string{"sam/site", "--file", "a.txt"}); err != nil {
+			t.Fatalf("read: %v", err)
+		}
+		// bare read hits the NON-raw content path → serves the file (here the fake "renders" it).
+		if got := out.String(); got != "<h1>RENDERED a.txt</h1>" {
+			t.Errorf("read output = %q", got)
+		}
+	})
+}

--- a/packages/cli/read.go
+++ b/packages/cli/read.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 	"strings"
 )
 
@@ -21,6 +23,7 @@ func (c *client) read(argv []string) error {
 		return fmt.Errorf("Usage: glance read <space/slug> [--file <path>]")
 	}
 	file, _ := flags["file"].(string)
+	pullDir, doPull := flags["pull"].(string)
 	if err := c.requireAuth(); err != nil {
 		return err
 	}
@@ -33,22 +36,23 @@ func (c *client) read(argv []string) error {
 	if !ok(resp) {
 		return fmt.Errorf("Could not read %s/%s (%d): %s", space, name, resp.StatusCode, bodySlice(resp))
 	}
+	// files[] + contentVersion are present only when the caller may replace (owner/editor/superadmin) —
+	// the manifest the pull needs. A plain viewer gets neither, so --pull refuses (below).
 	var meta struct {
-		ContentURL string `json:"contentUrl"`
+		ContentURL     string   `json:"contentUrl"`
+		Files          []string `json:"files"`
+		ContentVersion int      `json:"contentVersion"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&meta); err != nil {
 		return err
 	}
 
-	// contentUrl always ends with '/'; append the in-site path (empty -> site root / single file).
-	// Encode each segment so paths with spaces/unicode resolve, mirroring a browser request.
-	segs := strings.Split(strings.TrimLeft(file, "/"), "/")
-	for i, s := range segs {
-		segs[i] = encodeURIComponent(s)
+	if doPull {
+		return c.pullTree(space, name, pullDir, meta.ContentURL, meta.Files, meta.ContentVersion)
 	}
-	path := strings.Join(segs, "/")
 
-	cres, err := c.http.Get(meta.ContentURL + path)
+	// contentUrl always ends with '/'; append the in-site path (empty -> site root / single file).
+	cres, err := c.http.Get(meta.ContentURL + encodePath(file))
 	if err != nil {
 		return err
 	}
@@ -66,4 +70,53 @@ func (c *client) read(argv []string) error {
 	}
 	_, err = c.out.Write(body) // raw bytes, no trailing newline (pipes cleanly)
 	return err
+}
+
+// pullTree downloads the whole site source into dir: each manifest file is fetched RAW (?raw=1 —
+// the .md source, not its rendered HTML) so a later `deploy` round-trips byte-identically, then a
+// .glance/pull.json marker records the site + version for a versioned redeploy. Dotfiles are written
+// as-is (the tree is trusted local output). Refuses when the manifest is empty — a plain viewer can't
+// see it, and there's nothing to pull.
+func (c *client) pullTree(space, name, dir, contentURL string, files []string, version int) error {
+	if len(files) == 0 {
+		return fmt.Errorf("Can't pull %s/%s: you need owner or editor access (no file manifest was returned).", space, name)
+	}
+	root, err := filepath.Abs(dir)
+	if err != nil {
+		return err
+	}
+	for _, rel := range files {
+		// Defense-in-depth: a manifest path is server-provided; never let one escape the target dir
+		// (e.g. "../../.ssh/authorized_keys"). Upload already sanitizes paths, but a filesystem write
+		// driven by a network response must contain itself.
+		dest := filepath.Join(root, filepath.FromSlash(rel))
+		if dest != root && !strings.HasPrefix(dest, root+string(os.PathSeparator)) {
+			return fmt.Errorf("refusing to write outside %s: %s", dir, rel)
+		}
+		cres, err := c.http.Get(contentURL + encodePath(rel) + "?raw=1")
+		if err != nil {
+			return err
+		}
+		if !ok(cres) {
+			code := cres.StatusCode
+			cres.Body.Close()
+			return fmt.Errorf("Could not pull %s (%d)", rel, code)
+		}
+		body, err := io.ReadAll(cres.Body)
+		cres.Body.Close()
+		if err != nil {
+			return err
+		}
+		if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+			return err
+		}
+		if err := os.WriteFile(dest, body, 0o644); err != nil {
+			return err
+		}
+	}
+	if err := writePullMarker(dir, pullMarker{Space: space, Name: name, ContentVersion: version}); err != nil {
+		return err
+	}
+	fmt.Fprintf(c.out, "Pulled %d file(s) → %s\n", len(files), dir)
+	return nil
 }

--- a/packages/web/src/components/ShareDialog.tsx
+++ b/packages/web/src/components/ShareDialog.tsx
@@ -3,7 +3,8 @@ import { useNavigate } from 'react-router'
 import { Check, Plus, Search, Share2 } from 'lucide-react'
 import { toast } from 'sonner'
 import { api } from '@/lib/api'
-import type { ShareSet, SpaceSummary, UserLite } from '@/lib/types'
+import { buildSharePayload } from '@/lib/shares'
+import type { ShareRole, ShareSet, SpaceSummary, UserLite } from '@/lib/types'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -36,6 +37,14 @@ function toggle(set: Set<string>, id: string): Set<string> {
   return next
 }
 
+// Add a user (default viewer) or remove them; preserves the role of everyone else.
+function toggleUser(map: Map<string, ShareRole>, id: string): Map<string, ShareRole> {
+  const next = new Map(map)
+  if (next.has(id)) next.delete(id)
+  else next.set(id, 'viewer')
+  return next
+}
+
 // Owner-only sharing: pick specific people and/or groups to grant access, on top of the
 // site's visibility tier. Data loads on open via a ref-callback on the dialog content (Radix
 // mounts it on every open — and a controlled/external open does NOT fire Radix onOpenChange,
@@ -50,7 +59,9 @@ export function ShareDialog({ spaceSlug, siteSlug, title, compact, open: openPro
   const [saving, setSaving] = useState(false)
   const [users, setUsers] = useState<UserLite[]>([])
   const [groups, setGroups] = useState<SpaceSummary[]>([])
-  const [selUsers, setSelUsers] = useState<Set<string>>(new Set())
+  // Per-user grant: id → role. A user in the map is shared-with (default 'viewer'); absent = not
+  // shared. Groups stay a plain Set — they're always view-only.
+  const [selUsers, setSelUsers] = useState<Map<string, ShareRole>>(new Map())
   const [selGroups, setSelGroups] = useState<Set<string>>(new Set())
   const [q, setQ] = useState('')
 
@@ -70,7 +81,10 @@ export function ShareDialog({ spaceSlug, siteSlug, title, compact, open: openPro
         .then(([us, sp, shares]) => {
           setUsers(us)
           setGroups(sp.filter((s) => s.type === 'group'))
-          setSelUsers(new Set(shares.userIds))
+          // Prefer the role-aware `users` list; fall back to legacy userIds (all viewers) if absent.
+          setSelUsers(
+            new Map(shares.users?.map((u) => [u.id, u.role]) ?? shares.userIds.map((id) => [id, 'viewer' as ShareRole])),
+          )
           setSelGroups(new Set(shares.groupIds))
         })
         .catch((err) =>
@@ -84,10 +98,7 @@ export function ShareDialog({ spaceSlug, siteSlug, title, compact, open: openPro
   async function save() {
     setSaving(true)
     try {
-      await api.put(`/api/sites/${spaceSlug}/${siteSlug}/shares`, {
-        userIds: [...selUsers],
-        groupIds: [...selGroups],
-      })
+      await api.put(`/api/sites/${spaceSlug}/${siteSlug}/shares`, buildSharePayload(selUsers, selGroups))
       toast.success('Sharing updated')
       setOpen(false)
     } catch (err) {
@@ -190,15 +201,23 @@ export function ShareDialog({ spaceSlug, siteSlug, title, compact, open: openPro
                 {shownUsers.length === 0 ? (
                   <p className="px-2 py-6 text-center text-sm text-muted-foreground">No people found.</p>
                 ) : (
-                  shownUsers.map((u) => (
-                    <Row
-                      key={u.id}
-                      checked={selUsers.has(u.id)}
-                      onToggle={() => setSelUsers((s) => toggle(s, u.id))}
-                      label={u.name ?? u.email}
-                      sub={u.name ? u.email : undefined}
-                    />
-                  ))
+                  shownUsers.map((u) => {
+                    const role = selUsers.get(u.id)
+                    return (
+                      <div key={u.id} className="flex items-center gap-2">
+                        <Row
+                          className="flex-1"
+                          checked={role !== undefined}
+                          onToggle={() => setSelUsers((s) => toggleUser(s, u.id))}
+                          label={u.name ?? u.email}
+                          sub={u.name ? u.email : undefined}
+                        />
+                        {role !== undefined && (
+                          <RolePicker role={role} onChange={(r) => setSelUsers((s) => new Map(s).set(u.id, r))} />
+                        )}
+                      </div>
+                    )
+                  })
                 )}
               </div>
             </div>
@@ -224,17 +243,19 @@ function Row({
   onToggle,
   label,
   sub,
+  className,
 }: {
   checked: boolean
   onToggle: () => void
   label: string
   sub?: string
+  className?: string
 }) {
   return (
     <button
       type="button"
       onClick={onToggle}
-      className="flex w-full items-center gap-3 rounded-md px-2 py-1.5 text-left hover:bg-muted"
+      className={cn('flex w-full items-center gap-3 rounded-md px-2 py-1.5 text-left hover:bg-muted', className)}
     >
       <span
         className={cn(
@@ -249,5 +270,28 @@ function Row({
         {sub && <span className="block truncate text-xs text-muted-foreground">{sub}</span>}
       </span>
     </button>
+  )
+}
+
+// Segmented Viewer|Editor toggle shown beside a selected person. Editor = may redeploy the site's
+// content (never rename/move/delete). Groups get no such control — they stay view-only.
+function RolePicker({ role, onChange }: { role: ShareRole; onChange: (r: ShareRole) => void }) {
+  return (
+    <div className="flex shrink-0 overflow-hidden rounded-md border text-xs">
+      {(['viewer', 'editor'] as const).map((r) => (
+        <button
+          key={r}
+          type="button"
+          onClick={() => onChange(r)}
+          aria-pressed={role === r}
+          className={cn(
+            'px-2 py-1 capitalize transition-colors',
+            role === r ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:bg-muted',
+          )}
+        >
+          {r}
+        </button>
+      ))}
+    </div>
   )
 }

--- a/packages/web/src/components/siteColumns.tsx
+++ b/packages/web/src/components/siteColumns.tsx
@@ -26,6 +26,8 @@ export function nameColumn<T extends SiteSummary>(): Column<T> {
         {s.audio && <Mic className="size-3.5 shrink-0 text-primary" aria-label="Audio" />}
         <span className="truncate font-medium">{s.title ?? s.siteSlug}</span>
         {s.status === 'archived' && <Badge variant="secondary">archived</Badge>}
+        {/* "Shared with me" feed only: an editor grantee can redeploy this site's content. */}
+        {s.role === 'editor' && <Badge>You can edit</Badge>}
       </div>
     ),
   }

--- a/packages/web/src/lib/shares.test.ts
+++ b/packages/web/src/lib/shares.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from 'bun:test'
+import { buildSharePayload } from './shares'
+
+describe('buildSharePayload — ShareDialog selection → PUT body', () => {
+  test('shareDialog.role.map: selecting Editor sends role editor (Map, not Set)', () => {
+    const selUsers = new Map<string, 'viewer' | 'editor'>([
+      ['a', 'editor'],
+      ['b', 'viewer'],
+    ])
+    expect(buildSharePayload(selUsers, new Set(['g1']))).toEqual({
+      users: [
+        { id: 'a', role: 'editor' },
+        { id: 'b', role: 'viewer' },
+      ],
+      groupIds: ['g1'],
+    })
+  })
+
+  test('empty selection → empty payload', () => {
+    expect(buildSharePayload(new Map(), new Set())).toEqual({ users: [], groupIds: [] })
+  })
+})

--- a/packages/web/src/lib/shares.ts
+++ b/packages/web/src/lib/shares.ts
@@ -1,0 +1,14 @@
+import type { ShareRole } from './types'
+
+// Pure builder for the PUT /shares payload from the ShareDialog's selection state. Users carry a
+// role (viewer|editor) — a Map, not a Set — so "grant edit" round-trips; groups stay view-only (no
+// role). Kept pure + exported so the role-mapping invariant is unit-tested without the dialog.
+export function buildSharePayload(
+  selUsers: Map<string, ShareRole>,
+  selGroups: Set<string>,
+): { users: { id: string; role: ShareRole }[]; groupIds: string[] } {
+  return {
+    users: [...selUsers].map(([id, role]) => ({ id, role })),
+    groupIds: [...selGroups],
+  }
+}

--- a/packages/web/src/lib/types.ts
+++ b/packages/web/src/lib/types.ts
@@ -36,6 +36,9 @@ export interface SiteSummary {
   visibility: Visibility
   status: SiteStatus
   audio?: boolean // every file is audio — a recording/voice site; shows a Mic badge
+  // The caller's direct-share role on this site — set on the "Shared with me" feed so an editor row
+  // shows a "You can edit" badge. Absent on owned/team feeds.
+  role?: ShareRole
   url: string
   createdAt: string
 }
@@ -65,9 +68,13 @@ export interface UserLite {
   name: string | null
 }
 
+export type ShareRole = 'viewer' | 'editor'
+
 export interface ShareSet {
   userIds: string[]
   groupIds: string[]
+  // Role-aware user list (superset of userIds). Present on the new API; a viewer is the default.
+  users: { id: string; role: ShareRole }[]
 }
 
 export type SlugExists = { exists: false } | { exists: true; owned: boolean }


### PR DESCRIPTION
Grant one named person **edit** (content-replace redeploy) access to a site — not the whole team — enforced server-side, with a CLI source round-trip so it works in a no-git world. Fully additive: no existing command, gate, or response shape changes behavior.

## What you can do now
- In the **Share dialog**, give a specific person **Viewer** or **Editor** (groups stay view-only).
- An **editor** can `glance read <space/site> --pull ./dir` → edit → `glance deploy ./dir` to redeploy that site's *content* — without owning it or being in its space. No browser, no git.
- The dashboard's "Shared with me" shows a **"You can edit"** badge on editor rows.

## Scope of an editor grant
Editor = **content replace only**. Rename / move / delete / visibility / title stay owner-or-superadmin. Editor replaces are content-only, blocked on archived sites, and **`contentVersion` CAS-guarded** (a stale redeploy 409s instead of clobbering a newer one). Owner replaces are unchanged (version bump is advisory).

## Phases (5 revertable commits, each gated by a thermo-nuclear review + full suite + tsc/lint/build)
1. **Data model** — migration `0009` (`site_user_shares.role`, `sites.contentVersion`, `sites.lastReplacedBy`); `resolveShareRole`; role-aware + backward-compatible `PUT/GET /shares`.
2. **Enforcement** — resolve the site before authorizing so a non-member editor can REPLACE; content-only + archived-block + version CAS (`.returning()` miss → 409, files untouched).
3. **Read endpoints** — gated file manifest, `/exists` → `canReplace`, content-worker `?raw=1` (raw source for the pull); canonical `canReplace()` helper.
4. **Go CLI** — `read --pull <dir>` (manifest → raw fetch → tree + `.glance/pull.json`) and version-aware `deploy` (sends `expectedVersion`, targets the pulled site, `canReplace` gate); path-traversal guard.
5. **Web UI** — segmented Viewer|Editor control + `/shared` role + "You can edit" badge.

## Testing
Full suite green: **api 385 · web 73 · go all pass**; tsc + lint + `build:web` clean. New coverage includes the CAS-concurrent race, stale-version-leaves-files-untouched, non-member-editor-replace, gated-manifest, raw-source pull, and the pull path-traversal guard.

The ShareDialog segmented control and the badge render are `build:web` + typecheck verified — the web package has no component-render harness, and the two-user "shared with me" badge scenario is proven at the API layer (`shared.response.role`), per CLAUDE.md's testing guidance.

## Screenshots

**Share dialog — per-person Viewer│Editor control** (owner grants one named person Editor):

![Share dialog with Viewer/Editor segmented control](https://github.com/plivo-labs/glance/releases/download/assets-pr34-editor-share/es-share-dialog.png)

**"You can edit" badge** in the recipient's *Shared with me* feed:

![You can edit badge](https://github.com/plivo-labs/glance/releases/download/assets-pr34-editor-share/es-editor-badge.png)

## Residual risk (accepted, documented)
**Confused-deputy on `glance.db`:** an editor can plant JS in a site; when the *owner* opens it, that script runs with the owner's `glance.db` caps. Signed off as accepted (editor = semi-trusted, git-collaborator model); `dataCapsFor` stays owner-keyed and is pinned by `dataCaps.editor.pin`. A `SECURITY` note records the deferred mitigation (gate on `lastReplacedBy`).

Live TDD ledger: https://glance.plivo.com/samuel-lawerence/editor-share-progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WgWXz4uyaMk9LxsmtzbGEL
