### PR TITLE
Render hosted HTML on a light canvas, not the app's dark theme

### DIFF
--- a/packages/web/src/routes/viewer.tsx
+++ b/packages/web/src/routes/viewer.tsx
@@ -396,7 +396,14 @@ function Viewer() {
             ) : (
               <iframe
                 ref={iframeRef}
-                className="size-full border-0 bg-background"
+                // Hosted HTML is rendered on a stable WHITE canvas (the browser's default page
+                // background that every uploaded document assumes), NOT the theme-aware
+                // `bg-background` — which is dark in dark mode, so a doc with hardcoded dark text
+                // and no background of its own showed dark-on-dark (invisible). A doc that designs
+                // itself dark still paints over this white with its own background. colorScheme:light
+                // keeps native controls/scrollbars consistent with the light canvas.
+                className="size-full border-0 bg-white"
+                style={{ colorScheme: 'light' }}
                 src={src}
                 title={site.title ?? site.siteSlug}
                 onLoad={() => setLoaded(true)}


### PR DESCRIPTION
## Problem
Hosted HTML that doesn't declare its own `color-scheme` renders **dark-on-dark and unreadable** in the viewer when the app is in dark mode. A normal light-mode report (hardcoded dark text, transparent background) is affected.

**Real deployed report in dark mode (before):**

![before](https://github.com/plivo-labs/glance/releases/download/assets-pr-dark-canvas/before-deployed-dark.png)

## Root cause — the viewer, not the document
The pulled source has **no `color-scheme` and no `background` on `html`/`body`** — a standard transparent light-mode page. Opened standalone, even under `prefers-color-scheme: dark`, **it renders perfectly** (proof it's blameless):

![doc renders fine standalone](https://github.com/plivo-labs/glance/releases/download/assets-pr-dark-canvas/doc-renders-fine-standalone.png)

It only breaks inside Glance: the content iframe used `bg-background` (dark in dark mode) and sits in the app's `color-scheme: dark` context. Chrome **propagates the embedder's dark `color-scheme` into a cross-origin iframe whose document declares none** → the doc's canvas resolves dark → the report's hardcoded dark text lands on a dark canvas. Light mode only worked because `bg-background` is white there.

## Fix (`packages/web/src/routes/viewer.tsx`)
Pin the content iframe to a stable light canvas — the browser's default page background every uploaded document assumes:
- `bg-white` (was `bg-background`)
- `style={{ colorScheme: 'light' }}` — makes a child document's *unspecified* scheme resolve light, defeating the propagation.

A document that **deliberately** designs itself dark still overrides both with its own `color-scheme`/background, so nothing regresses. Fixes **every existing hosted file**, not just future ones.

## Verification
- `bun run typecheck` (web + api), biome lint, `bun run build:web` — all green
- Document-is-blameless proven above; the in-viewer dark propagation reproduces only in the real deployed cross-origin viewer (Chrome won't fire it for `file://`/`srcdoc` headless), so the live after-shot will be captured post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
