### PR TITLE
Comments tab: one merged feed of mentions + authored comments

### DIFF
--- a/packages/api/drizzle/0012_comments_author_index.sql
+++ b/packages/api/drizzle/0012_comments_author_index.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS `comments_author`;--> statement-breakpoint
+CREATE INDEX `comments_author_deleted_created` ON `comments` (`authorId`,`deletedAt`,`createdAt`);

--- a/packages/api/drizzle/meta/_journal.json
+++ b/packages/api/drizzle/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1783400100000,
       "tag": "0011_whats_new_watermark",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "6",
+      "when": 1783843200000,
+      "tag": "0012_comments_author_index",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/src/db/comment-feed.test.ts
+++ b/packages/api/src/db/comment-feed.test.ts
@@ -1,0 +1,538 @@
+// Comments-feed DB layer specs. C1.1 pins migration 0012: the single-column
+// comments_author index is replaced by (authorId, deletedAt, createdAt) so the
+// authored-arm feed scan (deletedAt IS NULL ORDER BY createdAt DESC) is covered.
+import { describe, expect, test } from 'bun:test'
+import { sql } from 'drizzle-orm'
+import type { SessionUser } from '../types'
+import {
+  makeDb,
+  seedComment,
+  seedMember,
+  seedNotification,
+  seedSite,
+  seedSpace,
+  seedThread,
+  seedUser,
+} from '../test/harness'
+import {
+  assembleCommentFeed,
+  authoredCandidatesStmt,
+  type AuthoredCandidateRow,
+  mentionCandidatesStmt,
+  type MentionCandidateRow,
+} from './comment-feed'
+import { foldSharedSiteRoles } from './repo'
+
+describe('migration 0012 — comments author index', () => {
+  test('C1.1 comments_author_deleted_created has exactly (authorId, deletedAt, createdAt); comments_author is gone', async () => {
+    const db = makeDb()
+    const cols = await db.all(
+      sql`SELECT name FROM pragma_index_info('comments_author_deleted_created') ORDER BY seqno`,
+    )
+    expect(cols).toEqual([{ name: 'authorId' }, { name: 'deletedAt' }, { name: 'createdAt' }])
+    const old = await db.all(sql`SELECT name FROM pragma_index_list('comments') WHERE name = 'comments_author'`)
+    expect(old).toEqual([])
+  })
+})
+
+describe('comments feed candidate statements', () => {
+  test('C2.1 authored and mention candidates carry their space and site slugs through one batch', async () => {
+    const db = makeDb()
+    const userId = await seedUser(db)
+    const spaceA = await seedSpace(db, { createdBy: userId, slug: 'space-a' })
+    const spaceB = await seedSpace(db, { createdBy: userId, slug: 'space-b' })
+    await seedMember(db, spaceA, userId)
+    await seedMember(db, spaceB, userId)
+    const siteA = await seedSite(db, { spaceId: spaceA, ownerId: userId, slug: 'site-a' })
+    const siteB = await seedSite(db, { spaceId: spaceB, ownerId: userId, slug: 'site-b' })
+    const threadA = await seedThread(db, { siteId: siteA, filePath: 'a.html' })
+    const threadB = await seedThread(db, { siteId: siteB, filePath: 'b.html' })
+    await seedComment(db, { threadId: threadA, authorId: userId })
+    await seedComment(db, { threadId: threadB, authorId: userId })
+    await seedNotification(db, { recipientId: userId, threadId: threadA, siteId: siteA })
+    await seedNotification(db, { recipientId: userId, threadId: threadB, siteId: siteB })
+
+    const [authored, mentioned] = await db.batch([
+      authoredCandidatesStmt(db, userId),
+      mentionCandidatesStmt(db, userId),
+    ])
+
+    expect(authored.map((row) => [row.spaceSlug, row.siteSlug]).sort()).toEqual([
+      ['space-a', 'site-a'],
+      ['space-b', 'site-b'],
+    ])
+    expect(mentioned.map((row) => [row.spaceSlug, row.siteSlug]).sort()).toEqual([
+      ['space-a', 'site-a'],
+      ['space-b', 'site-b'],
+    ])
+  })
+
+  test('C2.2 authored candidates exclude a soft-deleted comment beside a live timestamp tie', async () => {
+    const db = makeDb()
+    const userId = await seedUser(db)
+    const spaceId = await seedSpace(db, { createdBy: userId })
+    await seedMember(db, spaceId, userId)
+    const siteId = await seedSite(db, { spaceId, ownerId: userId })
+    const threadId = await seedThread(db, { siteId, filePath: 'index.html' })
+    const createdAt = '2026-07-11T10:00:00.000Z'
+    const liveId = await seedComment(db, { threadId, authorId: userId, createdAt })
+    await seedComment(db, {
+      threadId,
+      authorId: userId,
+      createdAt,
+      deletedAt: '2026-07-11T10:01:00.000Z',
+    })
+
+    const [authored] = await db.batch([authoredCandidatesStmt(db, userId)])
+
+    expect(authored.map((row) => row.id)).toEqual([liveId])
+  })
+
+  test('C2.3 mention candidates preserve named, email-only, and deleted actor states', async () => {
+    const db = makeDb()
+    const userId = await seedUser(db)
+    const namedActorId = await seedUser(db, { email: 'named@example.com', name: 'Named Actor' })
+    const emailActorId = await seedUser(db, { email: 'email-only@example.com', name: null })
+    const spaceId = await seedSpace(db, { createdBy: userId })
+    await seedMember(db, spaceId, userId)
+    const siteId = await seedSite(db, { spaceId, ownerId: userId })
+    const threadId = await seedThread(db, { siteId, filePath: 'index.html' })
+    const namedNotificationId = await seedNotification(db, {
+      recipientId: userId,
+      actorId: namedActorId,
+      siteId,
+      threadId,
+    })
+    const emailNotificationId = await seedNotification(db, {
+      recipientId: userId,
+      actorId: emailActorId,
+      siteId,
+      threadId,
+    })
+    const deletedNotificationId = await seedNotification(db, {
+      recipientId: userId,
+      actorId: null,
+      siteId,
+      threadId,
+    })
+
+    const [mentioned] = await db.batch([mentionCandidatesStmt(db, userId)])
+
+    expect(mentioned.map((row) => [row.id, row.actorName, row.actorEmail]).sort()).toEqual(
+      [
+        [namedNotificationId, 'Named Actor', 'named@example.com'],
+        [emailNotificationId, null, 'email-only@example.com'],
+        [deletedNotificationId, null, null],
+      ].sort(),
+    )
+  })
+
+  test('C2.4 mention candidates require a thread and derive the site only from that thread', async () => {
+    const db = makeDb()
+    const userId = await seedUser(db)
+    const ownerX = await seedUser(db)
+    const ownerY = await seedUser(db)
+    const spaceX = await seedSpace(db, { createdBy: ownerX, slug: 'space-x' })
+    const spaceY = await seedSpace(db, { createdBy: ownerY, slug: 'space-y' })
+    await seedMember(db, spaceX, userId)
+    await seedMember(db, spaceY, userId)
+    const siteX = await seedSite(db, { spaceId: spaceX, ownerId: ownerX, slug: 'site-x' })
+    const siteY = await seedSite(db, { spaceId: spaceY, ownerId: ownerY, slug: 'site-y' })
+    const threadY = await seedThread(db, { siteId: siteY, filePath: 'y.html' })
+    const orphanId = await seedNotification(db, { recipientId: userId, threadId: null, siteId: siteX })
+    const validId = await seedNotification(db, { recipientId: userId, threadId: threadY, siteId: siteY })
+    const mismatchedSiteId = await seedNotification(db, {
+      recipientId: userId,
+      threadId: threadY,
+      siteId: siteX,
+    })
+    const nullSiteId = await seedNotification(db, { recipientId: userId, threadId: threadY, siteId: null })
+
+    const [mentioned] = await db.batch([mentionCandidatesStmt(db, userId)])
+
+    expect(mentioned.map((row) => [row.id, row.siteSlug, row.ownerId]).sort()).toEqual(
+      [
+        [validId, 'site-y', ownerY],
+        [mismatchedSiteId, 'site-y', ownerY],
+        [nullSiteId, 'site-y', ownerY],
+      ].sort(),
+    )
+    expect(mentioned.some((row) => row.id === orphanId)).toBe(false)
+  })
+
+  test('C2.6 per-arm scan window keeps exactly the newest 200 of 205, rowid breaking timestamp ties', async () => {
+    const ts = (n: number) => new Date(Date.UTC(2026, 0, 1, 0, 0, 0) + n * 1000).toISOString()
+    const createdAtFor = (n: number) => (n === 200 || n === 201 || n === 202 ? ts(200) : ts(n))
+    type Seeded = { n: number; id: string; createdAt: string; insertionIndex: number }
+    const expectedIds = (seeded: Seeded[]) =>
+      [...seeded]
+        .sort((a, b) => b.createdAt.localeCompare(a.createdAt) || b.insertionIndex - a.insertionIndex)
+        .slice(0, 200)
+        .map((r) => r.id)
+
+    const db = makeDb()
+    const userId = await seedUser(db)
+    const spaceId = await seedSpace(db, { createdBy: userId })
+    await seedMember(db, spaceId, userId)
+    const siteId = await seedSite(db, { spaceId, ownerId: userId })
+    const threadId = await seedThread(db, { siteId, filePath: 'index.html' })
+
+    const authoredByN = new Map<number, string>()
+    const authoredSeeded: Seeded[] = []
+    for (let i = 0; i < 205; i++) {
+      const n = (i * 97) % 205
+      const createdAt = createdAtFor(n)
+      const id = await seedComment(db, { threadId, authorId: userId, createdAt })
+      authoredByN.set(n, id)
+      authoredSeeded.push({ n, id, createdAt, insertionIndex: i })
+    }
+
+    const [authoredRows] = await db.batch([authoredCandidatesStmt(db, userId)])
+    expect(authoredRows.length).toBe(200)
+    for (let n = 0; n < 5; n++) {
+      expect(authoredRows.some((row) => row.id === authoredByN.get(n))).toBe(false)
+    }
+    expect(authoredRows.map((row) => row.id)).toEqual(expectedIds(authoredSeeded))
+
+    const mentionByN = new Map<number, string>()
+    const mentionSeeded: Seeded[] = []
+    for (let i = 0; i < 205; i++) {
+      const n = (i * 97) % 205
+      const createdAt = createdAtFor(n)
+      const id = await seedNotification(db, {
+        recipientId: userId,
+        threadId,
+        siteId,
+        snippet: `mention-${n}`,
+        createdAt,
+      })
+      mentionByN.set(n, id)
+      mentionSeeded.push({ n, id, createdAt, insertionIndex: i })
+    }
+
+    const [mentionRows] = await db.batch([mentionCandidatesStmt(db, userId)])
+    expect(mentionRows.length).toBe(200)
+    for (let n = 0; n < 5; n++) {
+      expect(mentionRows.some((row) => row.id === mentionByN.get(n))).toBe(false)
+    }
+    expect(mentionRows.map((row) => row.id)).toEqual(expectedIds(mentionSeeded))
+  })
+})
+
+function makeUser(overrides: Partial<SessionUser> = {}): SessionUser {
+  return {
+    id: 'user-1',
+    email: 'user@example.com',
+    name: 'Test User',
+    role: 'member',
+    ...overrides,
+  }
+}
+
+function authoredRow(overrides: Partial<AuthoredCandidateRow> = {}): AuthoredCandidateRow {
+  return {
+    id: 'authored-1',
+    body: 'Authored comment',
+    createdAt: '2026-07-11T10:00:00.000Z',
+    editedAt: null,
+    rowid: 1,
+    threadId: 'thread-1',
+    threadStatus: 'open',
+    filePath: 'index.html',
+    siteId: 'site-1',
+    siteSlug: 'site',
+    siteTitle: 'Site',
+    visibility: 'private',
+    siteStatus: 'active',
+    ownerId: 'user-1',
+    spaceId: 'space-1',
+    spaceSlug: 'space',
+    ...overrides,
+  }
+}
+
+function mentionRow(overrides: Partial<MentionCandidateRow> = {}): MentionCandidateRow {
+  return {
+    id: 'mention-1',
+    snippet: 'Mention snapshot',
+    createdAt: '2026-07-11T10:00:00.000Z',
+    rowid: 1,
+    actorName: 'Mentioner',
+    actorEmail: 'mentioner@example.com',
+    threadId: 'thread-1',
+    threadStatus: 'open',
+    filePath: 'index.html',
+    siteId: 'site-1',
+    siteSlug: 'site',
+    siteTitle: 'Site',
+    visibility: 'private',
+    siteStatus: 'active',
+    ownerId: 'user-1',
+    spaceId: 'space-1',
+    spaceSlug: 'space',
+    ...overrides,
+  }
+}
+
+describe('assembleCommentFeed', () => {
+  test('C3.1 merges candidates by timestamp, kind rank, then same-kind rowid', () => {
+    const result = assembleCommentFeed({
+      authored: [
+        authoredRow({ id: 'authored-tie-low', createdAt: '2026-07-11T11:00:00.000Z', rowid: 3 }),
+        authoredRow({ id: 'authored-kind-tie', createdAt: '2026-07-11T12:00:00.000Z', rowid: 99 }),
+        authoredRow({ id: 'authored-oldest', createdAt: '2026-07-11T10:00:00.000Z', rowid: 100 }),
+        authoredRow({ id: 'authored-tie-high', createdAt: '2026-07-11T11:00:00.000Z', rowid: 8 }),
+      ],
+      mentions: [
+        mentionRow({ id: 'mention-newest', createdAt: '2026-07-11T13:00:00.000Z', rowid: 1 }),
+        mentionRow({ id: 'mention-kind-tie', createdAt: '2026-07-11T12:00:00.000Z', rowid: 1 }),
+      ],
+      user: makeUser(),
+      memberSpaceIds: new Set(),
+      sharedSiteRoles: new Map(),
+    })
+
+    expect(result.map((row) => row.id)).toEqual([
+      'mention-newest',
+      'mention-kind-tie',
+      'authored-kind-tie',
+      'authored-tie-high',
+      'authored-tie-low',
+      'authored-oldest',
+    ])
+  })
+
+  test('C3.2 folds membership and shared-site facts through the access oracle', () => {
+    const groupRoles = foldSharedSiteRoles([], [{ siteId: 'site-private-group' }])
+    const directRoles = foldSharedSiteRoles(
+      [
+        { siteId: 'site-private-direct', role: 'editor' },
+        { siteId: 'site-archived-granted', role: 'viewer' },
+      ],
+      [],
+    )
+    const plainUserResult = assembleCommentFeed({
+      authored: [
+        authoredRow({
+          id: 'members-member',
+          siteId: 'site-members-keep',
+          spaceId: 'space-member',
+          visibility: 'members',
+          ownerId: 'someone-else',
+        }),
+        authoredRow({
+          id: 'private-group',
+          siteId: 'site-private-group',
+          visibility: 'private',
+          ownerId: 'someone-else',
+        }),
+        authoredRow({
+          id: 'private-no-grant',
+          siteId: 'site-private-none',
+          visibility: 'private',
+          ownerId: 'someone-else',
+        }),
+      ],
+      mentions: [
+        mentionRow({
+          id: 'members-non-member',
+          siteId: 'site-members-drop',
+          spaceId: 'space-non-member',
+          visibility: 'members',
+          ownerId: 'someone-else',
+        }),
+        mentionRow({
+          id: 'private-direct',
+          siteId: 'site-private-direct',
+          visibility: 'private',
+          ownerId: 'someone-else',
+        }),
+        mentionRow({
+          id: 'archived-plain-with-grant',
+          siteId: 'site-archived-granted',
+          visibility: 'private',
+          siteStatus: 'archived',
+          ownerId: 'someone-else',
+        }),
+      ],
+      user: makeUser(),
+      memberSpaceIds: new Set(['space-member']),
+      sharedSiteRoles: new Map([...groupRoles, ...directRoles]),
+    })
+    const superadminResult = assembleCommentFeed({
+      authored: [
+        authoredRow({
+          id: 'archived-superadmin',
+          siteId: 'site-archived-superadmin',
+          visibility: 'private',
+          siteStatus: 'archived',
+          ownerId: 'someone-else',
+        }),
+      ],
+      mentions: [],
+      user: makeUser({ role: 'superadmin' }),
+      memberSpaceIds: new Set(),
+      sharedSiteRoles: new Map(),
+    })
+
+    expect([...plainUserResult, ...superadminResult].map((row) => row.id).sort()).toEqual([
+      'archived-superadmin',
+      'members-member',
+      'private-direct',
+      'private-group',
+    ])
+  })
+
+  test('C3.3 limits the feed to the newest 50 with rowid breaking the boundary tie', () => {
+    const shuffledRanks = Array.from({ length: 60 }, (_, index) => ((index * 17) % 60) + 1)
+    const distinctRows = shuffledRanks.map((rank) =>
+      authoredRow({
+        id: `authored-${String(rank).padStart(2, '0')}`,
+        createdAt: `2026-07-11T10:${String(rank - 1).padStart(2, '0')}:00.000Z`,
+        rowid: rank,
+      }),
+    )
+    // Plain descending id sequence (60, 59, …) — ranks 11-60 need no zero padding.
+    const authoredIdsDescFrom60 = (count: number) =>
+      Array.from({ length: count }, (_, index) => `authored-${60 - index}`)
+    const expectedNewest = authoredIdsDescFrom60(50)
+
+    const distinctResult = assembleCommentFeed({
+      authored: distinctRows,
+      mentions: [],
+      user: makeUser(),
+      memberSpaceIds: new Set(),
+      sharedSiteRoles: new Map(),
+    })
+
+    expect(distinctResult.map((row) => row.id)).toEqual(expectedNewest)
+
+    const boundaryRows = distinctRows.map((row) => {
+      if (row.id === 'authored-10') {
+        return { ...row, id: 'boundary-high', createdAt: '2026-07-11T10:10:00.000Z', rowid: 900 }
+      }
+      if (row.id === 'authored-11') {
+        return { ...row, id: 'boundary-low', createdAt: '2026-07-11T10:10:00.000Z', rowid: 100 }
+      }
+      return row
+    })
+    // authored-60 … authored-12, then boundary-high wins the 10:10 tie on rowid.
+    const expectedBoundary = [...authoredIdsDescFrom60(49), 'boundary-high']
+
+    const boundaryResult = assembleCommentFeed({
+      authored: boundaryRows,
+      mentions: [],
+      user: makeUser(),
+      memberSpaceIds: new Set(),
+      sharedSiteRoles: new Map(),
+    })
+
+    expect(boundaryResult.map((row) => row.id)).toEqual(expectedBoundary)
+  })
+
+  test('C3.4 maps authored and mention candidates to exact public payloads', () => {
+    const authoredBody = 'x'.repeat(201)
+    const [authored] = assembleCommentFeed({
+      authored: [
+        authoredRow({
+          id: 'authored-payload',
+          body: authoredBody,
+          createdAt: '2026-07-11T14:00:00.000Z',
+          editedAt: '2026-07-11T14:05:00.000Z',
+          threadId: 'thread-authored',
+          threadStatus: 'resolved',
+          filePath: 'docs/authored.html',
+          siteId: 'internal-authored-site-id',
+          siteSlug: 'authored-site',
+          siteTitle: null,
+          spaceId: 'internal-authored-space-id',
+          spaceSlug: 'authored-space',
+          rowid: 77,
+        }),
+      ],
+      mentions: [],
+      user: makeUser(),
+      memberSpaceIds: new Set(),
+      sharedSiteRoles: new Map(),
+    })
+
+    expect(authored).toEqual({
+      kind: 'authored',
+      id: 'authored-payload',
+      snippet: 'x'.repeat(200),
+      actorName: null,
+      spaceSlug: 'authored-space',
+      siteSlug: 'authored-site',
+      siteTitle: null,
+      filePath: 'docs/authored.html',
+      threadId: 'thread-authored',
+      threadStatus: 'resolved',
+      createdAt: '2026-07-11T14:00:00.000Z',
+      editedAt: '2026-07-11T14:05:00.000Z',
+    })
+
+    for (const body of ['y'.repeat(199), 'z'.repeat(200)]) {
+      const [item] = assembleCommentFeed({
+        authored: [authoredRow({ body })],
+        mentions: [],
+        user: makeUser(),
+        memberSpaceIds: new Set(),
+        sharedSiteRoles: new Map(),
+      })
+      expect(item?.snippet).toBe(body)
+    }
+
+    const surrogateBody = `${'x'.repeat(199)}\u{1F600}`
+    const [surrogateItem] = assembleCommentFeed({
+      authored: [authoredRow({ body: surrogateBody })],
+      mentions: [],
+      user: makeUser(),
+      memberSpaceIds: new Set(),
+      sharedSiteRoles: new Map(),
+    })
+    expect(surrogateItem?.snippet?.length).toBe(199)
+    expect(surrogateItem?.snippet).toBe('x'.repeat(199))
+
+    // The notification snippet is a write-time snapshot: editing or deleting its source comment
+    // later does not change the feed payload.
+    const [mention] = assembleCommentFeed({
+      authored: [],
+      mentions: [
+        mentionRow({
+          id: 'mention-payload',
+          snippet: 'Stored mention snapshot',
+          actorName: 'Ada Mentioner',
+          actorEmail: 'ignored@example.com',
+          createdAt: '2026-07-11T15:00:00.000Z',
+          threadId: 'thread-mention',
+          threadStatus: 'open',
+          filePath: 'docs/mention.html',
+          siteId: 'internal-mention-site-id',
+          siteSlug: 'mention-site',
+          siteTitle: 'Mention Site',
+          spaceId: 'internal-mention-space-id',
+          spaceSlug: 'mention-space',
+          rowid: 88,
+        }),
+      ],
+      user: makeUser(),
+      memberSpaceIds: new Set(),
+      sharedSiteRoles: new Map(),
+    })
+
+    expect(mention).toEqual({
+      kind: 'mention',
+      id: 'mention-payload',
+      snippet: 'Stored mention snapshot',
+      actorName: 'Ada Mentioner',
+      spaceSlug: 'mention-space',
+      siteSlug: 'mention-site',
+      siteTitle: 'Mention Site',
+      filePath: 'docs/mention.html',
+      threadId: 'thread-mention',
+      threadStatus: 'open',
+      createdAt: '2026-07-11T15:00:00.000Z',
+      editedAt: null,
+    })
+  })
+})

