### PR TITLE
Fork: copy a site you can read into a space of your own

### DIFF
--- a/glance-cli/SKILL.md
+++ b/glance-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: glance-cli
-description: Use the `glance` CLI to build a self-contained HTML explainer/dashboard for a codebase or system and publish it — "explain with html", "make an html dashboard", "visualize this architecture", "a simple HTML summary for my boss" — or to deploy any file/folder to a Glance instance and get a URL, manage sites (list, delete, move), and close the review loop from the terminal (pull a site's review comments, reply to a thread, then redeploy).
+description: Use the `glance` CLI to build a self-contained HTML explainer/dashboard for a codebase or system and publish it — "explain with html", "make an html dashboard", "visualize this architecture", "a simple HTML summary for my boss" — or to deploy any file/folder to a Glance instance and get a URL, manage sites (list, delete, move, fork), and close the review loop from the terminal (pull a site's review comments, reply to a thread, then redeploy).
 ---
 
 # Glance CLI
@@ -34,6 +34,7 @@ Put it in your shell profile to make it permanent. Token + URL are saved to `~/.
 | `glance list` | lists your sites — `space/slug  visibility  url` |
 | `glance delete <space/slug>` | confirms (y/N), then deletes |
 | `glance move <space/slug> <new-space>` | moves a site to another space you belong to (keeps its files, comments, shares) |
+| `glance fork <space/slug> [--space <slug>] [--name <slug>]` | copies a site you can open into your own space — your copy, to edit freely |
 | `glance comments <space/slug> [--file <path>] [--open] [--json]` | prints a site's review comments as a markdown digest (or raw JSON) |
 | `glance reply <space/slug> <threadId> [message] [--tag <label>\|--no-tag]` | posts a reply to a comment thread (get the `threadId` from `glance comments`) |
 | `glance read <space/slug> [--file <path>] [--pull <dir>]` | prints a file to stdout, or `--pull` downloads the whole site's source into a folder to edit + redeploy |
@@ -78,6 +79,21 @@ Argument must be `space/slug` (with the slash), e.g. `glance delete docs/api-ref
 
 ### move
 Move an existing site into another space you belong to: `glance move <space/slug> <new-space>`, e.g. `glance move my-handle/api-reference docs`. The site keeps its files, comments and shares — only its URL changes to `/<new-space>/<slug>`. Owner-only. Fails if a site with the same slug already exists in the target space.
+
+### fork
+Make your own copy of a site you can open: `glance fork <space/slug>`, e.g. `glance fork alice/roadmap`. Anyone who can *view* a site can fork it.
+
+- The copy lands in your **personal space** as `<slug>-copy` (then `-copy-2`, `-copy-3`… if that's taken). Prints `✓ Forked → <url>`.
+- `--space <slug>` forks into a team/group space you belong to instead.
+- `--name <slug>` names the new site (same meaning as `deploy --name` — it's the new site's slug).
+- The fork is **yours and independent**: you own it, it starts with the source's files, and it carries none of the original's comments or shares. Editing it never touches the original.
+
+```bash
+glance fork alice/roadmap                                  # → /<you>/roadmap-copy
+glance fork docs/api-reference --space team --name api-v2  # → /team/api-v2
+```
+
+Use it when you want to riff on someone's page instead of commenting on it — fork, `glance read --pull` your copy, edit, redeploy.
 
 ### comments
 Pulls the review comments (threads) on a deployed site so an agent can read them from the terminal.

--- a/packages/api/drizzle/0013_fork_site.sql
+++ b/packages/api/drizzle/0013_fork_site.sql
@@ -1,0 +1,6 @@
+-- Fork ("remix"): provenance for a site copied from another site. Nullable — null means the site
+-- was deployed directly, not forked. ON DELETE SET NULL (not cascade): deleting the SOURCE must
+-- never delete its forks — a fork owns its own R2 objects (the bytes are COPIED to a fresh prefix,
+-- never shared), so only the provenance link is lost, not the content. Plain ADD COLUMN (nullable,
+-- no default) — no table rebuild, backfills every existing row to NULL.
+ALTER TABLE `sites` ADD COLUMN `forkedFrom` text REFERENCES `sites`(`id`) ON DELETE SET NULL;

--- a/packages/api/drizzle/meta/_journal.json
+++ b/packages/api/drizzle/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1783843200000,
       "tag": "0012_comments_author_index",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "6",
+      "when": 1784073600000,
+      "tag": "0013_fork_site",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/src/db/schema.ts
+++ b/packages/api/src/db/schema.ts
@@ -1,4 +1,4 @@
-import { index, integer, primaryKey, sqliteTable, text, unique } from 'drizzle-orm/sqlite-core'
+import { type AnySQLiteColumn, index, integer, primaryKey, sqliteTable, text, unique } from 'drizzle-orm/sqlite-core'
 
 // Column names mirror the spec's SQL exactly (camelCase) so raw `wrangler d1 execute`
 // queries in the runbook keep working. IDs are app-generated UUIDs; timestamps are ISO-8601.
@@ -53,6 +53,11 @@ export const sites = sqliteTable(
     // last swapped the bytes (owner id or an editor's user id) — read-only provenance today.
     contentVersion: integer('contentVersion').notNull().default(0),
     lastReplacedBy: text('lastReplacedBy'),
+    // Provenance for a forked ("remixed") site: the site it was copied from. Null = deployed
+    // directly. SET NULL (never cascade) — a fork's R2 objects are its OWN (fork COPIES the bytes
+    // to a fresh prefix; an object is referenced by exactly one file row, ever), so deleting the
+    // source may only drop the link, never the content.
+    forkedFrom: text('forkedFrom').references((): AnySQLiteColumn => sites.id, { onDelete: 'set null' }),
     createdAt: text('createdAt').notNull().$defaultFn(() => new Date().toISOString()),
   },
   (t) => [unique('sites_space_slug_unq').on(t.spaceId, t.slug), index('sites_owner').on(t.ownerId)],

--- a/packages/api/src/lib/storage.ts
+++ b/packages/api/src/lib/storage.ts
@@ -37,6 +37,53 @@ export async function deleteKeys(bucket: R2Bucket, keys: string[]): Promise<void
   }
 }
 
+// Bounded parallelism for the fork copy loop — mirrors the upload put loop, sized well under the
+// Workers subrequest budget (a fork is 2 subrequests per file: one get + one put).
+const COPY_CONCURRENCY = 10
+
+export type CopyableFile = { path: string; storageKey: string; mimeType: string | null; size: number | null }
+
+/**
+ * Copy a site's stored objects to a FRESH uuid prefix (fork). Returns the new file rows.
+ *
+ * The bytes are genuinely copied — a fork never shares an R2 object with its source. That keeps the
+ * system's core storage invariant intact: **an object is referenced by exactly one `files` row**, so
+ * deleting any site only ever deletes objects nothing else can reach. (The alternative — sharing keys
+ * and reference-counting the deletes — makes every delete path capable of stranding a live site, to
+ * optimize an operation that happens far less often than deploy. Not worth it.)
+ *
+ * The Workers R2 binding has no server-side copy, so this is a real get→put per file
+ * (https://developers.cloudflare.com/r2/api/workers/workers-api-reference/). If ANY object fails or
+ * is missing, every key written so far is deleted and the error propagates — the caller must not have
+ * committed rows yet, so a fork can never commit pointing at absent bytes.
+ */
+export async function copyObjects(
+  bucket: R2Bucket,
+  rows: CopyableFile[],
+  prefix: string,
+): Promise<CopyableFile[]> {
+  const plan = rows.map((r) => ({ from: r.storageKey, to: `${prefix}/${r.path}`, row: r }))
+  const written: string[] = []
+  try {
+    for (let i = 0; i < plan.length; i += COPY_CONCURRENCY) {
+      await Promise.all(
+        plan.slice(i, i + COPY_CONCURRENCY).map(async ({ from, to, row }) => {
+          const object = await bucket.get(from)
+          if (!object) throw new Error(`source object missing: ${from}`)
+          written.push(to)
+          await bucket.put(to, object.body, {
+            httpMetadata: { contentType: row.mimeType ?? 'application/octet-stream' },
+          })
+        }),
+      )
+    }
+  } catch (err) {
+    await deleteKeys(bucket, written)
+    throw err
+  }
+  return plan.map(({ to, row }) => ({ path: row.path, storageKey: to, mimeType: row.mimeType, size: row.size }))
+}
+
 /** Delete all R2 objects recorded for a site: the site's uploaded files AND its voice-comment
  *  audio (comments ⨝ threads on this site with a non-null audioKey), batched ≤1000. */
 export async function deleteSiteObjects(db: DrizzleD1Database, bucket: R2Bucket, siteId: string): Promise<void> {

--- a/packages/api/src/routes/sites-fork.test.ts
+++ b/packages/api/src/routes/sites-fork.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, test } from 'bun:test'
+import { eq, sql } from 'drizzle-orm'
+import { Hono } from 'hono'
+import { files as filesTable, sites as sitesTable } from '../db/schema'
+import { requireSameOrigin } from '../middleware/auth'
+import { makeDb, makeKv, makeR2, seedFile, seedMember, seedSite, seedSpace, seedUser, seedUserShare } from '../test/harness'
+import type { AppEnv } from '../types'
+import { sites } from './sites'
+
+// Fork ("remix"): any user who can READ a site may copy it into a space they belong to (default:
+// their personal space). The copy is INDEPENDENT — new id, new owner, fresh R2 objects under a new
+// prefix, no shares, no comments. The bytes are COPIED, never shared: an R2 object belongs to
+// exactly one file row, so deleting either site can never strand the other (the invariant that let
+// us drop reference-counted deletion entirely).
+
+const APP_URL = 'https://glance.example.com'
+
+async function setup() {
+  const db = makeDb()
+  const kv = makeKv()
+  const r2 = makeR2()
+  const env = {
+    APP_URL,
+    SESSION_SECRET: 's',
+    CONTENT_URL: 'https://content.example.com',
+    CONTENT_TOKEN_SECRET: 'ct',
+    GLANCE_SESSIONS: kv,
+    GLANCE_FILES: r2,
+  } as unknown as AppEnv['Bindings']
+  const app = new Hono<AppEnv>()
+  app.use('/api/*', requireSameOrigin)
+  app.use('/api/*', async (c, next) => {
+    c.set('db', db)
+    await next()
+  })
+  app.route('/api/sites', sites)
+
+  // owner in `acme`; `rd` is a plain team-tier reader with a personal space; `st` has no space.
+  await seedUser(db, { id: 'owner', email: 'owner@e.com' })
+  await seedSpace(db, { id: 'acme', slug: 'acme', createdBy: 'owner' })
+  await seedMember(db, 'acme', 'owner')
+  const site = await seedSite(db, { id: 'site', spaceId: 'acme', ownerId: 'owner', slug: 'doc', visibility: 'team', title: 'Doc' })
+  await seedFile(db, r2, site, { path: 'index.html', text: '<h1>hi</h1>', mimeType: 'text/html' })
+  await seedFile(db, r2, site, { path: 'a/style.css', text: 'body{}', mimeType: 'text/css' })
+
+  await seedUser(db, { id: 'rd', email: 'rd@e.com' })
+  await seedSpace(db, { id: 'rd-personal', slug: 'rd', type: 'personal', createdBy: 'rd' })
+  await seedMember(db, 'rd-personal', 'rd')
+
+  await seedUser(db, { id: 'st', email: 'st@e.com' })
+
+  for (const id of ['owner', 'rd', 'st'])
+    await kv.put(`cli:tok-${id}`, JSON.stringify({ id, email: `${id}@e.com`, name: null, role: 'member' }))
+  return { db, app, env, r2 }
+}
+
+const auth = (id: string) => ({ Authorization: `Bearer tok-${id}`, Origin: APP_URL, 'content-type': 'application/json' })
+const fork = (app: Hono<AppEnv>, env: AppEnv['Bindings'], id: string, body: unknown = {}, path = '/api/sites/acme/doc/fork') =>
+  app.request(path, { method: 'POST', headers: auth(id), body: JSON.stringify(body) }, env)
+
+describe('POST /api/sites/:space/:site/fork', () => {
+  test('fork.reader.ok: a plain reader forks into their personal space; copy is independent', async () => {
+    const { db, app, env } = await setup()
+    const res = await fork(app, env, 'rd')
+    expect(res.status).toBe(200)
+    expect(await res.json()).toMatchObject({ spaceSlug: 'rd', siteSlug: 'doc-copy', url: `${APP_URL}/rd/doc-copy` })
+
+    const copy = (await db.select().from(sitesTable).where(eq(sitesTable.slug, 'doc-copy')))[0]
+    expect(copy).toMatchObject({ ownerId: 'rd', spaceId: 'rd-personal', forkedFrom: 'site', contentVersion: 0 })
+    expect(copy?.id).not.toBe('site')
+  })
+
+  test('fork.files.copied: every file row is reproduced with FRESH storage keys (no shared objects)', async () => {
+    const { db, app, env, r2 } = await setup()
+    await fork(app, env, 'rd')
+    const copy = (await db.select().from(sitesTable).where(eq(sitesTable.slug, 'doc-copy')))[0]
+
+    const src = await db.select().from(filesTable).where(eq(filesTable.siteId, 'site'))
+    const dst = await db.select().from(filesTable).where(eq(filesTable.siteId, copy?.id ?? ''))
+    expect(dst.map((f) => f.path).sort()).toEqual(['a/style.css', 'index.html'])
+
+    // The invariant the whole design rests on: one R2 object, one file row.
+    const srcKeys = new Set(src.map((f) => f.storageKey))
+    for (const f of dst) expect(srcKeys.has(f.storageKey)).toBe(false)
+
+    // Bytes really were copied — the new keys resolve to the same content.
+    const idx = dst.find((f) => f.path === 'index.html')
+    expect(await (await r2.get(idx?.storageKey ?? ''))?.text()).toBe('<h1>hi</h1>')
+    expect(dst.find((f) => f.path === 'index.html')?.mimeType).toBe('text/html')
+  })
+
+  test('fork.deleting.source.keeps.copy: purging the source never touches the fork’s objects', async () => {
+    const { db, app, env, r2 } = await setup()
+    // The harness runs with FK enforcement OFF (bun:sqlite default) so seeds can reference absent
+    // parents — but `forkedFrom`'s ON DELETE SET NULL is exactly what this test is here to pin, and
+    // it's a FK action. Turn FKs on for this one connection so the real D1 behaviour is exercised.
+    await db.run(sql`PRAGMA foreign_keys = ON`)
+    await fork(app, env, 'rd')
+    const copy = (await db.select().from(sitesTable).where(eq(sitesTable.slug, 'doc-copy')))[0]
+    const dst = await db.select().from(filesTable).where(eq(filesTable.siteId, copy?.id ?? ''))
+
+    const del = await app.request('/api/sites/acme/doc', { method: 'DELETE', headers: auth('owner') }, env)
+    expect(del.status).toBe(200)
+
+    for (const f of dst) expect(await r2.get(f.storageKey)).not.toBeNull()
+    // forkedFrom is SET NULL on source delete — provenance is lost, the content is not.
+    const after = (await db.select().from(sitesTable).where(eq(sitesTable.id, copy?.id ?? '')))[0]
+    expect(after?.forkedFrom).toBeNull()
+  })
+
+  test('fork.slug.collision: a second fork lands on doc-copy-2', async () => {
+    const { app, env } = await setup()
+    await fork(app, env, 'rd')
+    const res = await fork(app, env, 'rd')
+    expect(res.status).toBe(200)
+    expect(await res.json()).toMatchObject({ siteSlug: 'doc-copy-2' })
+  })
+
+  test('fork.custom.slug: an explicit slug is honoured; an invalid one 400s', async () => {
+    const { app, env } = await setup()
+    expect(await (await fork(app, env, 'rd', { slug: 'my-fork' })).json()).toMatchObject({ siteSlug: 'my-fork' })
+    expect((await fork(app, env, 'rd', { slug: 'Not A Slug' })).status).toBe(400)
+  })
+
+  test('fork.no.read.403: a stranger with no access cannot fork', async () => {
+    const { db, app, env } = await setup()
+    await db.update(sitesTable).set({ visibility: 'private' }).where(eq(sitesTable.id, 'site'))
+    expect((await fork(app, env, 'st')).status).toBe(403)
+  })
+
+  test('fork.shared.reader.ok: a viewer-share on a PRIVATE site is enough to fork it', async () => {
+    const { db, app, env } = await setup()
+    await db.update(sitesTable).set({ visibility: 'private' }).where(eq(sitesTable.id, 'site'))
+    await seedUserShare(db, 'site', 'rd', 'viewer')
+    expect((await fork(app, env, 'rd')).status).toBe(200)
+  })
+
+  test('fork.dest.space.membership: forking into a space you are not in is 403', async () => {
+    const { app, env } = await setup()
+    expect((await fork(app, env, 'rd', { space: 'acme' })).status).toBe(403)
+  })
+
+  test('fork.no.personal.space: a user with no space and no explicit dest 400s (never silently drops)', async () => {
+    const { app, env } = await setup()
+    // `st` can READ (team tier) but has no personal space to fork into.
+    expect((await fork(app, env, 'st')).status).toBe(400)
+  })
+
+  test('fork.missing.404: forking a site that does not exist', async () => {
+    const { app, env } = await setup()
+    expect((await fork(app, env, 'rd', {}, '/api/sites/acme/nope/fork')).status).toBe(404)
+  })
+
+  test('fork.archived.410: an archived site cannot be forked', async () => {
+    const { db, app, env } = await setup()
+    await db.update(sitesTable).set({ status: 'archived' }).where(eq(sitesTable.id, 'site'))
+    expect((await fork(app, env, 'rd')).status).toBe(410)
+  })
+})

--- a/packages/api/src/routes/sites.ts
+++ b/packages/api/src/routes/sites.ts
@@ -1,4 +1,5 @@
 import { and, desc, eq, inArray, or, sql } from 'drizzle-orm'
+import type { DrizzleD1Database } from 'drizzle-orm/d1'
 import { Hono } from 'hono'
 import {
   type ShareUser,
@@ -17,9 +18,9 @@ import { canReplace, checkAccess } from '../lib/access'
 import { batchAll, chunk, D1_MAX_IN } from '../lib/d1'
 import { pureAudioSql } from '../lib/site-audio'
 import { readSessionOrBearer } from '../lib/session'
-import { resolveSite } from '../lib/site-access'
+import { resolveSite, resolveSiteForAccess } from '../lib/site-access'
 import { isValidSlug } from '../lib/slug'
-import { deleteSiteObjects } from '../lib/storage'
+import { copyObjects, deleteKeys, deleteSiteObjects } from '../lib/storage'
 import { signToken } from '../lib/token'
 import { isVisibility, normalizeVisibility } from '../lib/visibility'
 import { requireAuth } from '../middleware/auth'
@@ -585,6 +586,119 @@ sites.post('/:spaceSlug/:siteSlug/move', requireAuth, async (c) => {
 
   await db.update(sitesTable).set({ spaceId: dest.id }).where(eq(sitesTable.id, site.id))
   return c.json({ ok: true, spaceSlug: dest.slug, siteSlug: site.slug, url: `${c.env.APP_URL}/${dest.slug}/${site.slug}` })
+})
+
+// A forked slug: `doc` → `doc-copy`, then `doc-copy-2`, `-3`… on collision. Bounded so a pathological
+// space can't spin here; past the cap the caller must name the fork explicitly.
+const FORK_SLUG_TRIES = 50
+
+async function freeForkSlug(db: DrizzleD1Database, spaceId: string, base: string): Promise<string | null> {
+  const taken = new Set(
+    (await db.select({ slug: sitesTable.slug }).from(sitesTable).where(eq(sitesTable.spaceId, spaceId))).map(
+      (r) => r.slug,
+    ),
+  )
+  for (let n = 1; n <= FORK_SLUG_TRIES; n++) {
+    const slug = n === 1 ? `${base}-copy` : `${base}-copy-${n}`
+    if (!taken.has(slug) && isValidSlug(slug)) return slug
+  }
+  return null
+}
+
+// POST /api/sites/:spaceSlug/:siteSlug/fork — copy a site you can READ into a space you belong to
+// (default: your personal space). The fork is INDEPENDENT: new id, new owner, its own R2 objects,
+// no shares, no comments, version 0. Read access is the whole gate — if you can open it, you can
+// fork it (you could already download the bytes and redeploy them by hand).
+sites.post('/:spaceSlug/:siteSlug/fork', requireAuth, async (c) => {
+  const user = c.get('user')
+  const db = c.get('db')
+  const { spaceSlug, siteSlug } = c.req.param()
+
+  const { site, access } = await resolveSiteForAccess(db, spaceSlug, siteSlug, user)
+  if (!site) return c.json({ error: 'not found' }, 404)
+  if (!access.ok) return c.json({ error: 'forbidden' }, access.status)
+
+  const body = (await c.req.json().catch(() => null)) as { space?: unknown; slug?: unknown; title?: unknown } | null
+  const wantSpace = body?.space
+  const wantSlug = body?.slug
+  if (wantSpace !== undefined && typeof wantSpace !== 'string') return c.json({ error: 'invalid space' }, 400)
+  if (wantSlug !== undefined && typeof wantSlug !== 'string') return c.json({ error: 'invalid slug' }, 400)
+  if (typeof wantSlug === 'string' && !isValidSlug(wantSlug)) return c.json({ error: 'invalid slug' }, 400)
+
+  // Destination: an explicitly named space, else the caller's personal space. A user with neither
+  // gets a 400 — never a silent fork into somewhere they didn't ask for.
+  const dest = (
+    await db
+      .select({ id: spaces.id, slug: spaces.slug })
+      .from(spaces)
+      .where(
+        typeof wantSpace === 'string'
+          ? eq(spaces.slug, wantSpace)
+          : and(eq(spaces.type, 'personal'), eq(spaces.createdBy, user.id)),
+      )
+      .limit(1)
+  )[0]
+  if (!dest) {
+    return typeof wantSpace === 'string'
+      ? c.json({ error: 'space not found' }, 404)
+      : c.json({ error: 'no personal space — name a destination space' }, 400)
+  }
+  // Same rule as `move`: you can't drop a site into a space you're not in.
+  if (user.role !== 'superadmin' && !(await isSpaceMember(db, dest.id, user.id))) {
+    return c.json({ error: 'forbidden' }, 403)
+  }
+
+  const slug = typeof wantSlug === 'string' ? wantSlug : await freeForkSlug(db, dest.id, site.slug)
+  if (!slug) return c.json({ error: 'could not derive a free slug — name the fork explicitly' }, 409)
+
+  const sourceFiles = await db
+    .select({
+      path: filesTable.path,
+      storageKey: filesTable.storageKey,
+      mimeType: filesTable.mimeType,
+      size: filesTable.size,
+    })
+    .from(filesTable)
+    .where(eq(filesTable.siteId, site.id))
+
+  // Copy the bytes BEFORE any D1 write: a failed/missing object aborts with nothing committed and
+  // every copied key reclaimed, so a fork can never exist pointing at absent bytes.
+  const copied = await copyObjects(c.env.GLANCE_FILES, sourceFiles, crypto.randomUUID())
+  const newKeys = copied.map((f) => f.storageKey)
+
+  const id = crypto.randomUUID()
+  const title = typeof body?.title === 'string' && body.title.trim() ? body.title.trim().slice(0, 200) : site.title
+  try {
+    await db.batch([
+      db.insert(sitesTable).values({
+        id,
+        spaceId: dest.id,
+        slug,
+        title,
+        // Inherit the source's tier: a fork of a private site is private, not silently widened.
+        visibility: site.visibility,
+        ownerId: user.id,
+        forkedFrom: site.id,
+      }),
+      ...copied.map((f) => db.insert(filesTable).values({ id: crypto.randomUUID(), siteId: id, ...f })),
+    ])
+  } catch (err) {
+    // Don't orphan the objects we just wrote (e.g. a concurrent fork won the (spaceId, slug) unique).
+    await deleteKeys(c.env.GLANCE_FILES, newKeys)
+    if (isUniqueConstraintError(err)) {
+      return c.json({ error: 'a site with this slug already exists in that space', conflict: true }, 409)
+    }
+    throw err
+  }
+
+  return c.json({
+    id,
+    spaceSlug: dest.slug,
+    siteSlug: slug,
+    fileCount: copied.length,
+    forkedFrom: `${spaceSlug}/${siteSlug}`,
+    url: `${c.env.APP_URL}/${dest.slug}/${slug}`,
+  })
 })
 
 // DELETE /api/sites/:spaceSlug/:siteSlug — hard delete (owner or superadmin). Purges R2 first.

--- a/packages/api/src/routes/whats-new.test.ts
+++ b/packages/api/src/routes/whats-new.test.ts
@@ -12,8 +12,11 @@ import { findOrCreateUser } from './auth'
 import { whatsNew } from './whats-new'
 
 const APP_URL = 'https://glance.example.com'
-// A watermark strictly between the two seeded releases (2026-06-20 links, 2026-07-01 voice), so
-// exactly the newest one is unread.
+// A watermark inside the real catalog's range: older than 2026-07-01 (voice) but newer than
+// 2026-06-20 (links). Everything published after it counts as unread.
+// CATALOG-COUPLED: the unreadCount literals below (`3`) = the number of releases dated after MID.
+// Adding a release note NEWER than MID bumps them — rebuild with `bun run build:whatsnew`, then
+// bump these. (links 06-20 | MID | voice 07-01, comments-tab 07-11, fork 07-14 → 3 unread.)
 const MID = '2026-06-25T00:00:00.000Z'
 
 function setup() {
@@ -56,7 +59,7 @@ describe('C6 route.auth.401 — unauthenticated GET and POST both 401, watermark
 })
 
 describe('C7 route.get.exactJSON — exact ordered items, unreadCount, throughDate', () => {
-  test('mid watermark → exact slugs/dates/bodies + unreadCount 1 + throughDate===newest', async () => {
+  test('mid watermark → exact slugs/dates/bodies + unreadCount 3 + throughDate===newest', async () => {
     const { app, db, kv, env } = setup()
     const id = await seedUser(db, { id: 'u1' })
     await db.update(users).set({ lastSeenReleaseAt: MID }).where(eq(users.id, id))
@@ -65,7 +68,7 @@ describe('C7 route.get.exactJSON — exact ordered items, unreadCount, throughDa
     // Whole-response deep-equal, not key-presence: a dropped item field or an extra top-level key fails.
     expect(await res.json()).toEqual({
       items: JSON.parse(JSON.stringify(RELEASES)),
-      unreadCount: 2,
+      unreadCount: 3,
       throughDate: NEWEST_RELEASE_DATE,
     })
   })
@@ -140,6 +143,6 @@ describe('B3 relogin.noReset — the existing-user branch must not clear an exis
     await findOrCreateUser(db, { SUPERADMIN_EMAIL: 'boss@example.com' } as never, { sub: 'g1', name: 'A2' } as never, 'a@example.com')
     expect(await getWatermark(db, first.id)).toBe(before as string)
     const res = await app.request('/api/whats-new', { headers: await mintBearer(kv, first.id) }, env)
-    expect(((await res.json()) as { unreadCount: number }).unreadCount).toBe(2)
+    expect(((await res.json()) as { unreadCount: number }).unreadCount).toBe(3)
   })
 })

--- a/packages/api/src/test/harness.ts
+++ b/packages/api/src/test/harness.ts
@@ -43,6 +43,7 @@ const MIGRATIONS = [
   'drizzle/0010_notifications.sql',
   'drizzle/0011_whats_new_watermark.sql',
   'drizzle/0012_comments_author_index.sql',
+  'drizzle/0013_fork_site.sql',
 ]
 
 // --- S0 recorder: one shared, ordered timeline across D1/R2/cache mocks so perf specs can

--- a/packages/api/src/whats-new/catalog.ts
+++ b/packages/api/src/whats-new/catalog.ts
@@ -4,6 +4,13 @@ import type { Release } from './bake'
 
 export const RELEASES: Release[] = [
   {
+    "slug": "fork-a-site",
+    "title": "Make it your own — fork any site",
+    "date": "2026-07-14T12:00:00.000Z",
+    "featured": true,
+    "bodyHtml": "<p>Found a site you want to build on? <strong>Fork</strong> it. You get your own copy in your own space — edit it, redeploy it, break it, without touching the original.</p>\n<ul>\n<li>Fork from the <strong>⋯ menu</strong> on the dashboard, or straight from the <strong>top bar</strong> of any site you&#39;re viewing</li>\n<li>Anyone who can open a site can fork it, so a page someone shared with you is yours to riff on</li>\n<li>The copy is completely independent: your own files, your own comments, your own sharing</li>\n<li>Handy before a risky redeploy — fork first, and you&#39;ve got a snapshot to fall back on</li>\n</ul>\n"
+  },
+  {
     "slug": "comments-tab",
     "title": "All your comments, one feed",
     "date": "2026-07-11T12:00:00.000Z",
@@ -26,4 +33,4 @@ export const RELEASES: Release[] = [
   }
 ]
 
-export const NEWEST_RELEASE_DATE: string | null = "2026-07-11T12:00:00.000Z"
+export const NEWEST_RELEASE_DATE: string | null = "2026-07-14T12:00:00.000Z"

--- a/packages/api/src/whats-new/notes/2026-07-14-fork-a-site.md
+++ b/packages/api/src/whats-new/notes/2026-07-14-fork-a-site.md
@@ -1,0 +1,12 @@
+---
+title: Make it your own — fork any site
+slug: fork-a-site
+date: 2026-07-14T12:00:00.000Z
+featured: true
+---
+Found a site you want to build on? **Fork** it. You get your own copy in your own space — edit it, redeploy it, break it, without touching the original.
+
+- Fork from the **⋯ menu** on the dashboard, or straight from the **top bar** of any site you're viewing
+- Anyone who can open a site can fork it, so a page someone shared with you is yours to riff on
+- The copy is completely independent: your own files, your own comments, your own sharing
+- Handy before a risky redeploy — fork first, and you've got a snapshot to fall back on

--- a/packages/cli/SKILL.md
+++ b/packages/cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: glance-cli
-description: Use the `glance` CLI to build a self-contained HTML explainer/dashboard for a codebase or system and publish it — "explain with html", "make an html dashboard", "visualize this architecture", "a simple HTML summary for my boss" — or to deploy any file/folder to a Glance instance and get a URL, manage sites (list, delete, move), and close the review loop from the terminal (pull a site's review comments, reply to a thread, then redeploy).
+description: Use the `glance` CLI to build a self-contained HTML explainer/dashboard for a codebase or system and publish it — "explain with html", "make an html dashboard", "visualize this architecture", "a simple HTML summary for my boss" — or to deploy any file/folder to a Glance instance and get a URL, manage sites (list, delete, move, fork), and close the review loop from the terminal (pull a site's review comments, reply to a thread, then redeploy).
 ---
 
 # Glance CLI
@@ -34,6 +34,7 @@ Put it in your shell profile to make it permanent. Token + URL are saved to `~/.
 | `glance list` | lists your sites — `space/slug  visibility  url` |
 | `glance delete <space/slug>` | confirms (y/N), then deletes |
 | `glance move <space/slug> <new-space>` | moves a site to another space you belong to (keeps its files, comments, shares) |
+| `glance fork <space/slug> [--space <slug>] [--name <slug>]` | copies a site you can open into your own space — your copy, to edit freely |
 | `glance comments <space/slug> [--file <path>] [--open] [--json]` | prints a site's review comments as a markdown digest (or raw JSON) |
 | `glance reply <space/slug> <threadId> [message] [--tag <label>\|--no-tag]` | posts a reply to a comment thread (get the `threadId` from `glance comments`) |
 | `glance read <space/slug> [--file <path>] [--pull <dir>]` | prints a file to stdout, or `--pull` downloads the whole site's source into a folder to edit + redeploy |
@@ -78,6 +79,21 @@ Argument must be `space/slug` (with the slash), e.g. `glance delete docs/api-ref
 
 ### move
 Move an existing site into another space you belong to: `glance move <space/slug> <new-space>`, e.g. `glance move my-handle/api-reference docs`. The site keeps its files, comments and shares — only its URL changes to `/<new-space>/<slug>`. Owner-only. Fails if a site with the same slug already exists in the target space.
+
+### fork
+Make your own copy of a site you can open: `glance fork <space/slug>`, e.g. `glance fork alice/roadmap`. Anyone who can *view* a site can fork it.
+
+- The copy lands in your **personal space** as `<slug>-copy` (then `-copy-2`, `-copy-3`… if that's taken). Prints `✓ Forked → <url>`.
+- `--space <slug>` forks into a team/group space you belong to instead.
+- `--name <slug>` names the new site (same meaning as `deploy --name` — it's the new site's slug).
+- The fork is **yours and independent**: you own it, it starts with the source's files, and it carries none of the original's comments or shares. Editing it never touches the original.
+
+```bash
+glance fork alice/roadmap                                  # → /<you>/roadmap-copy
+glance fork docs/api-reference --space team --name api-v2  # → /team/api-v2
+```
+
+Use it when you want to riff on someone's page instead of commenting on it — fork, `glance read --pull` your copy, edit, redeploy.
 
 ### comments
 Pulls the review comments (threads) on a deployed site so an agent can read them from the terminal.

--- a/packages/cli/fork.go
+++ b/packages/cli/fork.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// fork copies a site you can READ into a space you belong to. Both flags are optional and the
+// SERVER owns the defaulting (your personal space, slug `<slug>-copy`, then `-copy-2`, …) - so an
+// omitted flag is omitted from the body rather than guessed at here, where a stale guess would
+// silently diverge from the server's collision suffixing.
+func (c *client) fork(argv []string) error {
+	positional, flags := parseArgs(argv, nil)
+	target := ""
+	if len(positional) > 0 {
+		target = positional[0]
+	}
+	usage := "Usage: glance fork <space/slug> [--space <slug>] [--name <slug>]"
+	space, name, err := splitSpaceSlug(target)
+	if err != nil {
+		return fmt.Errorf("%s", usage)
+	}
+
+	// `--name` is the NEW site slug (same meaning as `deploy --name`). Validate it up front with the
+	// same rule the server applies, so a typo reads as a usage error instead of a bare 400.
+	body := map[string]string{}
+	if raw, present := flags["space"]; present {
+		dest := raw.(string)
+		if dest == "" {
+			return fmt.Errorf("%s", usage)
+		}
+		body["space"] = dest
+	}
+	if raw, present := flags["name"]; present {
+		newName := raw.(string)
+		if !isValidSlug(newName) {
+			return fmt.Errorf("Invalid --name %q. Use a slug (lowercase, 3–40 chars).", newName)
+		}
+		body["slug"] = newName
+	}
+	if err := c.requireAuth(); err != nil {
+		return err
+	}
+
+	payload, _ := json.Marshal(body)
+	resp, err := c.authed("POST", "/api/sites/"+space+"/"+name+"/fork",
+		strings.NewReader(string(payload)), map[string]string{"Content-Type": "application/json"})
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if !ok(resp) {
+		return fmt.Errorf("Fork failed (%d): %s", resp.StatusCode, bodySlice(resp))
+	}
+	var out struct {
+		URL string `json:"url"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return err
+	}
+	fmt.Fprintf(c.out, "✓ Forked → %s\n", out.URL)
+	return nil
+}

--- a/packages/cli/fork_test.go
+++ b/packages/cli/fork_test.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestForkCommand(t *testing.T) {
+	// No flags: the body carries NO space/slug, so the server applies its own defaults (personal
+	// space, `<slug>-copy`). A client-side guess here would drift from the server's suffixing.
+	t.Run("posts-fork-with-empty-body-by-default", func(t *testing.T) {
+		srv, reqs := recordingServer(t, func(r *capturedReq) (int, string) {
+			return 200, `{"url":"https://g/me/api-copy","siteSlug":"api-copy"}`
+		})
+		c, out := newTestClient(srv.URL, "tok")
+		if err := c.fork([]string{"docs/api"}); err != nil {
+			t.Fatalf("fork: %v", err)
+		}
+		if len(*reqs) != 1 {
+			t.Fatalf("requests = %+v", *reqs)
+		}
+		r := (*reqs)[0]
+		if r.method != "POST" || r.path != "/api/sites/docs/api/fork" {
+			t.Fatalf("request = %+v", r)
+		}
+		if r.auth != "Bearer tok" || !strings.Contains(r.ct, "application/json") {
+			t.Fatalf("auth/ct = %q %q", r.auth, r.ct)
+		}
+		if string(r.body) != `{}` {
+			t.Fatalf("body = %q, want {}", r.body)
+		}
+		if !strings.Contains(out.String(), "https://g/me/api-copy") {
+			t.Fatalf("out = %q", out.String())
+		}
+	})
+
+	t.Run("space-and-name-flags-go-into-body", func(t *testing.T) {
+		srv, reqs := recordingServer(t, func(r *capturedReq) (int, string) {
+			return 200, `{"url":"https://g/team/api-v2"}`
+		})
+		c, out := newTestClient(srv.URL, "tok")
+		if err := c.fork([]string{"docs/api", "--space", "team", "--name", "api-v2"}); err != nil {
+			t.Fatalf("fork: %v", err)
+		}
+		r := (*reqs)[0]
+		if r.path != "/api/sites/docs/api/fork" {
+			t.Fatalf("path = %q", r.path)
+		}
+		// --name is the NEW SITE SLUG (as in `deploy --name`), so it maps to the body's `slug` field.
+		if !strings.Contains(string(r.body), `"space":"team"`) || !strings.Contains(string(r.body), `"slug":"api-v2"`) {
+			t.Fatalf("body = %q", r.body)
+		}
+		if !strings.Contains(out.String(), "✓ Forked → https://g/team/api-v2") {
+			t.Fatalf("out = %q", out.String())
+		}
+	})
+
+	t.Run("missing-target-usage-error", func(t *testing.T) {
+		c, _ := newTestClient("http://unused", "tok")
+		if err := c.fork(nil); err == nil {
+			t.Fatal("want usage error")
+		}
+	})
+
+	// a/b/c must not be truncated to a/b: reject the malformed source before hitting the network.
+	t.Run("extra-segments-rejected", func(t *testing.T) {
+		srv, reqs := recordingServer(t, func(r *capturedReq) (int, string) { return 200, `{}` })
+		c, _ := newTestClient(srv.URL, "tok")
+		if err := c.fork([]string{"docs/api/extra"}); err == nil {
+			t.Fatal("want usage error for extra segments")
+		}
+		if len(*reqs) != 0 {
+			t.Fatalf("must not send a request for a malformed target, got %+v", *reqs)
+		}
+	})
+
+	t.Run("invalid-name-rejected-before-request", func(t *testing.T) {
+		srv, reqs := recordingServer(t, func(r *capturedReq) (int, string) { return 200, `{}` })
+		c, _ := newTestClient(srv.URL, "tok")
+		if err := c.fork([]string{"docs/api", "--name", "NOPE!"}); err == nil {
+			t.Fatal("want error for an invalid slug")
+		}
+		if len(*reqs) != 0 {
+			t.Fatalf("must not send a request for an invalid slug, got %+v", *reqs)
+		}
+	})
+
+	// Usage errors beat "Not logged in" (house ordering: validate args, then requireAuth).
+	t.Run("requires-auth", func(t *testing.T) {
+		c, _ := newTestClient("http://unused", "")
+		err := c.fork([]string{"docs/api"})
+		if err == nil || !strings.Contains(err.Error(), "Not logged in") {
+			t.Fatalf("err = %v, want Not logged in", err)
+		}
+	})
+
+	// A slug collision (409) must surface the server's message, not a silent success.
+	t.Run("server-error-surfaces-status-and-body", func(t *testing.T) {
+		srv, _ := recordingServer(t, func(r *capturedReq) (int, string) {
+			return 409, `{"error":"slug taken"}`
+		})
+		c, out := newTestClient(srv.URL, "tok")
+		err := c.fork([]string{"docs/api"})
+		if err == nil || !strings.Contains(err.Error(), "409") || !strings.Contains(err.Error(), "slug taken") {
+			t.Fatalf("err = %v", err)
+		}
+		if strings.Contains(out.String(), "Forked") {
+			t.Fatalf("must not report success, out = %q", out.String())
+		}
+	})
+}

--- a/packages/cli/main.go
+++ b/packages/cli/main.go
@@ -53,7 +53,7 @@ func dispatch(cmd string, rest []string) error {
 			base, token = cfg.ApiUrl, cfg.Token
 		}
 		return newClient(base, token, os.Stdout).logout()
-	case "deploy", "list", "delete", "move", "comments", "read", "reply":
+	case "deploy", "list", "delete", "move", "fork", "comments", "read", "reply":
 		// Authed commands resolve the instance from the STORED config (not the env override) - the
 		// per-command requireAuth() inside each handler produces the clean "Not logged in" message.
 		cfg := readConfig()
@@ -71,6 +71,8 @@ func dispatch(cmd string, rest []string) error {
 			return c.del(rest)
 		case "move":
 			return c.move(rest)
+		case "fork":
+			return c.fork(rest)
 		case "comments":
 			return c.comments(rest)
 		case "read":
@@ -95,6 +97,7 @@ func printHelp() {
 	fmt.Println("  glance list")
 	fmt.Println("  glance delete <space/slug>")
 	fmt.Println("  glance move <space/slug> <new-space>")
+	fmt.Println("  glance fork <space/slug> [--space <slug>] [--name <slug>]")
 	fmt.Println("  glance comments <space/slug> [--file <path>] [--open] [--json]")
 	fmt.Println("  glance reply <space/slug> <threadId> [message] [--tag <label> | --no-tag]")
 	fmt.Println("  glance read <space/slug> [--file <path>] [--pull <dir>]")

--- a/packages/web/src/components/SitesTable.tsx
+++ b/packages/web/src/components/SitesTable.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useState } from 'react'
 import { useRevalidator } from 'react-router'
-import { Copy, FolderInput, MoreVertical, Pencil, Share2, Trash2 } from 'lucide-react'
+import { Copy, FolderInput, GitFork, MoreVertical, Pencil, Share2, Trash2 } from 'lucide-react'
 import { toast } from 'sonner'
 import { ConfirmDialog } from '@/components/ConfirmDialog'
 import { ShareDialog } from '@/components/ShareDialog'
@@ -34,6 +34,7 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { useForkSite } from '@/hooks/useForkSite'
 import { api } from '@/lib/api'
 import type { SiteSummary, SpaceSummary, Visibility } from '@/lib/types'
 
@@ -89,10 +90,12 @@ function OwnerVisibilityCell({ site }: { site: SiteSummary }) {
 
 type RowDialog = 'rename' | 'move' | 'share' | 'delete' | null
 
-// Open + a kebab that collapses Rename / Move / Share / Copy link / Delete.
+// Open + a kebab that collapses Rename / Move / Share / Copy link / Fork / Delete.
 function OwnerActions({ site }: { site: SiteSummary }) {
   const revalidator = useRevalidator()
   const [dialog, setDialog] = useState<RowDialog>(null)
+  // Fork needs no dialog: it POSTs an empty body and the API picks the destination + free slug.
+  const { fork, forking } = useForkSite(site)
   const refresh = () => revalidator.revalidate()
   const close = () => setDialog(null)
 
@@ -130,6 +133,10 @@ function OwnerActions({ site }: { site: SiteSummary }) {
           <DropdownMenuItem onSelect={() => void copyLink()}>
             <Copy />
             Copy link
+          </DropdownMenuItem>
+          <DropdownMenuItem disabled={forking} onSelect={() => void fork()}>
+            <GitFork />
+            Fork
           </DropdownMenuItem>
           <DropdownMenuSeparator />
           <DropdownMenuItem variant="destructive" onSelect={() => setDialog('delete')}>

--- a/packages/web/src/components/ViewerTopBar.tsx
+++ b/packages/web/src/components/ViewerTopBar.tsx
@@ -1,10 +1,12 @@
-import { Check, ChevronRight, Command, History, MessageSquare } from 'lucide-react'
+import { Check, ChevronRight, Command, GitFork, History, MessageSquare } from 'lucide-react'
 import { Link } from 'react-router'
+import { useForkSite } from '@/hooks/useForkSite'
 import type { ViewerSite } from '@/lib/types'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import { Segmented } from '@/components/ui/segmented'
 import { ShareDialog } from '@/components/ShareDialog'
+import { Spinner } from '@/components/states'
 import type { ReviewMode } from '@/components/review/ReviewRail'
 
 // Canvas width for the preview iframe: full-bleed, a wide column, or a narrow reading measure
@@ -22,8 +24,28 @@ const MODES = [
   { value: 'annotate', label: 'Annotate', title: 'Click an element to comment' },
 ] as const satisfies readonly { value: ReviewMode; label: string; title: string }[]
 
+// Copy this site into a space of your own. Deliberately NOT gated on site.isOwner (unlike Share):
+// anyone who can read a site can fork it, so a plain viewer gets this button too.
+function ForkButton({ site }: { site: ViewerSite }) {
+  const { fork, forking } = useForkSite(site)
+  return (
+    <Button
+      size="sm"
+      variant="ghost"
+      className="gap-1.5"
+      disabled={forking}
+      onClick={() => void fork()}
+      title="Copy this site into your own space"
+    >
+      {forking ? <Spinner className="size-3.5" /> : <GitFork className="size-3.5" />}
+      Fork
+    </Button>
+  )
+}
+
 // The persistent top chrome for the viewer: brand (→ dashboard) + a breadcrumb, then the actions.
-// Outside review: Comments (with an open count) + Share. In review: Read·Annotate, width, Share, Done.
+// Outside review: Comments (with an open count) + Fork + Share. In review: Read·Annotate, width,
+// Share, Done — review is a focused annotate mode, so Fork stays out of it.
 // Replaces the old floating PreviewToolbar dock.
 export function ViewerTopBar({
   site,
@@ -117,6 +139,7 @@ export function ViewerTopBar({
                 </span>
               )}
             </Button>
+            <ForkButton site={site} />
             {site.isOwner && <ShareDialog spaceSlug={site.spaceSlug} siteSlug={site.siteSlug} title={site.title} compact />}
           </>
         )}

--- a/packages/web/src/hooks/useForkSite.ts
+++ b/packages/web/src/hooks/useForkSite.ts
@@ -1,0 +1,44 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router'
+import { toast } from 'sonner'
+import { api } from '@/lib/api'
+
+// Fork = copy a site's files into a space of your own. ANY user who can READ a site can fork it,
+// so this is offered to plain viewers too — not just owners/editors (cf. the owner-only kebab
+// actions, which are gated by the table they live in).
+//
+// The empty body is the happy path: the API forks into the caller's personal space under
+// `<slug>-copy` (auto-deduped to `-copy-2`…), so the UI needs no dialog and no inputs.
+// On success we navigate to the fork — the response carries its space/site — which both shows the
+// result and (on the dashboard) leaves a route whose loader refetches the site list on return.
+interface ForkedSite {
+  spaceSlug: string
+  siteSlug: string
+  url: string
+}
+
+export function useForkSite(site: { spaceSlug: string; siteSlug: string }) {
+  const navigate = useNavigate()
+  const [forking, setForking] = useState(false)
+
+  async function fork() {
+    if (forking) return
+    setForking(true)
+    try {
+      const forked = await api.post<ForkedSite>(
+        `/api/sites/${site.spaceSlug}/${site.siteSlug}/fork`,
+        {},
+      )
+      toast.success('Site forked', { description: `${forked.spaceSlug}/${forked.siteSlug}` })
+      navigate(`/${forked.spaceSlug}/${forked.siteSlug}`)
+    } catch (err) {
+      toast.error('Could not fork site', {
+        description: err instanceof Error ? err.message : undefined,
+      })
+    } finally {
+      setForking(false)
+    }
+  }
+
+  return { fork, forking }
+}


### PR DESCRIPTION
Anyone who can **read** a site can fork it — they could already pull the bytes and redeploy them by hand. The copy is independent: new id, new owner, its own R2 objects, no shares, no comments, version 0.

- `POST /api/sites/:space/:site/fork` — empty body is the happy path: personal space, slug `<slug>-copy`, auto-deduped to `-copy-2`
- `glance fork <space/slug> [--space x] [--name y]`
- **Fork** in the dashboard row kebab and the viewer top bar (ungated from `isOwner`, so plain viewers get it)

## The decision worth reviewing

Fork **copies** the bytes (`get` → streaming `put` at a fresh uuid prefix) rather than pointing a second `files` row at the source's R2 objects. That preserves the invariant the rest of the system already relies on — **an object is referenced by exactly one `files` row** — so every existing delete path stays correct untouched, and `unique(storageKey)` stays.

The alternative (share keys, reference-count the deletes) makes fork free but makes *every* delete path capable of removing bytes a **live** site is serving, possibly in another space. Its prune race is not fixable by re-checking: the survivor query returns zero refs → a fork commits rows against those keys → prune deletes the objects → and [R2 delete is strongly consistent](https://developers.cloudflare.com/r2/reference/consistency/), so nothing heals it. Deploys are hot and forks are rare; paying get+put on the rare path buys a trivially safe deletion model on the hot one.

Two external reviewers (codex `gpt-5.6-sol`, cursor `grok-4.5`) independently rejected the shared-key design on these grounds before any code was written.

## Behaviour

| | |
|---|---|
| **Gate** | `checkAccess` — a plain viewer, or a viewer-share on a private site, suffices. Archived → 410. Destination must be a space you belong to. |
| **Commit order** | Bytes are copied **before** any D1 write. A missing/failed object aborts with nothing committed and every copied key reclaimed — a fork can never exist pointing at absent bytes. |
| **Provenance** | `sites.forkedFrom`, `ON DELETE SET NULL` (never cascade) — deleting the source drops the *link*, never the fork's content. |
| **Visibility** | Inherited from the source, so a fork never silently widens access. |

## Verification

- 11 new API tests (gate, slug suffixing, fresh-key invariant, source-delete) + 7 Go CLI tests. Full gate green: **654 api + 156 web** tests, `go test`, `go vet`, typecheck, lint.
- One test flips `PRAGMA foreign_keys = ON`: the harness runs with FK enforcement off by design, so `ON DELETE SET NULL` would otherwise have gone untested.
- **Smoked on real D1 + R2**, not the mocks: forked a site, deleted the **source** (which purges its R2 objects), and the fork still served every file byte-intact with `forkedFrom` nulled. Three distinct storage prefixes in D1, zero shared keys.

## Not in scope

Versioning/restore was considered and cut — the storage cost is inside R2's free tier, but the engineering surface (archive table, historical serving path, retention + GC job) was most of the slice. Source view/download deferred: it needs a same-origin raw proxy, since content is a separate origin and `?raw=1` sets neither CORS nor `Content-Disposition`.

## Open

- Fork isn't reachable from the "Shared with me" / "Team" dashboard rows — those tables have no kebab at all, so a viewer's path is: open the site → Fork in the top bar.
- **No What's New entry yet** — say if this warrants one before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018M1QFCMVEgHsScrB2gxaQd