### PR TITLE
Drop the dashed box around the empty-dashboard walkthrough

### DIFF
--- a/packages/web/src/routes/dashboard.tsx
+++ b/packages/web/src/routes/dashboard.tsx
@@ -221,11 +221,15 @@ function TabBody({ tab }: { tab: DashboardTab }) {
         <TabPanel content={tab.content} what="your sites">
           {(sites) =>
             sites.length === 0 ? (
-              <EmptyState icon={Rocket} title="No sites yet" className="mx-auto max-w-lg">
-                <div className="w-full text-left">
-                  <GettingStarted />
+              <div className="mx-auto max-w-2xl py-10">
+                <div className="mb-6 flex flex-col items-center gap-3 text-center">
+                  <div className="flex size-11 items-center justify-center rounded-lg bg-muted text-muted-foreground">
+                    <Rocket className="size-5" />
+                  </div>
+                  <div className="font-medium">No sites yet</div>
                 </div>
-              </EmptyState>
+                <GettingStarted />
+              </div>
             ) : (
               <SitesTable sites={sites} />
             )


### PR DESCRIPTION
The EmptyState dashed card was narrower than the walkthrough content (screenshot in #53 comments showed the text overflowing the box). The empty sites tab now renders the rocket + "No sites yet" and the `GettingStarted` walkthrough in a plain centered column, widened to `max-w-2xl` so the prompts don't truncate.

![no box](https://github.com/plivo-labs/glance/releases/download/assets-pr-onboarding/onboarding-no-box.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HabShybGX24hVioeHhdMSp