--- a/packages/api/src/db/comment-feed.ts
+++ b/packages/api/src/db/comment-feed.ts
@@ -1,0 +1,172 @@
+import { and, desc, eq, isNull, sql } from 'drizzle-orm'
+import type { DrizzleD1Database } from 'drizzle-orm/d1'
+import { checkAccess } from '../lib/access'
+import type { SessionUser } from '../types'
+import {
+  comments,
+  commentThreads,
+  notifications,
+  sites,
+  spaces,
+  users,
+  type ThreadStatus,
+  type Visibility,
+} from './schema'
+
+type SiteStatus = (typeof sites.$inferSelect)['status']
+
+// Access filtering runs AFTER this newest-per-arm window, so a user whose newest 200
+// candidates are inaccessible sees an under-filled feed (accepted contract, pinned later
+// by route case C4.9; fix would be a bigger cap, never cursors).
+export const FEED_SCAN_WINDOW = 200
+export const FEED_LIMIT = 50
+export const FEED_SNIPPET_LENGTH = 200
+
+// Thread/site/space columns shared by both candidate arms. Every column is aliased with .as() —
+// D1 batch results map by result-column NAME, so unaliased join columns would silently collide.
+const THREAD_SITE_COLUMNS = {
+  threadId: sql<string>`${commentThreads.id}`.as('threadId'),
+  threadStatus: sql<ThreadStatus>`${commentThreads.status}`.as('threadStatus'),
+  filePath: sql<string>`${commentThreads.filePath}`.as('filePath'),
+  siteId: sql<string>`${sites.id}`.as('siteId'),
+  siteSlug: sql<string>`${sites.slug}`.as('siteSlug'),
+  siteTitle: sql<string | null>`${sites.title}`.as('siteTitle'),
+  visibility: sql<Visibility>`${sites.visibility}`.as('visibility'),
+  siteStatus: sql<SiteStatus>`${sites.status}`.as('siteStatus'),
+  ownerId: sql<string>`${sites.ownerId}`.as('ownerId'),
+  spaceId: sql<string>`${spaces.id}`.as('spaceId'),
+  spaceSlug: sql<string>`${spaces.slug}`.as('spaceSlug'),
+}
+
+const commentsRowid = sql<number>`"comments".rowid`
+const notificationsRowid = sql<number>`"notifications".rowid`
+
+export function authoredCandidatesStmt(db: DrizzleD1Database, userId: string) {
+  return db
+    .select({
+      id: sql<string>`${comments.id}`.as('id'),
+      body: sql<string>`${comments.body}`.as('body'),
+      createdAt: sql<string>`${comments.createdAt}`.as('createdAt'),
+      editedAt: sql<string | null>`${comments.editedAt}`.as('editedAt'),
+      rowid: commentsRowid.as('rowid'),
+      ...THREAD_SITE_COLUMNS,
+    })
+    .from(comments)
+    .innerJoin(commentThreads, eq(comments.threadId, commentThreads.id))
+    .innerJoin(sites, eq(commentThreads.siteId, sites.id))
+    .innerJoin(spaces, eq(sites.spaceId, spaces.id))
+    .where(and(eq(comments.authorId, userId), isNull(comments.deletedAt)))
+    .orderBy(desc(comments.createdAt), desc(commentsRowid))
+    .limit(FEED_SCAN_WINDOW)
+}
+
+export function mentionCandidatesStmt(db: DrizzleD1Database, userId: string) {
+  return db
+    .select({
+      id: sql<string>`${notifications.id}`.as('id'),
+      snippet: sql<string | null>`${notifications.snippet}`.as('snippet'),
+      createdAt: sql<string>`${notifications.createdAt}`.as('createdAt'),
+      rowid: notificationsRowid.as('rowid'),
+      actorName: sql<string | null>`${users.name}`.as('actorName'),
+      actorEmail: sql<string | null>`${users.email}`.as('actorEmail'),
+      ...THREAD_SITE_COLUMNS,
+    })
+    .from(notifications)
+    .innerJoin(commentThreads, eq(notifications.threadId, commentThreads.id))
+    .innerJoin(sites, eq(commentThreads.siteId, sites.id))
+    .innerJoin(spaces, eq(sites.spaceId, spaces.id))
+    .leftJoin(users, eq(notifications.actorId, users.id))
+    .where(and(eq(notifications.recipientId, userId), eq(notifications.type, 'mention')))
+    .orderBy(desc(notifications.createdAt), desc(notificationsRowid))
+    .limit(FEED_SCAN_WINDOW)
+}
+
+export type AuthoredCandidateRow = Awaited<ReturnType<typeof authoredCandidatesStmt>>[number]
+export type MentionCandidateRow = Awaited<ReturnType<typeof mentionCandidatesStmt>>[number]
+
+export type CommentFeedItem = {
+  kind: 'mention' | 'authored'
+  id: string
+  snippet: string | null
+  actorName: string | null
+  spaceSlug: string
+  siteSlug: string
+  siteTitle: string | null
+  filePath: string
+  threadId: string
+  threadStatus: ThreadStatus
+  createdAt: string
+  editedAt: string | null
+}
+
+type FeedCandidate =
+  | { kind: 'mention'; row: MentionCandidateRow }
+  | { kind: 'authored'; row: AuthoredCandidateRow }
+
+const KIND_RANK = { mention: 0, authored: 1 } as const
+
+function snippet(body: string): string {
+  const s = body.slice(0, FEED_SNIPPET_LENGTH)
+  return s.length === FEED_SNIPPET_LENGTH && /[\uD800-\uDBFF]$/.test(s) ? s.slice(0, -1) : s
+}
+
+function compareFeedCandidates(a: FeedCandidate, b: FeedCandidate): number {
+  return (
+    b.row.createdAt.localeCompare(a.row.createdAt) ||
+    KIND_RANK[a.kind] - KIND_RANK[b.kind] ||
+    b.row.rowid - a.row.rowid
+  )
+}
+
+function toCommentFeedItem(candidate: FeedCandidate): CommentFeedItem {
+  const { row } = candidate
+  const common = {
+    id: row.id,
+    spaceSlug: row.spaceSlug,
+    siteSlug: row.siteSlug,
+    siteTitle: row.siteTitle,
+    filePath: row.filePath,
+    threadId: row.threadId,
+    threadStatus: row.threadStatus,
+    createdAt: row.createdAt,
+  }
+  return candidate.kind === 'authored'
+    ? {
+        kind: 'authored',
+        ...common,
+        snippet: snippet(candidate.row.body),
+        actorName: null,
+        editedAt: candidate.row.editedAt,
+      }
+    : {
+        kind: 'mention',
+        ...common,
+        snippet: candidate.row.snippet,
+        actorName: candidate.row.actorName ?? candidate.row.actorEmail ?? null,
+        editedAt: null,
+      }
+}
+
+export function assembleCommentFeed(input: {
+  authored: AuthoredCandidateRow[]
+  mentions: MentionCandidateRow[]
+  user: SessionUser
+  memberSpaceIds: Set<string>
+  sharedSiteRoles: { has(siteId: string): boolean }
+}): CommentFeedItem[] {
+  return [
+    ...input.mentions.map((row) => ({ kind: 'mention' as const, row })),
+    ...input.authored.map((row) => ({ kind: 'authored' as const, row })),
+  ]
+    .filter(({ row }) =>
+      checkAccess(
+        { visibility: row.visibility, status: row.siteStatus, ownerId: row.ownerId },
+        input.user,
+        input.memberSpaceIds.has(row.spaceId),
+        input.sharedSiteRoles.has(row.siteId),
+      ).ok,
+    )
+    .sort(compareFeedCandidates)
+    .slice(0, FEED_LIMIT)
+    .map(toCommentFeedItem)
+}

