### PR TITLE
Viewer top bar: label the summary button TL;DR

### DIFF
--- a/packages/api/src/whats-new/catalog.ts
+++ b/packages/api/src/whats-new/catalog.ts
@@ -8,7 +8,7 @@ export const RELEASES: Release[] = [
     "title": "TL;DR any site",
     "date": "2026-07-14T18:00:00.000Z",
     "featured": true,
-    "bodyHtml": "<p>Every site now has an AI summary one click away: hit <strong>Summarize</strong> in the viewer top bar, or <strong>Summary</strong> from a site&#39;s row menu on the dashboard.</p>\n<ul>\n<li>Summaries are cached — reopening one is instant and free until the site&#39;s content changes</li>\n<li>When content changes, the sheet shows what version the summary was written for and offers a one-click update</li>\n<li>Sites with a summary show a sparkle next to their name on the dashboard</li>\n</ul>\n"
+    "bodyHtml": "<p>Every site now has an AI summary one click away: hit <strong>TL;DR</strong> in the viewer top bar, or <strong>Summary</strong> from a site&#39;s row menu on the dashboard.</p>\n<ul>\n<li>Summaries are cached — reopening one is instant and free until the site&#39;s content changes</li>\n<li>When content changes, the sheet shows what version the summary was written for and offers a one-click update</li>\n<li>Sites with a summary show a sparkle next to their name on the dashboard</li>\n</ul>\n"
   },
   {
     "slug": "fork-a-site",

--- a/packages/api/src/whats-new/notes/2026-07-14-tldr-summaries.md
+++ b/packages/api/src/whats-new/notes/2026-07-14-tldr-summaries.md
@@ -4,7 +4,7 @@ slug: tldr-summaries
 date: 2026-07-14T18:00:00.000Z
 featured: true
 ---
-Every site now has an AI summary one click away: hit **Summarize** in the viewer top bar, or **Summary** from a site's row menu on the dashboard.
+Every site now has an AI summary one click away: hit **TL;DR** in the viewer top bar, or **Summary** from a site's row menu on the dashboard.
 
 - Summaries are cached — reopening one is instant and free until the site's content changes
 - When content changes, the sheet shows what version the summary was written for and offers a one-click update

--- a/packages/web/src/components/ViewerTopBar.tsx
+++ b/packages/web/src/components/ViewerTopBar.tsx
@@ -46,8 +46,8 @@ function ForkButton({ site }: { site: ViewerSite }) {
 }
 
 // The persistent top chrome for the viewer: brand (→ dashboard) + a breadcrumb, then the actions.
-// Outside review: Comments (with an open count) + Fork. Summarize and Share are always available.
-// In review: Read·Annotate, width, Summarize, Share, Done — review is a focused annotate mode, so
+// Outside review: Comments (with an open count) + Fork. TL;DR and Share are always available.
+// In review: Read·Annotate, width, TL;DR, Share, Done — review is a focused annotate mode, so
 // Fork stays out of it. Replaces the old floating PreviewToolbar dock.
 export function ViewerTopBar({
   site,
@@ -140,7 +140,7 @@ export function ViewerTopBar({
         )}
         <Button size="sm" variant="ghost" className="gap-1.5" title="AI summary" onClick={() => setSummaryOpen(true)}>
           <Sparkles className="size-3.5" />
-          Summarize
+          TL;DR
         </Button>
         {site.isOwner && <ShareDialog spaceSlug={site.spaceSlug} siteSlug={site.siteSlug} title={site.title} compact />}
         {review && (


### PR DESCRIPTION
The top-bar entry point reads better as **TL;DR** — the explicit **Summarize** CTA lives inside the sheet (empty state), and the dashboard row-menu item stays **Summary**. What's New copy updated to match; catalog regenerated (same date, no watermark-pin changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0144hFyjY8TVNTFB5795syjS