### PR TITLE
Review mode: Read default + mode toggle in the comments rail

### DIFF
--- a/packages/web/src/components/ViewerTopBar.tsx
+++ b/packages/web/src/components/ViewerTopBar.tsx
@@ -9,7 +9,6 @@ import { Segmented } from '@/components/ui/segmented'
 import { ShareDialog } from '@/components/ShareDialog'
 import { SummarySheet } from '@/components/SummarySheet'
 import { Spinner } from '@/components/states'
-import type { ReviewMode } from '@/components/review/ReviewRail'
 
 // Canvas width for the preview iframe: full-bleed, a wide column, or a narrow reading measure
 // (the wrapper letterboxes the rest).
@@ -20,11 +19,6 @@ const WIDTHS = [
   { value: 'wide', label: 'Wide', title: 'Wide column' },
   { value: 'reading', label: 'Read', title: 'Reading width' },
 ] as const satisfies readonly { value: CanvasWidth; label: string; title: string }[]
-
-const MODES = [
-  { value: 'read', label: 'Read', title: 'Browse the page' },
-  { value: 'annotate', label: 'Annotate', title: 'Click an element to comment' },
-] as const satisfies readonly { value: ReviewMode; label: string; title: string }[]
 
 // Copy this site into a space of your own. Deliberately NOT gated on site.isOwner (unlike Share):
 // anyone who can read a site can fork it, so a plain viewer gets this button too.
@@ -45,16 +39,14 @@ function ForkButton({ site }: { site: ViewerSite }) {
   )
 }
 