--- a/packages/api/src/db/comment-feed.ts
+++ b/packages/api/src/db/comment-feed.ts
@@ -18,9 +18,9 @@ type SiteStatus = (typeof sites.$inferSelect)['status']
 // Access filtering runs AFTER this newest-per-arm window, so a user whose newest 200
 // candidates are inaccessible sees an under-filled feed (accepted contract, pinned later
 // by route case C4.9; fix would be a bigger cap, never cursors).
-export const FEED_SCAN_WINDOW = 200
-export const FEED_LIMIT = 50
-export const FEED_SNIPPET_LENGTH = 200
+const FEED_SCAN_WINDOW = 200
+const FEED_LIMIT = 50
+const FEED_SNIPPET_LENGTH = 200
 
 // Thread/site/space columns shared by both candidate arms. Every column is aliased with .as() —
 // D1 batch results map by result-column NAME, so unaliased join columns would silently collide.
@@ -105,7 +105,7 @@ type FeedCandidate =
 
 const KIND_RANK = { mention: 0, authored: 1 } as const
 
-function snippet(body: string): string {
+export function truncateSnippet(body: string): string {
   const s = body.slice(0, FEED_SNIPPET_LENGTH)
   return s.length === FEED_SNIPPET_LENGTH && /[\uD800-\uDBFF]$/.test(s) ? s.slice(0, -1) : s
 }
@@ -134,7 +134,7 @@ function toCommentFeedItem(candidate: FeedCandidate): CommentFeedItem {
     ? {
         kind: 'authored',
         ...common,
-        snippet: snippet(candidate.row.body),
+        snippet: truncateSnippet(candidate.row.body),
         actorName: null,
         editedAt: candidate.row.editedAt,
       }

--- a/packages/api/src/db/repo.ts
+++ b/packages/api/src/db/repo.ts
@@ -216,7 +216,7 @@ export function memberSpaceIdsStmt(db: DrizzleD1Database, userId: string) {
 /** Set of space ids the user is a member of (mirrors `sharedSiteIds` for the search candidate query). */
 export async function memberSpaceIds(db: DrizzleD1Database, userId: string): Promise<Set<string>> {
   const rows = await memberSpaceIdsStmt(db, userId)
-  return new Set(rows.map((r) => r.spaceId))
+  return foldMemberSpaceIds(rows)
 }
 
 /**
@@ -248,6 +248,11 @@ export function foldSharedSiteRoles(
   for (const r of viaGroup) roles.set(r.siteId, 'viewer')
   for (const r of direct) roles.set(r.siteId, r.role) // direct wins over group-derived viewer
   return roles
+}
+
+/** Fold the `memberSpaceIdsStmt` batched rows into a Set of space ids. */
+export function foldMemberSpaceIds(rows: { spaceId: string }[]): Set<string> {
+  return new Set(rows.map((r) => r.spaceId))
 }
 
 /** Set of site ids explicitly shared with the user (direct + via group membership). Derived from

--- a/packages/api/src/db/repo.ts
+++ b/packages/api/src/db/repo.ts
@@ -204,12 +204,18 @@ export async function resolveShareRole(
   return row[0]?.role ?? null
 }
 
-/** Set of space ids the user is a member of (mirrors `sharedSiteIds` for the search candidate query). */
-export async function memberSpaceIds(db: DrizzleD1Database, userId: string): Promise<Set<string>> {
-  const rows = await db
+/** The membership SELECT behind `memberSpaceIds`, exposed (like `sharedSiteRoleStmts`) so a route
+ *  can ride it in its OWN db.batch alongside other statements. */
+export function memberSpaceIdsStmt(db: DrizzleD1Database, userId: string) {
+  return db
     .select({ spaceId: spaceMembers.spaceId })
     .from(spaceMembers)
     .where(eq(spaceMembers.userId, userId))
+}
+
+/** Set of space ids the user is a member of (mirrors `sharedSiteIds` for the search candidate query). */
+export async function memberSpaceIds(db: DrizzleD1Database, userId: string): Promise<Set<string>> {
+  const rows = await memberSpaceIdsStmt(db, userId)
   return new Set(rows.map((r) => r.spaceId))
 }
 

--- a/packages/api/src/db/schema.ts
+++ b/packages/api/src/db/schema.ts
@@ -160,7 +160,11 @@ export const comments = sqliteTable(
     // holds the server-side transcript so the CLI/agent review loop still reads everything as text.
     audioKey: text('audioKey'),
   },
-  (t) => [index('comments_thread_created').on(t.threadId, t.createdAt), index('comments_author').on(t.authorId)],
+  (t) => [
+    index('comments_thread_created').on(t.threadId, t.createdAt),
+    // Covers the authored feed arm: WHERE authorId = ? AND deletedAt IS NULL ORDER BY createdAt DESC.
+    index('comments_author_deleted_created').on(t.authorId, t.deletedAt, t.createdAt),
+  ],
 )
 
 // Generic per-site document store backing the browser `glance.db` SDK (shared backend).

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -10,6 +10,7 @@ import { trackCliUsage } from './middleware/analytics'
 import { requireSameOrigin } from './middleware/auth'
 import { admin } from './routes/admin'
 import { auth } from './routes/auth'
+import { commentFeed } from './routes/comment-feed'
 import { comments } from './routes/comments'
 import { dataApi, dataToken } from './routes/data'
 import { notifications } from './routes/notifications'
@@ -96,6 +97,7 @@ app.route('/api/sites', sites)
 // Comments live under /api/sites/:space/:site/comments — three segments, so no collision with
 // the two-segment site routes above. Mounted separately to keep the comments surface isolated.
 app.route('/api/sites', comments)
+app.route('/api/comments', commentFeed)
 app.route('/api/upload', upload)
 // Session-authenticated mint for shared-backend data tokens (owner → read+write, viewer → read).
 app.route('/api/data-token', dataToken)

--- a/packages/api/src/routes/comment-feed.test.ts
+++ b/packages/api/src/routes/comment-feed.test.ts
@@ -1,0 +1,596 @@
+import { describe, expect, test } from 'bun:test'
+import { and, eq } from 'drizzle-orm'
+import type { CommentFeedItem } from '../db/comment-feed'
+import { comments, sites, siteUserShares, spaceMembers, users } from '../db/schema'
+import realApp from '../index'
+import type { AppEnv } from '../types'
+import {
+  makeKv,
+  seedComment,
+  seedGroupShare,
+  seedMember,
+  seedNotification,
+  seedSite,
+  seedSpace,
+  seedThread,
+  seedUserShare,
+} from '../test/harness'
+import { APP_URL, at, auth, makeRouteApp, mintUser, type RouteApp } from '../test/route-fixtures'
+
+const FEED_URL = '/api/comments/feed'
+
+async function seedGoldenFeed(db: RouteApp['db'], kv: RouteApp['kv']) {
+  const userId = await mintUser(db, kv, 'feed-user')
+  const actorId = await mintUser(db, kv, 'mention-actor', { email: 'actor@example.com' })
+  const spaceId = await seedSpace(db, { id: 'space-feed', createdBy: userId, slug: 'design', name: 'Design' })
+  await seedMember(db, spaceId, userId)
+  const siteId = await seedSite(db, {
+    id: 'site-feed',
+    spaceId,
+    ownerId: userId,
+    slug: 'review',
+    title: 'Review Board',
+    visibility: 'private',
+  })
+  const authoredThreadId = await seedThread(db, {
+    id: 'thread-authored',
+    siteId,
+    filePath: 'src/authored.ts',
+    status: 'open',
+    createdBy: userId,
+  })
+  await seedComment(db, {
+    id: 'comment-authored',
+    threadId: authoredThreadId,
+    authorId: userId,
+    body: 'Authored body',
+    createdAt: at(1),
+    editedAt: at(2),
+  })
+  const mentionThreadId = await seedThread(db, {
+    id: 'thread-mention',
+    siteId,
+    filePath: 'src/mention.ts',
+    status: 'resolved',
+    createdBy: actorId,
+  })
+  await seedNotification(db, {
+    id: 'notification-mention',
+    recipientId: userId,
+    actorId,
+    siteId,
+    siteLabel: 'must-not-leak/review',
+    threadId: mentionThreadId,
+    filePath: 'must-not-leak.ts',
+    snippet: 'Please review this.',
+    readAt: at(4),
+    createdAt: at(3),
+  })
+  return userId
+}
+
+/** Project a feed payload down to `{ kind, id }` for order/identity assertions. */
+function kindIds(items: unknown): Array<{ kind: string; id: string }> {
+  return (items as CommentFeedItem[]).map(({ kind, id }) => ({ kind, id }))
+}
+
+function expectRequestBudget(db: RouteApp['db']) {
+  expect(db.counters).toEqual({ loose: 1, batches: 1, batchStmts: 5, insert: 0, update: 0, delete: 0 })
+}
+
+describe('comment feed route — C4.1 auth', () => {
+  test('anonymous request returns the exact unauthorized response', async () => {
+    const { app, env } = makeRouteApp()
+
+    const res = await app.request(FEED_URL, {}, env)
+
+    expect(res.status).toBe(401)
+    expect(await res.json()).toEqual({ error: 'unauthorized' })
+  })
+
+  test('a valid token for a deleted user is rejected before the feed batch', async () => {
+    const { app, env, db, kv } = makeRouteApp()
+    const userId = await mintUser(db, kv, 'deleted-user')
+    await db.delete(users).where(eq(users.id, userId))
+    db.resetCounters()
+
+    const res = await app.request(FEED_URL, { headers: auth(userId) }, env)
+
+    expect(res.status).toBe(401)
+    expect(await res.json()).toEqual({ error: 'unauthorized' })
+    expect(db.counters.batches).toBe(0)
+  })
+})
+
+describe('comment feed route — C4.6 root-app composition', () => {
+  test('the real app mounts /api/comments/feed', async () => {
+    const env = {
+      APP_URL,
+      CONTENT_URL: 'https://content.example.com',
+      GLANCE_DB: {},
+      GLANCE_SESSIONS: makeKv(),
+    } as unknown as AppEnv['Bindings']
+
+    const res = await realApp.request(FEED_URL, {}, env)
+
+    expect(res.status).toBe(401)
+    expect(res.status).not.toBe(404)
+    expect(await res.json()).toEqual({ error: 'unauthorized' })
+  })
+})
+
+describe('comment feed route — C4.2 golden contract', () => {
+  test('returns the exact newest-first authored and mention payload', async () => {
+    const { app, env, db, kv } = makeRouteApp()
+    const userId = await seedGoldenFeed(db, kv)
+
+    const res = await app.request(FEED_URL, { headers: auth(userId) }, env)
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual([
+      {
+        kind: 'mention',
+        id: 'notification-mention',
+        snippet: 'Please review this.',
+        actorName: 'actor@example.com',
+        spaceSlug: 'design',
+        siteSlug: 'review',
+        siteTitle: 'Review Board',
+        filePath: 'src/mention.ts',
+        threadId: 'thread-mention',
+        threadStatus: 'resolved',
+        createdAt: '2026-01-01T00:00:03.000Z',
+        editedAt: null,
+      },
+      {
+        kind: 'authored',
+        id: 'comment-authored',
+        snippet: 'Authored body',
+        actorName: null,
+        spaceSlug: 'design',
+        siteSlug: 'review',
+        siteTitle: 'Review Board',
+        filePath: 'src/authored.ts',
+        threadId: 'thread-authored',
+        threadStatus: 'open',
+        createdAt: '2026-01-01T00:00:01.000Z',
+        editedAt: '2026-01-01T00:00:02.000Z',
+      },
+    ])
+  })
+})
+
+describe('comment feed route — C4.4 request budget', () => {
+  test('a populated feed uses one auth read and one five-statement batch with no writes', async () => {
+    const { app, env, db, kv } = makeRouteApp()
+    const userId = await seedGoldenFeed(db, kv)
+    db.resetCounters()
+
+    const res = await app.request(FEED_URL, { headers: auth(userId) }, env)
+
+    expect(res.status).toBe(200)
+    expectRequestBudget(db)
+  })
+
+  test('an empty feed keeps the same request budget', async () => {
+    const { app, env, db, kv } = makeRouteApp()
+    const userId = await mintUser(db, kv, 'empty-user')
+    db.resetCounters()
+
+    const res = await app.request(FEED_URL, { headers: auth(userId) }, env)
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual([])
+    expectRequestBudget(db)
+  })
+})
+
+describe('comment feed route — C4.3 live access transitions', () => {
+  test('re-evaluates both feed arms against live grants, membership, site state, and caller role', async () => {
+    const { app, env, db, kv } = makeRouteApp()
+    const ownerId = await mintUser(db, kv, 'transition-owner')
+    const userId = await mintUser(db, kv, 'transition-user')
+    const siteSpaceId = await seedSpace(db, {
+      id: 'space-transition-site',
+      createdBy: ownerId,
+      slug: 'transition-site-space',
+    })
+    const groupSpaceId = await seedSpace(db, {
+      id: 'space-transition-group',
+      createdBy: ownerId,
+      slug: 'transition-group-space',
+    })
+    const siteId = await seedSite(db, {
+      id: 'site-transition',
+      spaceId: siteSpaceId,
+      ownerId,
+      slug: 'transition-site',
+      visibility: 'private',
+    })
+    const authoredThreadId = await seedThread(db, {
+      id: 'thread-transition-authored',
+      siteId,
+      filePath: 'authored.ts',
+      createdBy: userId,
+    })
+    await seedComment(db, {
+      id: 'comment-transition-authored',
+      threadId: authoredThreadId,
+      authorId: userId,
+      body: 'Authored during transition',
+      createdAt: at(1),
+    })
+    const mentionThreadId = await seedThread(db, {
+      id: 'thread-transition-mention',
+      siteId,
+      filePath: 'mention.ts',
+      createdBy: ownerId,
+    })
+    await seedNotification(db, {
+      id: 'notification-transition-mention',
+      recipientId: userId,
+      actorId: ownerId,
+      siteId,
+      threadId: mentionThreadId,
+      snippet: 'Mentioned during transition',
+      createdAt: at(2),
+    })
+
+    const feedIds = async () => {
+      const res = await app.request(FEED_URL, { headers: auth(userId) }, env)
+      expect(res.status).toBe(200)
+      return kindIds(await res.json())
+    }
+    const bothArms = [
+      { kind: 'mention', id: 'notification-transition-mention' },
+      { kind: 'authored', id: 'comment-transition-authored' },
+    ]
+    expect(await feedIds()).toEqual([])
+
+    await seedUserShare(db, siteId, userId)
+    expect(await feedIds()).toEqual(bothArms)
+
+    await db
+      .delete(siteUserShares)
+      .where(and(eq(siteUserShares.siteId, siteId), eq(siteUserShares.userId, userId)))
+    expect(await feedIds()).toEqual([])
+
+    await seedGroupShare(db, siteId, groupSpaceId)
+    await seedMember(db, groupSpaceId, userId)
+    expect(await feedIds()).toEqual(bothArms)
+
+    await db
+      .delete(spaceMembers)
+      .where(and(eq(spaceMembers.spaceId, groupSpaceId), eq(spaceMembers.userId, userId)))
+    expect(await feedIds()).toEqual([])
+
+    await db.update(sites).set({ visibility: 'members' }).where(eq(sites.id, siteId))
+    await seedMember(db, siteSpaceId, userId)
+    expect(await feedIds()).toEqual(bothArms)
+
+    await db
+      .delete(spaceMembers)
+      .where(and(eq(spaceMembers.spaceId, siteSpaceId), eq(spaceMembers.userId, userId)))
+    expect(await feedIds()).toEqual([])
+
+    await seedUserShare(db, siteId, userId)
+    await db.update(sites).set({ status: 'archived' }).where(eq(sites.id, siteId))
+    expect(await feedIds()).toEqual([])
+
+    await db.update(users).set({ role: 'superadmin' }).where(eq(users.id, userId))
+    expect(await feedIds()).toEqual(bothArms)
+  })
+})
+
+describe('comment feed route — C4.5 moved site', () => {
+  test('uses the current space for both access and response metadata after a move', async () => {
+    const { app, env, db, kv } = makeRouteApp()
+    const ownerId = await mintUser(db, kv, 'moved-owner')
+    const userId = await mintUser(db, kv, 'moved-user')
+    const spaceAId = await seedSpace(db, { id: 'space-moved-a', createdBy: ownerId, slug: 'a' })
+    const spaceBId = await seedSpace(db, { id: 'space-moved-b', createdBy: ownerId, slug: 'b' })
+    await seedMember(db, spaceAId, userId)
+    const siteId = await seedSite(db, {
+      id: 'site-moved',
+      spaceId: spaceAId,
+      ownerId,
+      slug: 'moved',
+      title: 'Moved Site',
+      visibility: 'members',
+    })
+    const authoredThreadId = await seedThread(db, {
+      id: 'thread-moved-authored',
+      siteId,
+      filePath: 'authored.ts',
+      createdBy: userId,
+      status: 'open',
+    })
+    await seedComment(db, {
+      id: 'comment-moved-authored',
+      threadId: authoredThreadId,
+      authorId: userId,
+      body: 'Authored before the move',
+      createdAt: at(1),
+    })
+    const mentionThreadId = await seedThread(db, {
+      id: 'thread-moved-mention',
+      siteId,
+      filePath: 'mention.ts',
+      createdBy: ownerId,
+      status: 'resolved',
+    })
+    await seedNotification(db, {
+      id: 'notification-moved-mention',
+      recipientId: userId,
+      actorId: ownerId,
+      siteId,
+      siteLabel: 'a/stale-label-must-not-surface',
+      threadId: mentionThreadId,
+      snippet: 'Mentioned before the move',
+      createdAt: at(2),
+    })
+
+    const getFeed = async () => {
+      const res = await app.request(FEED_URL, { headers: auth(userId) }, env)
+      expect(res.status).toBe(200)
+      return res.json()
+    }
+    // The full payload identical before and after the move except for the live space slug.
+    const movedFeed = (spaceSlug: string) => [
+      {
+        kind: 'mention',
+        id: 'notification-moved-mention',
+        snippet: 'Mentioned before the move',
+        actorName: 'moved-owner@example.com',
+        spaceSlug,
+        siteSlug: 'moved',
+        siteTitle: 'Moved Site',
+        filePath: 'mention.ts',
+        threadId: 'thread-moved-mention',
+        threadStatus: 'resolved',
+        createdAt: '2026-01-01T00:00:02.000Z',
+        editedAt: null,
+      },
+      {
+        kind: 'authored',
+        id: 'comment-moved-authored',
+        snippet: 'Authored before the move',
+        actorName: null,
+        spaceSlug,
+        siteSlug: 'moved',
+        siteTitle: 'Moved Site',
+        filePath: 'authored.ts',
+        threadId: 'thread-moved-authored',
+        threadStatus: 'open',
+        createdAt: '2026-01-01T00:00:01.000Z',
+        editedAt: null,
+      },
+    ]
+    expect(await getFeed()).toEqual(movedFeed('a'))
+
+    await db.update(sites).set({ spaceId: spaceBId }).where(eq(sites.id, siteId))
+    expect(await getFeed()).toEqual([])
+
+    await seedMember(db, spaceBId, userId)
+    expect(await getFeed()).toEqual(movedFeed('b'))
+  })
+})
+
+describe('comment feed route — C4.7 caller isolation', () => {
+  test("returns only the caller's authored comments and mention notifications", async () => {
+    const { app, env, db, kv } = makeRouteApp()
+    const userId = await mintUser(db, kv, 'isolation-me')
+    const otherUserId = await mintUser(db, kv, 'isolation-other')
+    const spaceId = await seedSpace(db, { id: 'space-isolation', createdBy: userId, slug: 'isolation' })
+    const siteId = await seedSite(db, {
+      id: 'site-isolation',
+      spaceId,
+      ownerId: userId,
+      slug: 'team-site',
+      visibility: 'team',
+    })
+    const myAuthoredThreadId = await seedThread(db, {
+      id: 'thread-isolation-my-authored',
+      siteId,
+      filePath: 'my-authored.ts',
+      createdBy: userId,
+    })
+    await seedComment(db, {
+      id: 'comment-isolation-my-authored',
+      threadId: myAuthoredThreadId,
+      authorId: userId,
+      body: 'My authored comment',
+      createdAt: at(1),
+    })
+    const myMentionThreadId = await seedThread(db, {
+      id: 'thread-isolation-my-mention',
+      siteId,
+      filePath: 'my-mention.ts',
+      createdBy: otherUserId,
+    })
+    await seedNotification(db, {
+      id: 'notification-isolation-my-mention',
+      recipientId: userId,
+      actorId: otherUserId,
+      siteId,
+      threadId: myMentionThreadId,
+      snippet: 'My mention',
+      createdAt: at(2),
+    })
+    const otherAuthoredThreadId = await seedThread(db, {
+      id: 'thread-isolation-other-authored',
+      siteId,
+      filePath: 'other-authored.ts',
+      createdBy: otherUserId,
+    })
+    await seedComment(db, {
+      id: 'comment-isolation-other-authored',
+      threadId: otherAuthoredThreadId,
+      authorId: otherUserId,
+      body: 'Other newer authored comment',
+      createdAt: at(3),
+    })
+    const otherMentionThreadId = await seedThread(db, {
+      id: 'thread-isolation-other-mention',
+      siteId,
+      filePath: 'other-mention.ts',
+      createdBy: userId,
+    })
+    await seedNotification(db, {
+      id: 'notification-isolation-other-mention',
+      recipientId: otherUserId,
+      actorId: userId,
+      siteId,
+      threadId: otherMentionThreadId,
+      snippet: 'Other newer mention',
+      createdAt: at(4),
+    })
+
+    const res = await app.request(FEED_URL, { headers: auth(userId) }, env)
+
+    expect(res.status).toBe(200)
+    expect(kindIds(await res.json())).toEqual([
+      { kind: 'mention', id: 'notification-isolation-my-mention' },
+      { kind: 'authored', id: 'comment-isolation-my-authored' },
+    ])
+  })
+})
+
+describe('comment feed route — C4.8 mention read state', () => {
+  test('returns both read and unread mention notifications', async () => {
+    const { app, env, db, kv } = makeRouteApp()
+    const userId = await mintUser(db, kv, 'read-state-user')
+    const actorId = await mintUser(db, kv, 'read-state-actor')
+    const spaceId = await seedSpace(db, { id: 'space-read-state', createdBy: userId, slug: 'read-state' })
+    const siteId = await seedSite(db, {
+      id: 'site-read-state',
+      spaceId,
+      ownerId: userId,
+      slug: 'read-state-site',
+      visibility: 'private',
+    })
+    const unreadThreadId = await seedThread(db, {
+      id: 'thread-unread-mention',
+      siteId,
+      filePath: 'unread.ts',
+      createdBy: actorId,
+    })
+    await seedNotification(db, {
+      id: 'notification-unread-mention',
+      recipientId: userId,
+      actorId,
+      siteId,
+      threadId: unreadThreadId,
+      snippet: 'Unread mention',
+      readAt: null,
+      createdAt: at(1),
+    })
+    const readThreadId = await seedThread(db, {
+      id: 'thread-read-mention',
+      siteId,
+      filePath: 'read.ts',
+      createdBy: actorId,
+    })
+    await seedNotification(db, {
+      id: 'notification-read-mention',
+      recipientId: userId,
+      actorId,
+      siteId,
+      threadId: readThreadId,
+      snippet: 'Read mention',
+      readAt: at(3),
+      createdAt: at(2),
+    })
+
+    const res = await app.request(FEED_URL, { headers: auth(userId) }, env)
+
+    expect(res.status).toBe(200)
+    expect(kindIds(await res.json())).toEqual([
+      { kind: 'mention', id: 'notification-read-mention' },
+      { kind: 'mention', id: 'notification-unread-mention' },
+    ])
+  })
+})
+
+describe('comment feed route — C4.10 batch failure', () => {
+  test('returns a 5xx response instead of an empty successful feed when the batch rejects', async () => {
+    const { app, env, db, kv } = makeRouteApp()
+    const userId = await mintUser(db, kv, 'batch-failure-user')
+    db.batch = (() => Promise.reject(new Error('d1 down'))) as typeof db.batch
+
+    const res = await app.request(FEED_URL, { headers: auth(userId) }, env)
+
+    expect(res.status).toBeGreaterThanOrEqual(500)
+    expect(await res.text()).not.toEqual('[]')
+  })
+})
+
+describe('comment feed route — C4.9 scan-cap hole', () => {
+  test('does not backfill an accessible authored row beyond the 200-candidate window', async () => {
+    const { app, env, db, kv } = makeRouteApp()
+    const userId = await mintUser(db, kv, 'scan-cap-user')
+    const otherUserId = await mintUser(db, kv, 'scan-cap-owner')
+    const ownSpaceId = await seedSpace(db, { id: 'space-scan-cap-own', createdBy: userId, slug: 'scan-cap-own' })
+    const ownSiteId = await seedSite(db, {
+      id: 'site-scan-cap-own',
+      spaceId: ownSpaceId,
+      ownerId: userId,
+      slug: 'own-site',
+      visibility: 'private',
+    })
+    const ownThreadId = await seedThread(db, {
+      id: 'thread-scan-cap-own',
+      siteId: ownSiteId,
+      filePath: 'old.ts',
+      createdBy: userId,
+    })
+    await seedComment(db, {
+      id: 'comment-scan-cap-old-accessible',
+      threadId: ownThreadId,
+      authorId: userId,
+      body: 'Old accessible comment',
+      createdAt: at(0),
+    })
+    const privateSpaceId = await seedSpace(db, {
+      id: 'space-scan-cap-private',
+      createdBy: otherUserId,
+      slug: 'scan-cap-private',
+    })
+    const privateSiteId = await seedSite(db, {
+      id: 'site-scan-cap-private',
+      spaceId: privateSpaceId,
+      ownerId: otherUserId,
+      slug: 'private-site',
+      visibility: 'private',
+    })
+    const privateThreadId = await seedThread(db, {
+      id: 'thread-scan-cap-private',
+      siteId: privateSiteId,
+      filePath: 'private.ts',
+      createdBy: userId,
+    })
+    for (let i = 1; i <= 200; i++) {
+      await seedComment(db, {
+        id: `comment-scan-cap-private-${i.toString().padStart(3, '0')}`,
+        threadId: privateThreadId,
+        authorId: userId,
+        body: `Newer inaccessible comment ${i}`,
+        createdAt: at(i),
+      })
+    }
+
+    const first = await app.request(FEED_URL, { headers: auth(userId) }, env)
+
+    expect(first.status).toBe(200)
+    expect(await first.json()).toEqual([])
+
+    await db
+      .update(comments)
+      .set({ deletedAt: at(201) })
+      .where(eq(comments.id, 'comment-scan-cap-private-200'))
+    const second = await app.request(FEED_URL, { headers: auth(userId) }, env)
+
+    expect(second.status).toBe(200)
+    expect(kindIds(await second.json())).toEqual([{ kind: 'authored', id: 'comment-scan-cap-old-accessible' }])
+  })
+})

--- a/packages/api/src/routes/comment-feed.ts
+++ b/packages/api/src/routes/comment-feed.ts
@@ -1,0 +1,25 @@
+import { Hono } from 'hono'
+import { assembleCommentFeed, authoredCandidatesStmt, mentionCandidatesStmt } from '../db/comment-feed'
+import { foldMemberSpaceIds, foldSharedSiteRoles, memberSpaceIdsStmt, sharedSiteRoleStmts } from '../db/repo'
+import { batchAll } from '../lib/d1'
+import { requireAuth } from '../middleware/auth'
+import type { AppEnv } from '../types'
+
+export const commentFeed = new Hono<AppEnv>()
+
+commentFeed.use('*', requireAuth)
+
+commentFeed.get('/feed', async (c) => {
+  const db = c.get('db')
+  const user = c.get('user')
+  const [authored, mentions, memberSpaces, direct, viaGroup] = await batchAll(db, [
+    authoredCandidatesStmt(db, user.id),
+    mentionCandidatesStmt(db, user.id),
+    memberSpaceIdsStmt(db, user.id),
+    ...sharedSiteRoleStmts(db, user.id),
+  ])
+  const memberSpaceIds = foldMemberSpaceIds(memberSpaces)
+  const sharedSiteRoles = foldSharedSiteRoles(direct, viaGroup)
+
+  return c.json(assembleCommentFeed({ authored, mentions, user, memberSpaceIds, sharedSiteRoles }))
+})

--- a/packages/api/src/routes/comments.ts
+++ b/packages/api/src/routes/comments.ts
@@ -15,6 +15,7 @@ import {
   threadOfCommentStmt,
   threadsWithUsersBySlugsStmt,
 } from '../db/comments'
+import { truncateSnippet } from '../db/comment-feed'
 import { createNotifications } from '../db/notifications'
 import type { Comment, CommentThread } from '../db/schema'
 import { listMentionableUsers } from '../db/repo'
@@ -154,9 +155,6 @@ function cleanBody(v: unknown): string | null {
   return body
 }
 
-// Short preview of the comment body stored on the notification for the inbox/bell list.
-const MAX_SNIPPET = 200
-
 /** Raise mention notifications for a just-written comment. Explicit selections only (client sends
  *  ids from the autocomplete): dedup, drop self, then INTERSECT against `listMentionableUsers` —
  *  the same access set the autocomplete drew from — so a forged id for someone without access is
@@ -179,7 +177,7 @@ async function notifyMentions(
     if (recipients.length === 0) return
     const { space, site: siteSlug } = c.req.param()
     const siteLabel = `${space}/${siteSlug}`
-    const snippet = opts.snippet.slice(0, MAX_SNIPPET)
+    const snippet = truncateSnippet(opts.snippet)
     await fireAndForget(
       c,
       createNotifications(

--- a/packages/api/src/routes/whats-new.test.ts
+++ b/packages/api/src/routes/whats-new.test.ts
@@ -65,7 +65,7 @@ describe('C7 route.get.exactJSON — exact ordered items, unreadCount, throughDa
     // Whole-response deep-equal, not key-presence: a dropped item field or an extra top-level key fails.
     expect(await res.json()).toEqual({
       items: JSON.parse(JSON.stringify(RELEASES)),
-      unreadCount: 1,
+      unreadCount: 2,
       throughDate: NEWEST_RELEASE_DATE,
     })
   })
@@ -140,6 +140,6 @@ describe('B3 relogin.noReset — the existing-user branch must not clear an exis
     await findOrCreateUser(db, { SUPERADMIN_EMAIL: 'boss@example.com' } as never, { sub: 'g1', name: 'A2' } as never, 'a@example.com')
     expect(await getWatermark(db, first.id)).toBe(before as string)
     const res = await app.request('/api/whats-new', { headers: await mintBearer(kv, first.id) }, env)
-    expect(((await res.json()) as { unreadCount: number }).unreadCount).toBe(1)
+    expect(((await res.json()) as { unreadCount: number }).unreadCount).toBe(2)
   })
 })

--- a/packages/api/src/test/harness.ts
+++ b/packages/api/src/test/harness.ts
@@ -42,6 +42,7 @@ const MIGRATIONS = [
   'drizzle/0009_editor_share.sql',
   'drizzle/0010_notifications.sql',
   'drizzle/0011_whats_new_watermark.sql',
+  'drizzle/0012_comments_author_index.sql',
 ]
 
 // --- S0 recorder: one shared, ordered timeline across D1/R2/cache mocks so perf specs can

--- a/packages/api/src/test/route-fixtures.ts
+++ b/packages/api/src/test/route-fixtures.ts
@@ -4,6 +4,7 @@
 // mounted route group or env binding is inert for tests that never touch it.
 import { Hono } from 'hono'
 import { requireSameOrigin } from '../middleware/auth'
+import { commentFeed } from '../routes/comment-feed'
 import { comments } from '../routes/comments'
 import { sites } from '../routes/sites'
 import { spaces } from '../routes/spaces'
@@ -35,6 +36,7 @@ export function makeRouteApp() {
   app.route('/api/spaces', spaces)
   // Same order as index.ts: sites first, then comments on the same mount (3-segment paths).
   app.route('/api/sites', comments)
+  app.route('/api/comments', commentFeed)
   return { app, env, db, kv, r2 }
 }
 

--- a/packages/api/src/whats-new/catalog.ts
+++ b/packages/api/src/whats-new/catalog.ts
@@ -4,6 +4,13 @@ import type { Release } from './bake'
 
 export const RELEASES: Release[] = [
   {
+    "slug": "comments-tab",
+    "title": "All your comments, one feed",
+    "date": "2026-07-11T12:00:00.000Z",
+    "featured": true,
+    "bodyHtml": "<p>The dashboard has a new <strong>Comments</strong> tab: every <strong>mention of you</strong> and every <strong>comment you wrote</strong>, across all your sites, in one newest-first feed.</p>\n<ul>\n<li>Click any row to jump straight to that thread on the page, with the review rail already open</li>\n<li>Rows show where the conversation lives and whether it&#39;s still open or already resolved</li>\n<li>Mentions stay actionable here even after you&#39;ve read them in the bell</li>\n</ul>\n"
+  },
+  {
     "slug": "voice-comments",
     "title": "Comment with your voice",
     "date": "2026-07-01T15:00:00.000Z",
@@ -19,4 +26,4 @@ export const RELEASES: Release[] = [
   }
 ]
 
-export const NEWEST_RELEASE_DATE: string | null = "2026-07-01T15:00:00.000Z"
+export const NEWEST_RELEASE_DATE: string | null = "2026-07-11T12:00:00.000Z"

--- a/packages/api/src/whats-new/notes/2026-07-11-comments-tab.md
+++ b/packages/api/src/whats-new/notes/2026-07-11-comments-tab.md
@@ -1,0 +1,11 @@
+---
+title: All your comments, one feed
+slug: comments-tab
+date: 2026-07-11T12:00:00.000Z
+featured: true
+---
+The dashboard has a new **Comments** tab: every **mention of you** and every **comment you wrote**, across all your sites, in one newest-first feed.
+
+- Click any row to jump straight to that thread on the page, with the review rail already open
+- Rows show where the conversation lives and whether it's still open or already resolved
+- Mentions stay actionable here even after you've read them in the bell

--- a/packages/web/src/components/CommandPalette.tsx
+++ b/packages/web/src/components/CommandPalette.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/components/ui/command'
 import { toggleTheme } from '@/components/theme'
 import { api } from '@/lib/api'
+import { encodePathSegments } from '@/lib/paths'
 import { siteName, useRecents, visibleEntries } from '@/lib/recents'
 import type { Me, SiteSummary, SpaceSummary } from '@/lib/types'
 
@@ -117,7 +118,7 @@ export function CommandPalette({
             {recentRows.map((e) => {
               const name = siteName(e)
               const href = e.filePath
-                ? `/${e.spaceSlug}/${e.siteSlug}/${e.filePath.split('/').map(encodeURIComponent).join('/')}`
+                ? `/${e.spaceSlug}/${e.siteSlug}/${encodePathSegments(e.filePath)}`
                 : `/${e.spaceSlug}/${e.siteSlug}`
               return (
                 <CommandItem

--- a/packages/web/src/components/ViewerSidebar.tsx
+++ b/packages/web/src/components/ViewerSidebar.tsx
@@ -1,5 +1,6 @@
 import { X } from 'lucide-react'
 import { Link } from 'react-router'
+import { encodePathSegments } from '@/lib/paths'
 import { clear, type RecentEntry, removeEntry, siteName, useRecents, visibleEntries } from '@/lib/recents'
 import { timeAgo } from '@/lib/time'
 import { cn } from '@/lib/utils'
@@ -69,7 +70,7 @@ export function ViewerSidebar({
 }
 
 function entryHref(spaceSlug: string, siteSlug: string, filePath: string): string {
-  return filePath ? `/${spaceSlug}/${siteSlug}/${filePath.split('/').map(encodeURIComponent).join('/')}` : `/${spaceSlug}/${siteSlug}`
+  return filePath ? `/${spaceSlug}/${siteSlug}/${encodePathSegments(filePath)}` : `/${spaceSlug}/${siteSlug}`
 }
 
 function Row({

--- a/packages/web/src/components/ui/badge.tsx
+++ b/packages/web/src/components/ui/badge.tsx
@@ -18,6 +18,7 @@ const badgeVariants = cva(
           "border-border text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
         ghost: "[a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
         link: "text-primary underline-offset-4 [a&]:hover:underline",
+        success: "border-transparent bg-success/15 text-success",
       },
     },
     defaultVariants: {

--- a/packages/web/src/lib/feedState.test.ts
+++ b/packages/web/src/lib/feedState.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test'
 import { ApiError } from './api'
-import { deriveFeedState, type FeedSlot, type FeedSlots } from './feedState'
+import { deriveFeedState, feedRowPath, type FeedSlot, type FeedSlots } from './feedState'
+import { notificationHref } from './mentions'
 import type { CommentFeedItem, SiteSummary, SpaceSummary, TeamUpload } from './types'
 
 // deriveFeedState is the dashboard's per-feed render brain: these tests pin which tabs exist,
@@ -349,5 +350,41 @@ describe('deriveFeedState', () => {
       expect(state.tabs.at(-1)?.id).toBe('comments')
       expect({ ...state, tabs: state.tabs.filter((tab) => tab.id !== 'comments') }).toEqual(expected)
     }
+  })
+})
+
+describe('C5.4 — feedRowPath: hide redundant root-file paths', () => {
+  test('hides index.html', () => {
+    expect(feedRowPath({ filePath: 'index.html', siteSlug: 'anything' })).toBeNull()
+  })
+
+  test('hides a lone file whose basename matches the site slug', () => {
+    expect(feedRowPath({ filePath: 'report.html', siteSlug: 'report' })).toBeNull()
+  })
+
+  test('slugifies a spaced basename before matching the site slug', () => {
+    expect(feedRowPath({ filePath: 'Q3 Report.html', siteSlug: 'q3-report' })).toBeNull()
+  })
+
+  test('shows a nested path even when its basename could match', () => {
+    expect(feedRowPath({ filePath: 'charts/revenue.html', siteSlug: 'revenue' })).toBe(
+      'charts/revenue.html',
+    )
+  })
+
+  test('matching is extension-agnostic', () => {
+    expect(feedRowPath({ filePath: 'report.md', siteSlug: 'report' })).toBeNull()
+  })
+
+  test('matching is case-insensitive through slugify', () => {
+    expect(feedRowPath({ filePath: 'REPORT.HTML', siteSlug: 'report' })).toBeNull()
+  })
+
+  test('a hidden display path is still carried by notificationHref', () => {
+    const item = { filePath: 'report.html', siteSlug: 'report' }
+    expect(feedRowPath(item)).toBeNull()
+    expect(notificationHref({ siteLabel: 'docs/report', filePath: item.filePath, threadId: 't1' })).toBe(
+      '/docs/report/report.html?thread=t1&review=1',
+    )
   })
 })

--- a/packages/web/src/lib/feedState.test.ts
+++ b/packages/web/src/lib/feedState.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'bun:test'
 import { ApiError } from './api'
 import { deriveFeedState, type FeedSlot, type FeedSlots } from './feedState'
-import type { SiteSummary, SpaceSummary, TeamUpload } from './types'
+import type { CommentFeedItem, SiteSummary, SpaceSummary, TeamUpload } from './types'
 
 // deriveFeedState is the dashboard's per-feed render brain: these tests pin which tabs exist,
 // per-tab content state, 401 signalling, ?new=space steering fire-once, and temporal stability.
@@ -33,13 +33,42 @@ const upload = (id: string): TeamUpload => ({
   uploaderEmail: 'sam@example.com',
 })
 
+const comment = (id: string): CommentFeedItem => ({
+  kind: 'mention',
+  id,
+  snippet: 'Take a look',
+  actorName: 'Ada',
+  spaceSlug: 'docs',
+  siteSlug: 'guide',
+  siteTitle: 'Guide',
+  filePath: 'index.html',
+  threadId: `thread-${id}`,
+  threadStatus: 'open',
+  createdAt: '2026-07-01T00:00:00.000Z',
+  editedAt: null,
+})
+
 const pending = { status: 'pending' } as const
 const resolved = <T>(data: T): FeedSlot<T> => ({ status: 'resolved', data })
 const rejected = (error: unknown): FeedSlot<never> => ({ status: 'rejected', error })
 
-const allPending = (): FeedSlots => ({ sites: pending, shared: pending, spaces: pending, team: pending })
+const allPending = (): FeedSlots => ({
+  sites: pending,
+  shared: pending,
+  spaces: pending,
+  team: pending,
+  comments: pending,
+})
 
 const onSites = { requestedTab: 'sites', wantsNewSpace: false } as const
+
+// Every state a feed slot can be in — Comments' behavior must be invariant across all of them.
+const commentSlotStates: FeedSlot<CommentFeedItem[]>[] = [
+  pending,
+  resolved([]),
+  resolved([comment('c1')]),
+  rejected(new Error('boom')),
+]
 
 describe('deriveFeedState', () => {
   // T10.1 — mine resolved, everything else still pending: Your sites is renderable with rows
@@ -52,6 +81,7 @@ describe('deriveFeedState', () => {
       { id: 'sites', label: 'Your sites', count: 2, content: { kind: 'rows', rows: mine } },
       { id: 'spaces', label: 'Your spaces', count: null, content: { kind: 'loading' } },
       { id: 'team', label: 'Team activity', count: null, content: { kind: 'loading' } },
+      { id: 'comments', label: 'Comments', count: null, content: { kind: 'loading' } },
     ])
     expect(state.activeTab).toBe('sites')
     expect(state.unauthorized).toBe(false)
@@ -69,12 +99,13 @@ describe('deriveFeedState', () => {
       { id: 'shared', label: 'Shared with me', count: 3, content: { kind: 'rows', rows: theirs } },
       { id: 'spaces', label: 'Your spaces', count: null, content: { kind: 'loading' } },
       { id: 'team', label: 'Team activity', count: null, content: { kind: 'loading' } },
+      { id: 'comments', label: 'Comments', count: null, content: { kind: 'loading' } },
     ])
   })
 
   test('T10.2 shared resolves empty: tab stays absent', () => {
     const state = deriveFeedState({ ...allPending(), shared: resolved([]) }, onSites)
-    expect(state.tabs.map((t) => t.id)).toEqual(['sites', 'spaces', 'team'])
+    expect(state.tabs.map((t) => t.id)).toEqual(['sites', 'spaces', 'team', 'comments'])
   })
 
   // T10.3 — one failed feed degrades only its own tab; the rest render from their own slots.
@@ -86,6 +117,7 @@ describe('deriveFeedState', () => {
         shared: resolved([site('s')]),
         spaces: resolved([space('g', 'group')]),
         team: rejected(new ApiError(500, 'D1 exploded')),
+        comments: pending,
       },
       onSites,
     )
@@ -105,6 +137,7 @@ describe('deriveFeedState', () => {
         content: { kind: 'rows', rows: [space('g', 'group')] },
       },
       { id: 'team', label: 'Team activity', count: null, content: { kind: 'error', message: 'D1 exploded' } },
+      { id: 'comments', label: 'Comments', count: null, content: { kind: 'loading' } },
     ])
     expect(state.unauthorized).toBe(false)
   })
@@ -123,7 +156,7 @@ describe('deriveFeedState', () => {
     // A non-401 shared failure means we cannot prove it has rows — the tab stays absent.
     const broken = deriveFeedState({ ...allPending(), shared: rejected(new ApiError(500, 'boom')) }, onSites)
     expect(broken.unauthorized).toBe(false)
-    expect(broken.tabs.map((t) => t.id)).toEqual(['sites', 'spaces', 'team'])
+    expect(broken.tabs.map((t) => t.id)).toEqual(['sites', 'spaces', 'team', 'comments'])
   })
 
   // T10.4 — ?new=space steers IMMEDIATELY (the Spaces tab always exists, so a slow/rejected feed
@@ -165,6 +198,7 @@ describe('deriveFeedState', () => {
       shared: resolved([site('x')]),
       spaces: resolved([space('g', 'group')]),
       team: resolved([upload('t')]),
+      comments: pending,
     })
     const view = { requestedTab: 'team', wantsNewSpace: false } as const
 
@@ -172,7 +206,7 @@ describe('deriveFeedState', () => {
     const second = deriveFeedState(build(), view)
 
     expect(second).toEqual(first)
-    expect(second.tabs.map((t) => t.id)).toEqual(['sites', 'shared', 'spaces', 'team'])
+    expect(second.tabs.map((t) => t.id)).toEqual(['sites', 'shared', 'spaces', 'team', 'comments'])
     expect(second.activeTab).toBe('team')
   })
 
@@ -180,10 +214,10 @@ describe('deriveFeedState', () => {
     const view = { requestedTab: 'team', wantsNewSpace: false } as const
     const before = deriveFeedState(allPending(), view)
     expect(before.activeTab).toBe('team')
-    expect(before.tabs.map((t) => t.id)).toEqual(['sites', 'spaces', 'team'])
+    expect(before.tabs.map((t) => t.id)).toEqual(['sites', 'spaces', 'team', 'comments'])
 
     const after = deriveFeedState({ ...allPending(), shared: resolved([site('x')]) }, view)
-    expect(after.tabs.map((t) => t.id)).toEqual(['sites', 'shared', 'spaces', 'team'])
+    expect(after.tabs.map((t) => t.id)).toEqual(['sites', 'shared', 'spaces', 'team', 'comments'])
     expect(after.activeTab).toBe('team')
     expect(after.steerTo).toBeNull()
   })
@@ -195,5 +229,125 @@ describe('deriveFeedState', () => {
 
     const emptied = deriveFeedState({ ...allPending(), shared: resolved([]) }, view)
     expect(emptied.activeTab).toBe('sites')
+  })
+
+  test('C5.1 comments tab is always present across every slot state', () => {
+    for (const comments of commentSlotStates) {
+      const state = deriveFeedState({ ...allPending(), comments }, onSites)
+      expect(state.tabs.map((tab) => tab.id)).toEqual(['sites', 'spaces', 'team', 'comments'])
+    }
+  })
+
+  test('C5.1 comments count stays null even with rows', () => {
+    const state = deriveFeedState({ ...allPending(), comments: resolved([comment('c1')]) }, onSites)
+    expect(state.tabs.find((tab) => tab.id === 'comments')?.count).toBeNull()
+  })
+
+  test('C5.1 a 401 from only the comments slot raises the login-redirect signal', () => {
+    const state = deriveFeedState(
+      { ...allPending(), comments: rejected(new ApiError(401, 'Unauthorized')) },
+      onSites,
+    )
+    expect(state.unauthorized).toBe(true)
+  })
+
+  test('C5.1 requested Comments stays active across every slot state', () => {
+    for (const comments of commentSlotStates) {
+      const state = deriveFeedState(
+        { ...allPending(), comments },
+        { requestedTab: 'comments', wantsNewSpace: false },
+      )
+      expect(state.activeTab).toBe('comments')
+    }
+  })
+
+  test('C5.1 tab order keeps Comments last with and without Shared', () => {
+    const withShared = deriveFeedState(
+      { ...allPending(), shared: resolved([site('shared')]) },
+      onSites,
+    )
+    expect(withShared.tabs.map((tab) => tab.id)).toEqual([
+      'sites',
+      'shared',
+      'spaces',
+      'team',
+      'comments',
+    ])
+
+    const withoutShared = deriveFeedState({ ...allPending(), shared: resolved([]) }, onSites)
+    expect(withoutShared.tabs.map((tab) => tab.id)).toEqual(['sites', 'spaces', 'team', 'comments'])
+  })
+
+  test('C5.2 five-wide derivation preserves representative four-feed goldens', () => {
+    const cases = [
+      {
+        slots: allPending(),
+        view: onSites,
+        expected: {
+          tabs: [
+            { id: 'sites', label: 'Your sites', count: null, content: { kind: 'loading' } },
+            { id: 'spaces', label: 'Your spaces', count: null, content: { kind: 'loading' } },
+            { id: 'team', label: 'Team activity', count: null, content: { kind: 'loading' } },
+          ],
+          activeTab: 'sites',
+          unauthorized: false,
+          steerTo: null,
+        },
+      },
+      {
+        slots: { ...allPending(), shared: resolved([site('shared')]) },
+        view: { requestedTab: 'team', wantsNewSpace: false } as const,
+        expected: {
+          tabs: [
+            { id: 'sites', label: 'Your sites', count: null, content: { kind: 'loading' } },
+            {
+              id: 'shared',
+              label: 'Shared with me',
+              count: 1,
+              content: { kind: 'rows', rows: [site('shared')] },
+            },
+            { id: 'spaces', label: 'Your spaces', count: null, content: { kind: 'loading' } },
+            { id: 'team', label: 'Team activity', count: null, content: { kind: 'loading' } },
+          ],
+          activeTab: 'team',
+          unauthorized: false,
+          steerTo: null,
+        },
+      },
+      {
+        slots: { ...allPending(), shared: resolved([]) },
+        view: { requestedTab: 'shared', wantsNewSpace: false } as const,
+        expected: {
+          tabs: [
+            { id: 'sites', label: 'Your sites', count: null, content: { kind: 'loading' } },
+            { id: 'spaces', label: 'Your spaces', count: null, content: { kind: 'loading' } },
+            { id: 'team', label: 'Team activity', count: null, content: { kind: 'loading' } },
+          ],
+          activeTab: 'sites',
+          unauthorized: false,
+          steerTo: null,
+        },
+      },
+      {
+        slots: { ...allPending(), spaces: resolved([space('personal', 'personal')]) },
+        view: { requestedTab: 'sites', wantsNewSpace: true } as const,
+        expected: {
+          tabs: [
+            { id: 'sites', label: 'Your sites', count: null, content: { kind: 'loading' } },
+            { id: 'spaces', label: 'Your spaces', count: 0, content: { kind: 'rows', rows: [] } },
+            { id: 'team', label: 'Team activity', count: null, content: { kind: 'loading' } },
+          ],
+          activeTab: 'sites',
+          unauthorized: false,
+          steerTo: 'spaces',
+        },
+      },
+    ]
+
+    for (const { slots, view, expected } of cases) {
+      const state = deriveFeedState(slots, view)
+      expect(state.tabs.at(-1)?.id).toBe('comments')
+      expect({ ...state, tabs: state.tabs.filter((tab) => tab.id !== 'comments') }).toEqual(expected)
+    }
   })
 })

--- a/packages/web/src/lib/feedState.ts
+++ b/packages/web/src/lib/feedState.ts
@@ -1,5 +1,5 @@
 // The dashboard's per-feed render brain. The route used to gate every tab on one Promise.all of
-// all four feeds; now the component holds one slot per feed (pending/resolved/rejected) and this
+// all five feeds; now the component holds one slot per feed (pending/resolved/rejected) and this
 // pure function derives the whole tab model from them, so each tab paints as its OWN feed settles.
 // Everything decision-shaped lives here, unit-tested: which tabs exist (Shared pops in only once
 // its feed resolves with rows), per-tab content (rows / skeleton / contained error), 401 → login
@@ -7,7 +7,7 @@
 // derive an identical model, so revalidation can't churn tabs or steal the active one).
 
 import { ApiError } from './api'
-import type { SiteSummary, SpaceSummary, TeamUpload } from './types'
+import type { CommentFeedItem, SiteSummary, SpaceSummary, TeamUpload } from './types'
 
 export type FeedSlot<T> =
   | { status: 'pending' }
@@ -19,9 +19,10 @@ export interface FeedSlots {
   shared: FeedSlot<SiteSummary[]>
   spaces: FeedSlot<SpaceSummary[]>
   team: FeedSlot<TeamUpload[]>
+  comments: FeedSlot<CommentFeedItem[]>
 }
 
-export type TabId = 'sites' | 'shared' | 'spaces' | 'team'
+export type TabId = 'sites' | 'shared' | 'spaces' | 'team' | 'comments'
 
 export type TabContent<T> =
   | { kind: 'loading' }
@@ -34,6 +35,7 @@ export type DashboardTab =
   | { id: 'shared'; label: 'Shared with me'; count: number; content: TabContent<SiteSummary[]> }
   | { id: 'spaces'; label: 'Your spaces'; count: number | null; content: TabContent<SpaceSummary[]> }
   | { id: 'team'; label: 'Team activity'; count: null; content: TabContent<TeamUpload[]> }
+  | { id: 'comments'; label: 'Comments'; count: null; content: TabContent<CommentFeedItem[]> }
 
 export interface FeedState {
   tabs: DashboardTab[]
@@ -75,7 +77,7 @@ export function deriveFeedState(
   const groupSpaces =
     slots.spaces.status === 'resolved' ? slots.spaces.data.filter((s) => s.type === 'group') : null
 
-  // Sites, Spaces and Team always exist (a failed feed degrades to a contained error INSIDE its
+  // Sites, Spaces, Team and Comments always exist (a failed feed degrades to a contained error INSIDE its
   // tab). Shared exists only once its feed resolves with rows — no tab for an empty or unknown
   // feed, so it pops in on resolve and disappears if a revalidation empties it.
   const tabs: DashboardTab[] = [
@@ -102,6 +104,7 @@ export function deriveFeedState(
       content: groupSpaces === null ? contentOf(slots.spaces) : { kind: 'rows', rows: groupSpaces },
     },
     { id: 'team', label: 'Team activity', count: null, content: contentOf(slots.team) },
+    { id: 'comments', label: 'Comments', count: null, content: contentOf(slots.comments) },
   ]
 
   const activeTab = tabs.some((t) => t.id === view.requestedTab) ? view.requestedTab : 'sites'

--- a/packages/web/src/lib/feedState.ts
+++ b/packages/web/src/lib/feedState.ts
@@ -7,6 +7,7 @@
 // derive an identical model, so revalidation can't churn tabs or steal the active one).
 
 import { ApiError } from './api'
+import { slugify } from './slug'
 import type { CommentFeedItem, SiteSummary, SpaceSummary, TeamUpload } from './types'
 
 export type FeedSlot<T> =
@@ -115,4 +116,13 @@ export function deriveFeedState(
     unauthorized: Object.values(slots).some(isUnauthorized),
     steerTo: view.wantsNewSpace && activeTab !== 'spaces' ? 'spaces' : null,
   }
+}
+
+/** Hide a root file path when it only repeats the site identity. Nested paths remain useful
+ *  context even when their basename matches the site slug. */
+export function feedRowPath(item: { filePath: string; siteSlug: string }): string | null {
+  if (item.filePath === 'index.html') return null
+  if (item.filePath.includes('/')) return item.filePath
+  const basename = item.filePath.replace(/\.[^.]*$/, '')
+  return slugify(basename) === item.siteSlug ? null : item.filePath
 }

--- a/packages/web/src/lib/mentions.test.ts
+++ b/packages/web/src/lib/mentions.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test'
-import { type MentionUser, insertMention, mentionQuery, notificationHref } from './mentions'
+import { feedRowPath, type MentionUser, insertMention, mentionQuery, notificationHref } from './mentions'
 
 const ada: MentionUser = { id: 'u-ada', name: 'Ada Lovelace', email: 'ada@example.com' }
 const noName: MentionUser = { id: 'u-x', name: null, email: 'x@example.com' }
@@ -77,5 +77,50 @@ describe('C21 — notificationHref: deep-link into the viewer review rail', () =
 
   test('no site label → home', () => {
     expect(notificationHref({ siteLabel: null, filePath: null, threadId: null })).toBe('/')
+  })
+
+  test('encodes ? and # in path segments so they cannot truncate the pathname', () => {
+    expect(notificationHref({ siteLabel: 'acme/doc', filePath: 'Q3?Report.html', threadId: 't1' })).toBe(
+      '/acme/doc/Q3%3FReport.html?thread=t1&review=1',
+    )
+    expect(notificationHref({ siteLabel: 'acme/doc', filePath: 'notes#draft.html', threadId: 't1' })).toBe(
+      '/acme/doc/notes%23draft.html?thread=t1&review=1',
+    )
+  })
+})
+
+describe('C5.4 — feedRowPath: hide redundant root-file paths', () => {
+  test('hides index.html', () => {
+    expect(feedRowPath({ filePath: 'index.html', siteSlug: 'anything' })).toBeNull()
+  })
+
+  test('hides a lone file whose basename matches the site slug', () => {
+    expect(feedRowPath({ filePath: 'report.html', siteSlug: 'report' })).toBeNull()
+  })
+
+  test('slugifies a spaced basename before matching the site slug', () => {
+    expect(feedRowPath({ filePath: 'Q3 Report.html', siteSlug: 'q3-report' })).toBeNull()
+  })
+
+  test('shows a nested path even when its basename could match', () => {
+    expect(feedRowPath({ filePath: 'charts/revenue.html', siteSlug: 'revenue' })).toBe(
+      'charts/revenue.html',
+    )
+  })
+
+  test('matching is extension-agnostic', () => {
+    expect(feedRowPath({ filePath: 'report.md', siteSlug: 'report' })).toBeNull()
+  })
+
+  test('matching is case-insensitive through slugify', () => {
+    expect(feedRowPath({ filePath: 'REPORT.HTML', siteSlug: 'report' })).toBeNull()
+  })
+
+  test('a hidden display path is still carried by notificationHref', () => {
+    const item = { filePath: 'report.html', siteSlug: 'report' }
+    expect(feedRowPath(item)).toBeNull()
+    expect(notificationHref({ siteLabel: 'docs/report', filePath: item.filePath, threadId: 't1' })).toBe(
+      '/docs/report/report.html?thread=t1&review=1',
+    )
   })
 })

--- a/packages/web/src/lib/mentions.test.ts
+++ b/packages/web/src/lib/mentions.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test'
-import { feedRowPath, type MentionUser, insertMention, mentionQuery, notificationHref } from './mentions'
+import { type MentionUser, insertMention, mentionQuery, notificationHref } from './mentions'
 
 const ada: MentionUser = { id: 'u-ada', name: 'Ada Lovelace', email: 'ada@example.com' }
 const noName: MentionUser = { id: 'u-x', name: null, email: 'x@example.com' }
@@ -85,42 +85,6 @@ describe('C21 — notificationHref: deep-link into the viewer review rail', () =
     )
     expect(notificationHref({ siteLabel: 'acme/doc', filePath: 'notes#draft.html', threadId: 't1' })).toBe(
       '/acme/doc/notes%23draft.html?thread=t1&review=1',
-    )
-  })
-})
-
-describe('C5.4 — feedRowPath: hide redundant root-file paths', () => {
-  test('hides index.html', () => {
-    expect(feedRowPath({ filePath: 'index.html', siteSlug: 'anything' })).toBeNull()
-  })
-
-  test('hides a lone file whose basename matches the site slug', () => {
-    expect(feedRowPath({ filePath: 'report.html', siteSlug: 'report' })).toBeNull()
-  })
-
-  test('slugifies a spaced basename before matching the site slug', () => {
-    expect(feedRowPath({ filePath: 'Q3 Report.html', siteSlug: 'q3-report' })).toBeNull()
-  })
-
-  test('shows a nested path even when its basename could match', () => {
-    expect(feedRowPath({ filePath: 'charts/revenue.html', siteSlug: 'revenue' })).toBe(
-      'charts/revenue.html',
-    )
-  })
-
-  test('matching is extension-agnostic', () => {
-    expect(feedRowPath({ filePath: 'report.md', siteSlug: 'report' })).toBeNull()
-  })
-
-  test('matching is case-insensitive through slugify', () => {
-    expect(feedRowPath({ filePath: 'REPORT.HTML', siteSlug: 'report' })).toBeNull()
-  })
-
-  test('a hidden display path is still carried by notificationHref', () => {
-    const item = { filePath: 'report.html', siteSlug: 'report' }
-    expect(feedRowPath(item)).toBeNull()
-    expect(notificationHref({ siteLabel: 'docs/report', filePath: item.filePath, threadId: 't1' })).toBe(
-      '/docs/report/report.html?thread=t1&review=1',
     )
   })
 })

