### PR TITLE
Reposition: open-source alternative to Claude Artifacts, for every agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Glance
 
-**The human-in-the-loop review layer for coding agents.** Your agent builds something, deploys it to a URL with one command — you review it in the browser and drop comments like a Google Doc — and the agent reads your comments and fixes it.
+**Artifacts for every agent — open-source and self-hosted.** Your agent builds a self-contained page, dashboard, or app and ships it to a live URL with one command — from Claude Code, Cursor, Codex, Cline, Aider, or any harness that runs a shell command. Then you review it in the browser and drop comments like a Google Doc, and the agent reads your comments and fixes it.
 
-No more screenshotting your agent's output and pasting it back into the chat.
+An open-source alternative to Claude Artifacts — except you host it, you own it, and any agent can drive it. No more screenshotting your agent's output and pasting it back into the chat.
 
 <p align="center">
   <img src="https://github.com/plivo-labs/glance/releases/download/assets-readme/glance-demo.gif" alt="Glance demo: an agent deploys a folder to a URL, you leave review comments in the browser, and the agent reads the comments and fixes it" width="900">
@@ -14,7 +14,7 @@ No more screenshotting your agent's output and pasting it back into the chat.
   reads comments, fixes  ←  you comment in the browser
 ```
 
-Self-hosted on **Cloudflare's free tier** — $0/month, you own the whole loop. Ships with a CLI and an AI-agent skill, so agents drive deploy → pull comments → reply → redeploy with no human in the copy-paste path.
+Self-hosted on **Cloudflare's free tier** — $0/month, you own the whole loop. Ships with a CLI and an agent skill, so any agent — Claude Code, Cursor, Codex, Cline, Aider — drives deploy → pull comments → reply → redeploy with no human in the copy-paste path.
 
 Stack: Cloudflare Workers + Hono · React Router v7 · D1 · R2 · KV.
 
@@ -60,7 +60,7 @@ glance login          # device-code flow, opens browser
 glance deploy <path>  # file or folder → publishes to your personal space
 ```
 
-The installer bakes in your instance URL and installs the AI-agent skill so coding agents can drive the CLI.
+The installer bakes in your instance URL and installs the agent skill so coding agents can drive the CLI. Any agent that can run a shell command drives Glance by calling the `glance` CLI directly — it's harness-agnostic.
 
 | command | what it does |
 |---|---|

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "glance",
   "private": true,
   "type": "module",
-  "description": "Drop a folder of static files, get a URL. Self-hostable static hosting on Cloudflare Workers.",
+  "description": "An open-source alternative to Claude Artifacts for every coding agent — self-hosted on Cloudflare.",
   "author": "Plivo Inc.",
   "license": "MIT",
   "repository": {

--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -14,7 +14,11 @@
         }
       })()
     </script>
-    <title>Glance</title>
+    <title>Glance — Artifacts for every agent</title>
+    <meta
+      name="description"
+      content="An open-source alternative to Claude Artifacts. Any coding agent ships a self-contained page or app to a live URL, then you review it in the browser and the agent fixes it. Self-hosted on Cloudflare."
+    />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/packages/web/src/routes/login.tsx
+++ b/packages/web/src/routes/login.tsx
@@ -135,18 +135,19 @@ export function Component() {
               className="bp-rise mt-5 font-mono text-5xl font-semibold leading-[1.04] tracking-tight [text-shadow:0_2px_30px_rgba(7,11,22,0.85)] sm:text-6xl"
               style={{ animationDelay: '120ms' }}
             >
-              Ship static
+              Artifacts
               <br />
-              sites instantly.
+              for every
               <br />
-              <span className="text-primary">No build step.</span>
+              <span className="text-primary">agent.</span>
             </h1>
             <p
               className="bp-rise mt-6 max-w-md text-base leading-relaxed text-muted-foreground"
               style={{ animationDelay: '200ms' }}
             >
-              Glance is a self-hosted static host. Drop a folder of HTML, markdown, or assets — get a
-              live URL in seconds. No bundler, no Docker, no deploy pipeline to babysit.
+              An open-source alternative to Claude Artifacts. Any agent ships a self-contained page
+              or app to a live URL — then you review it in the browser and it fixes itself. No
+              bundler, no Docker, no deploy pipeline to babysit.
             </p>
 
             <ul


### PR DESCRIPTION
Repositions Glance as an **open-source alternative to Claude Artifacts, for every agent and harness** (not Claude Code specifically).

## What changed (copy only — typecheck + biome lint clean)
- **README** — hero → "Artifacts for every agent — open-source and self-hosted"; body adds the "open-source alternative to Claude Artifacts" line; CLI section spells out harness-agnostic (Claude Code, Cursor, Codex, Cline, Aider — any shell-capable agent drives the `glance` CLI).
- **Login hero** (`packages/web`) — h1 → "Artifacts / for every / agent."; subhead leads with the open-source-alternative line.
- **index.html** — `<title>` → "Glance — Artifacts for every agent" + a meta description.
- **package.json** — description updated.

Headers stay brand-free; "Claude Artifacts" appears only in body copy, as agreed.

Repo description + topics already updated live (added `artifacts`, `claude-artifacts`, `agent-agnostic`, `open-source`, `codex`, `cline`, `aider`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)