### PR TITLE
Hide the CLI-install banner once the user has used the CLI

### DIFF
--- a/packages/api/src/routes/auth-me.test.ts
+++ b/packages/api/src/routes/auth-me.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from 'bun:test'
+import { Hono } from 'hono'
+import { events } from '../db/schema'
+import { makeDb, makeKv, seedUser } from '../test/harness'
+import type { AppEnv } from '../types'
+import { auth } from './auth'
+
+// GET /api/auth/me — the hasUsedCli flag that gates the dashboard's CLI-install banner.
+
+function setup() {
+  const db = makeDb()
+  const kv = makeKv()
+  const env = {
+    APP_URL: 'https://glance.example.com',
+    SESSION_SECRET: 'sess-secret',
+    GLANCE_SESSIONS: kv,
+  } as unknown as AppEnv['Bindings']
+  const app = new Hono<AppEnv>()
+  app.use('*', async (c, next) => {
+    c.set('db', db)
+    await next()
+  })
+  app.route('/api/auth', auth)
+  return { app, env, db, kv }
+}
+
+async function bearer(kv: ReturnType<typeof makeKv>, userId: string) {
+  await kv.put(
+    `cli:tok-${userId}`,
+    JSON.stringify({ id: userId, email: `${userId}@x.com`, name: null, role: 'member' }),
+  )
+  return { Authorization: `Bearer tok-${userId}` }
+}
+
+describe('GET /api/auth/me — hasUsedCli', () => {
+  test('false for a user with no cli events', async () => {
+    const { app, env, db, kv } = setup()
+    const uid = await seedUser(db, { id: 'u1' })
+    const res = await app.request('/api/auth/me', { headers: await bearer(kv, uid) }, env)
+    expect(res.status).toBe(200)
+    expect(await res.json()).toMatchObject({ id: uid, hasUsedCli: false })
+  })
+
+  test('true once a cli event row exists', async () => {
+    const { app, env, db, kv } = setup()
+    const uid = await seedUser(db, { id: 'u1' })
+    await db.insert(events).values({ type: 'cli', action: 'upload', userId: uid })
+    const res = await app.request('/api/auth/me', { headers: await bearer(kv, uid) }, env)
+    expect(await res.json()).toMatchObject({ hasUsedCli: true })
+  })
+
+  test('view events and other users’ cli events do not count', async () => {
+    const { app, env, db, kv } = setup()
+    const uid = await seedUser(db, { id: 'u1' })
+    const other = await seedUser(db, { id: 'u2' })
+    await db.insert(events).values({ type: 'view', action: 'index.html', userId: uid })
+    await db.insert(events).values({ type: 'cli', action: 'upload', userId: other })
+    const res = await app.request('/api/auth/me', { headers: await bearer(kv, uid) }, env)
+    expect(await res.json()).toMatchObject({ hasUsedCli: false })
+  })
+})

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -1,8 +1,8 @@
 import { decodeIdToken, generateCodeVerifier, generateState } from 'arctic'
-import { eq } from 'drizzle-orm'
+import { and, eq } from 'drizzle-orm'
 import { Hono } from 'hono'
 import { deleteCookie, getSignedCookie, setSignedCookie } from 'hono/cookie'
-import { users } from '../db/schema'
+import { events, users } from '../db/schema'
 import { bootstrapSuperadminByEmail, createPersonalSpace, superadminStatus, toSessionUser } from '../db/repo'
 import { NEWEST_RELEASE_DATE } from '../whats-new/catalog'
 import { requireAuth } from '../middleware/auth'
@@ -94,7 +94,19 @@ auth.post('/logout', async (c) => {
   return c.json({ ok: true })
 })
 
-auth.get('/me', requireAuth, (c) => c.json(c.get('user')))
+// `hasUsedCli` rides along so the dashboard can hide the CLI-install banner for anyone whose CLI
+// has already made an authenticated call (an events row exists — see middleware/analytics.ts).
+// limit(1) is the EXISTS check; the events_user_created index serves it.
+auth.get('/me', requireAuth, async (c) => {
+  const user = c.get('user')
+  const used = await c
+    .get('db')
+    .select({ id: events.id })
+    .from(events)
+    .where(and(eq(events.type, 'cli'), eq(events.userId, user.id)))
+    .limit(1)
+  return c.json({ ...user, hasUsedCli: used.length > 0 })
+})
 
 // DEV ONLY: skip Google OAuth for local browser testing. Hard-gated to a localhost
 // APP_URL — in prod APP_URL is https://…workers.dev, so this 404s and can never run.

--- a/packages/web/src/lib/types.ts
+++ b/packages/web/src/lib/types.ts
@@ -8,6 +8,8 @@ export interface Me {
   email: string
   name: string | null
   role: 'member' | 'superadmin'
+  // True once any Bearer-authenticated CLI call landed an events row — gates the install banner.
+  hasUsedCli: boolean
 }
 
 // GET /api/config — public first-run config driving which login options the page offers.

--- a/packages/web/src/routes/dashboard.tsx
+++ b/packages/web/src/routes/dashboard.tsx
@@ -6,6 +6,7 @@ import {
   useLocation,
   useNavigate,
   useRevalidator,
+  useRouteLoaderData,
   useSearchParams,
 } from 'react-router'
 import { ChevronDown, Download, ExternalLink, Mic, Plus, Rocket, Terminal, Upload } from 'lucide-react'
@@ -60,6 +61,7 @@ import {
   feedRowPath,
 } from '@/lib/feedState'
 import { notificationHref } from '@/lib/mentions'
+import type { RootData } from '@/lib/notifications'
 import { timeAgo } from '@/lib/time'
 import type { CommentFeedItem, SiteSummary, SpaceSummary, TeamUpload } from '@/lib/types'
 
@@ -467,8 +469,12 @@ function DashboardToolbar({ spaces }: { spaces: SpaceSummary[] }) {
 // Onboarding banner under the hero: the one-liner installs the CLI *and* the agent skill, so a user
 // can hand it to their coding agent (Claude, Codex, Cursor) and start shipping from the terminal.
 // Pointed at THIS deployment's origin (mirrors GET /api/install), same as InstallDialog — no feed
-// needed, so it renders immediately, independent of every feed slot.
+// needed, so it renders immediately, independent of every feed slot. Hidden once the user's CLI
+// has made an authenticated call (me.hasUsedCli) — the install one-liner stays reachable via
+// NewMenu and the header HelpButton.
 function AgentSetup() {
+  const root = useRouteLoaderData('root') as RootData | undefined
+  if (root?.user?.hasUsedCli) return null
   const origin = typeof window !== 'undefined' ? window.location.origin : ''
   const installCmd = `curl -fsSL ${origin}/api/install | sh`
   return (


### PR DESCRIPTION
Closes the loop on the dashboard feedback: the `AgentSetup` install banner rendered unconditionally on every dashboard visit, even for long-time CLI users.

- **API**: `GET /api/auth/me` now returns `hasUsedCli` — a `LIMIT 1` existence check for a `type='cli'` row in the `events` stream (written by `trackCliUsage` on every Bearer-authenticated call), served by the existing `events_user_created` index. No migration.
- **Web**: `AgentSetup` returns `null` when `me.hasUsedCli` is true. The install one-liner stays reachable via the NewMenu "Install the CLI" entry and the header HelpButton.
- Tests: `auth-me.test.ts` pins false-when-no-events / true-after-cli-event / view-and-other-user-events-don't-count.

Caveat (accepted): pre-analytics CLI users see the banner until their next CLI call writes an events row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GwjQ7hmrN6z6GxtrgDwCzv