-// The persistent top chrome for the viewer: brand (→ dashboard) + a breadcrumb, then the actions.
-// Outside review: Comments (with an open count) + Fork. TL;DR and Share are always available.
-// In review: Read·Annotate, width, TL;DR, Share, Done — review is a focused annotate mode, so
-// Fork stays out of it. Replaces the old floating PreviewToolbar dock.
+// The persistent top chrome for the viewer: brand (→ dashboard) + a breadcrumb, then one action
+// row that stays put across modes — Comments (with an open count, outside review), Fork, TL;DR,
+// Share, and Done while reviewing. The Read·Annotate toggle lives in the ReviewRail header, next
+// to the comments it drives. Replaces the old floating PreviewToolbar dock.
 export function ViewerTopBar({
   site,
   sitePath,
   review,
-  mode,
-  onMode,
   width,
   onWidth,
   commentCount,
@@ -66,8 +58,6 @@ export function ViewerTopBar({
   site: ViewerSite
   sitePath: string
   review: boolean
-  mode: ReviewMode
-  onMode: (mode: ReviewMode) => void
   width: CanvasWidth
   onWidth: (width: CanvasWidth) => void
   commentCount: number
@@ -116,28 +106,24 @@ export function ViewerTopBar({
           </kbd>
         </Button>
         <Segmented value={width} options={WIDTHS} onChange={onWidth} />
-        {review ? (
-          <Segmented value={mode} options={MODES} onChange={onMode} />
-        ) : (
-          <>
-            <Button
-              size="sm"
-              variant="ghost"
-              onClick={onReview}
-              className={cn('gap-1.5', commentCount > 0 && 'text-primary')}
-              title={commentCount > 0 ? `${commentCount} open comment${commentCount === 1 ? '' : 's'}` : 'Comments'}
-            >
-              <MessageSquare className="size-3.5" />
-              Comments
-              {commentCount > 0 && (
-                <span className="flex h-4 min-w-4 items-center justify-center rounded-full bg-primary px-1 font-semibold text-[10px] text-primary-foreground leading-none tabular-nums">
-                  {commentCount > 9 ? '9+' : commentCount}
-                </span>
-              )}
-            </Button>
-            <ForkButton site={site} />
-          </>
+        {!review && (
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={onReview}
+            className={cn('gap-1.5', commentCount > 0 && 'text-primary')}
+            title={commentCount > 0 ? `${commentCount} open comment${commentCount === 1 ? '' : 's'}` : 'Comments'}
+          >
+            <MessageSquare className="size-3.5" />
+            Comments
+            {commentCount > 0 && (
+              <span className="flex h-4 min-w-4 items-center justify-center rounded-full bg-primary px-1 font-semibold text-[10px] text-primary-foreground leading-none tabular-nums">
+                {commentCount > 9 ? '9+' : commentCount}
+              </span>
+            )}
+          </Button>
         )}
+        <ForkButton site={site} />
         <Button size="sm" variant="ghost" className="gap-1.5" title="AI summary" onClick={() => setSummaryOpen(true)}>
           <Sparkles className="size-3.5" />
           TL;DR

--- a/packages/web/src/components/review/ReviewRail.tsx
+++ b/packages/web/src/components/review/ReviewRail.tsx
@@ -5,21 +5,28 @@ import { timestampPrefix } from '@/lib/audio'
 import type { Me, ViewerSite } from '@/lib/types'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
+import { Segmented } from '@/components/ui/segmented'
 import { AnchorChip } from '@/components/review/AnchorChip'
 import { Composer } from '@/components/review/Composer'
 import { ThreadCard } from '@/components/review/ThreadCard'
 
-// Read·Annotate lives on the ViewerTopBar; the type is shared from here (the rail owns the review
-// vocabulary).
 export type ReviewMode = 'read' | 'annotate'
+
+const MODES = [
+  { value: 'read', label: 'Read', title: 'Browse the page' },
+  { value: 'annotate', label: 'Annotate', title: 'Click an element to comment' },
+] as const satisfies readonly { value: ReviewMode; label: string; title: string }[]
 
 const byUpdatedDesc = (a: Thread, b: Thread) => b.updatedAt.localeCompare(a.updatedAt)
 
-// Persistent right-rail for review mode: filter (open/resolved), an anchor-prefilled composer on
-// select/pinpoint, and the thread list. Mode toggle + Done live in the ViewerTopBar.
+// Persistent right-rail for review mode: the Read·Annotate toggle in its header, filter
+// (open/resolved), an anchor-prefilled composer on select/pinpoint, and the thread list.
+// Done (exit review) lives in the ViewerTopBar.
 export function ReviewRail({
   site,
   me,
+  mode,
+  onMode,
   threads,
   composing,
   onCancelComposer,
@@ -33,6 +40,10 @@ export function ReviewRail({
 }: {
   site: ViewerSite
   me: Me | null
+  // Read·Annotate toggle in the rail header. Unset for content with no DOM to annotate (the
+  // audio view), which hides the toggle.
+  mode?: ReviewMode
+  onMode?: (mode: ReviewMode) => void
   threads: Thread[]
   composing: PendingAnchor | null
   onCancelComposer: () => void
@@ -75,6 +86,7 @@ export function ReviewRail({
     <aside className="flex max-h-[55vh] w-full shrink-0 flex-col border-t bg-background md:max-h-none md:h-full md:w-[360px] md:border-t-0 md:border-l">
       <header className="flex items-center justify-between gap-2 border-b px-4 py-3">
         <h2 className="font-semibold text-sm">Comments</h2>
+        {mode && onMode && <Segmented value={mode} options={MODES} onChange={onMode} />}
       </header>
 
       {composing ? (

--- a/packages/web/src/routes/viewer.tsx
+++ b/packages/web/src/routes/viewer.tsx
@@ -73,7 +73,7 @@ function Viewer() {
   const [review, setReview] = useState(false)
   // Within review, Read = normal browsing + text-select-to-comment; Annotate = also hover/click an
   // element to pinpoint it. Default annotate on entering review so element commenting works.
-  const [reviewMode, setReviewMode] = useState<ReviewMode>('annotate')
+  const [reviewMode, setReviewMode] = useState<ReviewMode>('read')
   const [width, setWidth] = useState<CanvasWidth>('full')
   const [loaded, setLoaded] = useState(false)
   const [me, setMe] = useState<Me | null>(null)
@@ -372,8 +372,6 @@ function Viewer() {
         site={site}
         sitePath={sitePath}
         review={review}
-        mode={reviewMode}
-        onMode={setReviewMode}
         width={width}
         onWidth={setWidth}
         commentCount={openCount}
@@ -430,6 +428,8 @@ function Viewer() {
           <ReviewRail
             site={site}
             me={me}
+            mode={isAudio ? undefined : reviewMode}
+            onMode={isAudio ? undefined : setReviewMode}
             threads={threads}
             composing={composing}
             onCancelComposer={() => setComposing(null)}


### PR DESCRIPTION
- Entering Comments defaults to **Read** (was Annotate)
- The Read·Annotate toggle moves out of the top bar into the **ReviewRail header**, right of the Comments heading (hidden on the audio view — no DOM to annotate)
- Top bar is now one stable action row across modes: Comments (outside review) · Fork · TL;DR · Share · Done (in review)

![review rail](https://github.com/plivo-labs/glance/releases/download/assets-site-summary/09-review-rail-toggle.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0144hFyjY8TVNTFB5795syjS