### PR TITLE
Onboarding: getting-started walkthrough on the empty dashboard + header help sheet

### DIFF
--- a/packages/web/src/components/AppShell.tsx
+++ b/packages/web/src/components/AppShell.tsx
@@ -5,6 +5,7 @@ import type { RootData } from '@/lib/notifications'
 import { api } from '@/lib/api'
 import { toggleTheme, useTheme } from '@/components/theme'
 import { CommandPalette } from '@/components/CommandPalette'
+import { HelpButton } from '@/components/HelpButton'
 import { NotificationsBell } from '@/components/NotificationsBell'
 import { WhatsNewButton } from '@/components/WhatsNewButton'
 import { Avatar, AvatarFallback } from '@/components/ui/avatar'
@@ -85,6 +86,7 @@ export function AppShell() {
             <Button variant="ghost" size="icon" onClick={toggleTheme} aria-label="Toggle theme" title="Toggle theme">
               {theme === 'dark' ? <Moon className="size-4" /> : <Sun className="size-4" />}
             </Button>
+            {user && <HelpButton />}
             {user && <WhatsNewButton whatsNew={whatsNew} />}
             {user && <NotificationsBell notifications={notifications} />}
             {user ? (

--- a/packages/web/src/components/CopyButton.tsx
+++ b/packages/web/src/components/CopyButton.tsx
@@ -27,6 +27,8 @@ export function CopyButton({
       variant={variant}
       size={size}
       className={className}
+      aria-label={label || 'Copy'}
+      title={label || 'Copy'}
       onClick={async () => {
         try {
           await navigator.clipboard.writeText(text)

--- a/packages/web/src/components/GettingStarted.tsx
+++ b/packages/web/src/components/GettingStarted.tsx
@@ -1,0 +1,77 @@
+import { MessageSquareText, Terminal } from 'lucide-react'
+import { CopyButton } from '@/components/CopyButton'
+
+// The onboarding walkthrough, rendered in TWO surfaces: the dashboard's empty sites tab and the
+// header HelpButton sheet. Prompt-first on purpose — the product pitch is "your AI writes the
+// HTML"; the CLI is plumbing. Every command and prompt is copyable.
+
+// One copyable line: mono text + an icon-only CopyButton. Used for shell commands and AI prompts
+// alike so the "grab this" affordance is identical everywhere.
+function CopyRow({ text, copiedMessage }: { text: string; copiedMessage: string }) {
+  return (
+    <div className="flex items-center gap-2 rounded-md border bg-muted/40 py-1 pr-1 pl-3">
+      <code className="min-w-0 flex-1 truncate font-mono text-xs" title={text}>
+        {text}
+      </code>
+      <CopyButton text={text} label="" copiedMessage={copiedMessage} variant="ghost" size="icon" className="shrink-0" />
+    </div>
+  )
+}
+
+function Step({ n, title, children }: { n: number; title: string; children: React.ReactNode }) {
+  return (
+    <li className="flex gap-3">
+      <span className="flex size-6 shrink-0 items-center justify-center rounded-full bg-primary/15 font-mono font-semibold text-primary text-xs">
+        {n}
+      </span>
+      <div className="min-w-0 flex-1 space-y-2">
+        <p className="font-medium text-sm leading-6">{title}</p>
+        {children}
+      </div>
+    </li>
+  )
+}
+
+const PROMPTS = [
+  'Explain this codebase with an HTML dashboard and publish it to glance',
+  'Turn these notes into a polished HTML page and deploy it to glance',
+]
+
+export function GettingStarted() {
+  const installCommand = `curl -fsSL ${window.location.origin}/api/install | sh`
+  return (
+    <div className="space-y-5">
+      <p className="text-muted-foreground text-sm">
+        Glance hosts self-contained HTML your AI builds — ship a page from the terminal, share the link, collect
+        comments.
+      </p>
+      <ol className="space-y-5">
+        <Step n={1} title="Install the CLI">
+          <CopyRow text={installCommand} copiedMessage="Install command copied" />
+          <p className="text-muted-foreground text-xs">
+            <Terminal className="mr-1 inline size-3 align-[-1px]" />
+            Also installs the glance skill, so Claude Code knows how to deploy here.
+          </p>
+        </Step>
+        <Step n={2} title="Sign in">
+          <CopyRow text="glance login" copiedMessage="Command copied" />
+        </Step>
+        <Step n={3} title="Ask your AI">
+          <div className="space-y-2">
+            {PROMPTS.map((prompt) => (
+              <CopyRow key={prompt} text={prompt} copiedMessage="Prompt copied" />
+            ))}
+          </div>
+          <p className="text-muted-foreground text-xs">
+            <MessageSquareText className="mr-1 inline size-3 align-[-1px]" />
+            Claude builds the HTML and runs <code className="font-mono">glance deploy</code> for you — or run it
+            yourself on any folder.
+          </p>
+        </Step>
+      </ol>
+      <p className="border-t pt-4 text-muted-foreground text-xs">
+        No CLI? Drop a folder or a lone HTML file on the dashboard to ship it straight from the browser.
+      </p>
+    </div>
+  )
+}

--- a/packages/web/src/components/HelpButton.tsx
+++ b/packages/web/src/components/HelpButton.tsx
@@ -1,0 +1,30 @@
+import { CircleHelp } from 'lucide-react'
+import { GettingStarted } from '@/components/GettingStarted'
+import { Button } from '@/components/ui/button'
+import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle, SheetTrigger } from '@/components/ui/sheet'
+
+// Header "?" next to the What's New sparkle: the same GettingStarted walkthrough the empty
+// dashboard shows, permanently reachable — e.g. grabbing the install one-liner on a new machine.
+export function HelpButton() {
+  return (
+    <Sheet>
+      <SheetTrigger asChild>
+        <Button variant="ghost" size="icon" aria-label="How to use Glance" title="How to use Glance">
+          <CircleHelp className="size-4" />
+        </Button>
+      </SheetTrigger>
+      <SheetContent side="right" className="flex w-full flex-col gap-0 p-0 sm:max-w-md">
+        <SheetHeader className="border-b px-5 py-4">
+          <SheetTitle className="flex items-center gap-2">
+            <CircleHelp className="size-4 text-primary" />
+            Using Glance
+          </SheetTitle>
+          <SheetDescription className="sr-only">How to install the CLI and publish your first site.</SheetDescription>
+        </SheetHeader>
+        <div className="flex-1 overflow-y-auto px-5 py-4">
+          <GettingStarted />
+        </div>
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/packages/web/src/routes/dashboard.tsx
+++ b/packages/web/src/routes/dashboard.tsx
@@ -12,6 +12,7 @@ import { ChevronDown, Download, ExternalLink, Mic, Plus, Rocket, Terminal, Uploa
 import { toast } from 'sonner'
 import { CopyButton } from '@/components/CopyButton'
 import { DeployCard } from '@/components/DeployCard'
+import { GettingStarted } from '@/components/GettingStarted'
 import { RecordDialog } from '@/components/record/RecordDialog'
 import {
   actionsColumn,
@@ -220,11 +221,11 @@ function TabBody({ tab }: { tab: DashboardTab }) {
         <TabPanel content={tab.content} what="your sites">
           {(sites) =>
             sites.length === 0 ? (
-              <EmptyState
-                icon={Rocket}
-                title="No sites yet"
-                description="Drop a folder above to ship your first."
-              />
+              <EmptyState icon={Rocket} title="No sites yet" className="mx-auto max-w-lg">
+                <div className="w-full text-left">
+                  <GettingStarted />
+                </div>
+              </EmptyState>
             ) : (
               <SitesTable sites={sites} />
             )


### PR DESCRIPTION
New users landing on an empty dashboard now get a 3-step walkthrough instead of a bare "No sites yet": install the CLI (origin-pointed `curl … /api/install | sh`), `glance login`, then copyable prompts to ask Claude for an HTML site. The same content is permanently reachable via a new `?` button in the shell header (Sheet, same pattern as What's New) — one shared `GettingStarted` component, two surfaces. `CopyButton` gains an accessible name so it works icon-only.

Empty dashboard:

![empty state](https://github.com/plivo-labs/glance/releases/download/assets-pr-onboarding/onboarding-empty-state.png)

Help sheet:

![help sheet](https://github.com/plivo-labs/glance/releases/download/assets-pr-onboarding/onboarding-help-sheet.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HabShybGX24hVioeHhdMSp