--- a/packages/web/src/lib/mentions.ts
+++ b/packages/web/src/lib/mentions.ts
@@ -1,5 +1,8 @@
 // Pure @-mention helpers, extracted from the Composer so they're bun-testable without a DOM.
-// The composer owns the textarea + dropdown; these own the string math and the notification link.
+// The composer owns the textarea + dropdown; these own the string math plus notification/feed-row
+// link and display helpers.
+
+import { slugify } from './slug'
 
 export interface MentionUser {
   id: string
@@ -60,9 +63,22 @@ export function notificationHref(n: {
   threadId: string | null
 }): string {
   if (!n.siteLabel) return '/'
-  const path = n.filePath ? `/${n.filePath.replace(/^\/+/, '')}` : ''
+  // Encode each path segment (mirrors ViewerSidebar's entryHref) — upload sanitization lets `?`
+  // and `#` through, and unencoded they truncate the pathname into query/fragment territory.
+  const path = n.filePath
+    ? `/${n.filePath.replace(/^\/+/, '').split('/').map(encodeURIComponent).join('/')}`
+    : ''
   const params = new URLSearchParams()
   if (n.threadId) params.set('thread', n.threadId)
   params.set('review', '1')
   return `/${n.siteLabel}${path}?${params.toString()}`
+}
+
+/** Hide a root file path when it only repeats the site identity. Nested paths remain useful
+ *  context even when their basename matches the site slug. */
+export function feedRowPath(item: { filePath: string; siteSlug: string }): string | null {
+  if (item.filePath === 'index.html') return null
+  if (item.filePath.includes('/')) return item.filePath
+  const basename = item.filePath.replace(/\.[^.]*$/, '')
+  return slugify(basename) === item.siteSlug ? null : item.filePath
 }

--- a/packages/web/src/lib/mentions.ts
+++ b/packages/web/src/lib/mentions.ts
@@ -1,8 +1,7 @@
 // Pure @-mention helpers, extracted from the Composer so they're bun-testable without a DOM.
-// The composer owns the textarea + dropdown; these own the string math plus notification/feed-row
-// link and display helpers.
+// The composer owns the textarea + dropdown; these own the string math plus the notification link.
 
-import { slugify } from './slug'
+import { encodePathSegments } from './paths'
 
 export interface MentionUser {
   id: string
@@ -66,19 +65,10 @@ export function notificationHref(n: {
   // Encode each path segment (mirrors ViewerSidebar's entryHref) — upload sanitization lets `?`
   // and `#` through, and unencoded they truncate the pathname into query/fragment territory.
   const path = n.filePath
-    ? `/${n.filePath.replace(/^\/+/, '').split('/').map(encodeURIComponent).join('/')}`
+    ? `/${encodePathSegments(n.filePath.replace(/^\/+/, ''))}`
     : ''
   const params = new URLSearchParams()
   if (n.threadId) params.set('thread', n.threadId)
   params.set('review', '1')
   return `/${n.siteLabel}${path}?${params.toString()}`
-}
-
-/** Hide a root file path when it only repeats the site identity. Nested paths remain useful
- *  context even when their basename matches the site slug. */
-export function feedRowPath(item: { filePath: string; siteSlug: string }): string | null {
-  if (item.filePath === 'index.html') return null
-  if (item.filePath.includes('/')) return item.filePath
-  const basename = item.filePath.replace(/\.[^.]*$/, '')
-  return slugify(basename) === item.siteSlug ? null : item.filePath
 }

--- a/packages/web/src/lib/paths.ts
+++ b/packages/web/src/lib/paths.ts
@@ -1,0 +1,3 @@
+/** Encode path segments so `?`/`#` in filenames can't truncate the pathname. */
+export const encodePathSegments = (filePath: string): string =>
+  filePath.split('/').map(encodeURIComponent).join('/')

--- a/packages/web/src/lib/types.ts
+++ b/packages/web/src/lib/types.ts
@@ -48,6 +48,22 @@ export interface TeamUpload extends SiteSummary {
   uploaderEmail: string
 }
 
+// Mirrors the API's CommentFeedItem (packages/api/src/db/comment-feed.ts) field-for-field — keep in sync.
+export interface CommentFeedItem {
+  kind: 'mention' | 'authored'
+  id: string
+  snippet: string | null
+  actorName: string | null
+  spaceSlug: string
+  siteSlug: string
+  siteTitle: string | null
+  filePath: string
+  threadId: string
+  threadStatus: 'open' | 'resolved'
+  createdAt: string
+  editedAt: string | null
+}
+
 export interface ViewerSite {
   id: string
   spaceSlug: string

--- a/packages/web/src/routes/dashboard.tsx
+++ b/packages/web/src/routes/dashboard.tsx
@@ -24,6 +24,7 @@ import {
 import { SitesTable } from '@/components/SitesTable'
 import { SortableTable, type Column } from '@/components/SortableTable'
 import { EmptyState, Spinner } from '@/components/states'
+import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
 import {
@@ -56,9 +57,11 @@ import {
   type TabContent,
   type TabId,
 } from '@/lib/feedState'
-import type { SiteSummary, SpaceSummary, TeamUpload } from '@/lib/types'
+import { feedRowPath, notificationHref } from '@/lib/mentions'
+import { timeAgo } from '@/lib/time'
+import type { CommentFeedItem, SiteSummary, SpaceSummary, TeamUpload } from '@/lib/types'
 
-// Stream the feeds instead of blocking the route on them: the loader returns the four promises
+// Stream the feeds instead of blocking the route on them: the loader returns the five promises
 // un-awaited, the component tracks one slot per feed (useFeedSlot), and deriveFeedState (pure,
 // unit-tested in lib/feedState.test.ts) maps the slots to the tab model — so each tab paints as
 // its OWN feed resolves instead of every tab waiting on the slowest call. A failed feed degrades
@@ -77,6 +80,7 @@ export function loader() {
     shared: observed(api.get<SiteSummary[]>('/api/sites/shared')),
     spaces: observed(api.get<SpaceSummary[]>('/api/spaces/mine')),
     team: observed(api.get<TeamUpload[]>('/api/sites/team')),
+    comments: observed(api.get<CommentFeedItem[]>('/api/comments/feed')),
   }
 }
 
@@ -136,12 +140,14 @@ export function Component() {
     shared: Promise<SiteSummary[]>
     spaces: Promise<SpaceSummary[]>
     team: Promise<TeamUpload[]>
+    comments: Promise<CommentFeedItem[]>
   }
   const slots = {
     sites: useFeedSlot(loaded.sites),
     shared: useFeedSlot(loaded.shared),
     spaces: useFeedSlot(loaded.spaces),
     team: useFeedSlot(loaded.team),
+    comments: useFeedSlot(loaded.comments),
   }
   const [searchParams] = useSearchParams()
   const location = useLocation()
@@ -272,6 +278,21 @@ function TabBody({ tab }: { tab: DashboardTab }) {
           }
         </TabPanel>
       )
+    case 'comments':
+      return (
+        <TabPanel content={tab.content} what="comments">
+          {(comments) =>
+            comments.length === 0 ? (
+              <EmptyState
+                title="No comments yet"
+                description="Mentions of you and comments you write will land here."
+              />
+            ) : (
+              <CommentsFeed comments={comments} />
+            )
+          }
+        </TabPanel>
+      )
   }
 }
 
@@ -351,6 +372,73 @@ function TeamActivityTable({ team }: { team: TeamUpload[] }) {
       getRowKey={(u) => u.id}
       initialSort={{ key: 'when', dir: 'desc' }}
     />
+  )
+}
+
+// ─── Comments ────────────────────────────────────────────────────────────────
+
+function CommentsFeed({ comments }: { comments: CommentFeedItem[] }) {
+  return (
+    <ul className="divide-y rounded-xl border">
+      {comments.map((item) => {
+        const path = feedRowPath(item)
+        const href = notificationHref({
+          siteLabel: `${item.spaceSlug}/${item.siteSlug}`,
+          filePath: item.filePath,
+          threadId: item.threadId,
+        })
+        const v =
+          item.kind === 'mention'
+            ? { author: item.actorName ?? 'Someone', verb: ' mentioned you', editedSuffix: false }
+            : { author: 'You', verb: '', editedSuffix: !!item.editedAt }
+        return (
+          <li key={`${item.kind}:${item.id}`}>
+            <Link
+              to={href}
+              className="flex items-start gap-3 px-4 py-3 transition-colors hover:bg-accent"
+            >
+              <span className="mt-0.5 w-16 shrink-0 rounded bg-muted px-1.5 py-0.5 text-center font-mono text-[10px] text-muted-foreground">
+                {item.kind}
+              </span>
+              <div className="min-w-0 flex-1">
+                <p className="truncate text-sm">
+                  <span className="font-medium">{v.author}</span>
+                  {v.verb}
+                  {item.snippet != null && (
+                    <>
+                      {' — "'}
+                      {item.snippet}
+                      {'"'}
+                    </>
+                  )}
+                </p>
+                <p className="truncate text-muted-foreground text-xs">
+                  <span className="font-mono">
+                    {item.spaceSlug}/{item.siteSlug}
+                  </span>
+                  {path && (
+                    <>
+                      {' · '}
+                      <span className="font-mono">{path}</span>
+                    </>
+                  )}
+                  {' · '}
+                  {timeAgo(item.createdAt)}
+                  {v.editedSuffix && ' · edited'}
+                </p>
+              </div>
+              {item.threadStatus === 'open' ? (
+                <Badge variant="success">open</Badge>
+              ) : (
+                <Badge variant="secondary" className="text-muted-foreground">
+                  resolved
+                </Badge>
+              )}
+            </Link>
+          </li>
+        )
+      })}
+    </ul>
   )
 }
 

--- a/packages/web/src/routes/dashboard.tsx
+++ b/packages/web/src/routes/dashboard.tsx
@@ -56,8 +56,9 @@ import {
   type FeedSlot,
   type TabContent,
   type TabId,
+  feedRowPath,
 } from '@/lib/feedState'
-import { feedRowPath, notificationHref } from '@/lib/mentions'
+import { notificationHref } from '@/lib/mentions'
 import { timeAgo } from '@/lib/time'
 import type { CommentFeedItem, SiteSummary, SpaceSummary, TeamUpload } from '@/lib/types'
 

--- a/packages/web/src/routes/viewer.tsx
+++ b/packages/web/src/routes/viewer.tsx
@@ -7,6 +7,7 @@ import { attachDbBroker } from '@/lib/dbBroker'
 import { cn } from '@/lib/utils'
 import { comments, type PendingAnchor, pendingToInput, type Thread } from '@/lib/comments'
 import { type Intent, parseIntent } from '@/lib/parseIntent'
+import { encodePathSegments } from '@/lib/paths'
 import { type ArbiterEvent, type ArbiterState, type Decision, initialArbiter, stepArbiter } from '@/lib/prefetchArbiter'
 import { recordVisit } from '@/lib/recents'
 import type { Me } from '@/lib/types'
@@ -459,5 +460,5 @@ function withAnnotate(u: string): string {
 // path so sub-resources still resolve relative to the site root. Each segment is encoded.
 function appendPath(contentUrl: string, filePath: string): string {
   if (!filePath) return contentUrl
-  return contentUrl + filePath.split('/').map(encodeURIComponent).join('/')
+  return contentUrl + encodePathSegments(filePath)
 }


### PR DESCRIPTION
## What

A fifth, always-present **Comments** tab on the dashboard: one time-sorted feed (newest first, max 50) merging **mentions of you** (from notifications) and **comments you authored**, each row deep-linking into the viewer's review rail (`?thread=<id>&review=1`).

![comments tab](https://github.com/plivo-labs/glance/releases/download/assets-pr-comments-tab/comments-tab.png)

## How

- **`GET /api/comments/feed`** — exactly **one `db.batch` of 5 statements** (authored candidates, mention candidates, member space ids, the two share-role statements), folded through a pure `assembleCommentFeed`: `checkAccess` per row (live — revoked grants drop instantly, unlike the bell's snapshot), merge by `createdAt DESC → mention-before-authored → rowid DESC`, slice 50. Request budget pinned by test: `{loose: 1, batches: 1, batchStmts: 5}`, zero writes.
- **Migration 0012** replaces `comments_author` with `(authorId, deletedAt, createdAt)` to cover the authored-arm scan.
- Site + access always derive from the **thread's** site join — `notifications.siteId`/`siteLabel` are never consulted, so moved/renamed sites always link live slugs.
- **Web**: 5-wide `FeedSlots`, Comments tab follows the Team idiom (always present, count deliberately null, pinned last). Rows: kind stamp, actor-or-You line, `space/site · filePath · age · edited`, open/resolved badge. `feedRowPath` hides `index.html` and lone-file slug echoes (`report` + `report.html`) — the href always carries the real path.
- Drive-by fix surfaced at review: `notificationHref` now URL-encodes path segments (`?`/`#` in filenames used to truncate the pathname) — shared with the bell.

## Accepted contract holes (documented in the tracker, pinned by tests)

- Mention snippets are write-time snapshots (no commentId on notifications); a mention of a since-deleted comment still surfaces.
- 200-per-arm scan window with post-window access filtering — a user whose newest 200 candidates are all inaccessible sees an under-filled feed (no backfill; pinned by test).
- Bell ⊃ tab inconsistency is intentional: inbox vs live-filtered work list.

## Testing

- 24 tracker cases across 3 phases: 643 api + 156 web pass, typecheck + lint + `build:web` clean.
- Every phase gated: simplify → suite → thermo-nuclear review + an independent codex adversarial pass (the encoding bug above was its one BLOCK).
- Browser-smoked on the local full stack: feed request fires, tab renders seeded rows, deep link opens the review thread (screenshot above).

Tracker (full journal + decisions): https://glance.plivo.com/samuel-lawerence/comments-tab-progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TkquRKQe5kUVSQb2qpYBr8