### PR TITLE
Show the commenter's real name instead of the Reviewer placeholder

### DIFF
--- a/packages/web/src/components/review/ThreadCard.tsx
+++ b/packages/web/src/components/review/ThreadCard.tsx
@@ -59,7 +59,7 @@ export function ThreadCard({
         {thread.comments.map((c) => (
           <li key={c.id} className="group text-sm">
             <div className="flex items-center gap-2 text-muted-foreground text-xs">
-              <span className="font-medium text-foreground">{c.authorId === me?.id ? 'You' : 'Reviewer'}</span>
+              <span className="font-medium text-foreground">{c.authorId === me?.id ? 'You' : (c.author ?? 'Reviewer')}</span>
               <span>{fmt(c.createdAt)}</span>
               {c.hasAudio && !c.deleted && (
                 <Badge variant="secondary" className="gap-1 px-1.5 py-0 font-medium">


### PR DESCRIPTION
Every commenter who wasn't you rendered as the literal "Reviewer" in the review rail — the API has always sent each comment's `author` display name (`name ?? email`), but `ThreadCard` never read it. Now renders the real name, keeping "You" for your own comments and "Reviewer" only as the fallback for deleted/dangling users (`author` null).

Verified on the local stack with a seeded second user:

![author name](https://github.com/plivo-labs/glance/releases/download/assets-pr-comment-author/comment-author-name.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HabShybGX24hVioeHhdMSp