### PR TITLE
Comment notifications: bell + CLI + 'on my sites' feed arm

### DIFF
--- a/glance-cli/SKILL.md
+++ b/glance-cli/SKILL.md
@@ -38,6 +38,7 @@ Put it in your shell profile to make it permanent. Token + URL are saved to `~/.
 | `glance comments <space/slug> [--file <path>] [--open] [--json]` | prints a site's review comments as a markdown digest (or raw JSON) |
 | `glance reply <space/slug> <threadId> [message] [--tag <label>\|--no-tag]` | posts a reply to a comment thread (get the `threadId` from `glance comments`) |
 | `glance read <space/slug> [--file <path>] [--pull <dir>]` | prints a file to stdout, or `--pull` downloads the whole site's source into a folder to edit + redeploy |
+| `glance notifications [--read] [--json]` | shows your notifications — mentions and comments on your sites (or raw JSON); `--read` marks them all read |
 | `glance logout` | revokes the server session and removes the local token |
 
 ### login
@@ -144,6 +145,24 @@ glance comments docs/api-reference --open                 # find the threadId on
 echo "reworded the intro as requested" | glance reply docs/api-reference k3f9q2
 glance reply docs/api-reference k3f9q2 "typo fixed" --no-tag
 ```
+
+### notifications
+Shows your notifications, newest first — who mentioned you and who commented on your sites — without opening the browser.
+
+```
+$ glance notifications
+2 unread · 3 shown
+● Priya N commented on eng/perf-dashboard (index.html, 2h ago)
+  “The p95 chart hides the cold-start spike, can we…”
+● Dev R mentioned you on design/onboarding-v2 (flows/step-3.html, 1d ago)
+✓ Someone commented on eng/perf-dashboard (index.html, 3d ago)
+```
+
+- The header always shows your **true unread total**, even when there are more notifications than the list window shows.
+- `●` = unread, `✓` = read. A deleted account shows as “Someone”.
+- `--read` marks everything read and prints a confirmation.
+- `--json` prints the raw server response instead — for piping into `jq` or an agent loop.
+- Follow up from the same terminal: `glance comments <space/slug>` to read the full thread, `glance reply <space/slug> <threadId>` to answer.
 
 ### read
 Prints a deployed file's contents to stdout.

--- a/packages/api/drizzle/0015_notifications_comment_id.sql
+++ b/packages/api/drizzle/0015_notifications_comment_id.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `notifications` ADD `commentId` text REFERENCES `comments`(`id`) ON DELETE SET NULL;

--- a/packages/api/drizzle/0016_notifications_comment_index.sql
+++ b/packages/api/drizzle/0016_notifications_comment_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX `notifications_comment` ON `notifications` (`commentId`);

--- a/packages/api/drizzle/meta/0015_snapshot.json
+++ b/packages/api/drizzle/meta/0015_snapshot.json
@@ -1,0 +1,1436 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "d2df699e-3cd8-4e09-90b6-9736036db24d",
+  "prevId": "4e973f71-f9f0-4169-8a01-75257f5eed70",
+  "tables": {
+    "comment_threads": {
+      "name": "comment_threads",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "siteId": {
+          "name": "siteId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "filePath": {
+          "name": "filePath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "anchorType": {
+          "name": "anchorType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'text'"
+        },
+        "quote": {
+          "name": "quote",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "anchor": {
+          "name": "anchor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "contentHash": {
+          "name": "contentHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "anchorStatus": {
+          "name": "anchorStatus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'anchored'"
+        },
+        "start": {
+          "name": "start",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "end": {
+          "name": "end",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'open'"
+        },
+        "resolvedBy": {
+          "name": "resolvedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolvedAt": {
+          "name": "resolvedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "threads_site_file_status": {
+          "name": "threads_site_file_status",
+          "columns": [
+            "siteId",
+            "filePath",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "threads_site_status_updated": {
+          "name": "threads_site_status_updated",
+          "columns": [
+            "siteId",
+            "status",
+            "updatedAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "comment_threads_siteId_sites_id_fk": {
+          "name": "comment_threads_siteId_sites_id_fk",
+          "tableFrom": "comment_threads",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "siteId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "comment_threads_resolvedBy_users_id_fk": {
+          "name": "comment_threads_resolvedBy_users_id_fk",
+          "tableFrom": "comment_threads",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolvedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "comment_threads_createdBy_users_id_fk": {
+          "name": "comment_threads_createdBy_users_id_fk",
+          "tableFrom": "comment_threads",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comments": {
+      "name": "comments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "threadId": {
+          "name": "threadId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "authorId": {
+          "name": "authorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "editedAt": {
+          "name": "editedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "audioKey": {
+          "name": "audioKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "comments_thread_created": {
+          "name": "comments_thread_created",
+          "columns": [
+            "threadId",
+            "createdAt"
+          ],
+          "isUnique": false
+        },
+        "comments_author_deleted_created": {
+          "name": "comments_author_deleted_created",
+          "columns": [
+            "authorId",
+            "deletedAt",
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "comments_threadId_comment_threads_id_fk": {
+          "name": "comments_threadId_comment_threads_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "comment_threads",
+          "columnsFrom": [
+            "threadId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "comments_authorId_users_id_fk": {
+          "name": "comments_authorId_users_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "authorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "documents": {
+      "name": "documents",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "siteId": {
+          "name": "siteId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "collection": {
+          "name": "collection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "docId": {
+          "name": "docId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "json": {
+          "name": "json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "documents_site_collection_creator": {
+          "name": "documents_site_collection_creator",
+          "columns": [
+            "siteId",
+            "collection",
+            "createdBy"
+          ],
+          "isUnique": false
+        },
+        "documents_site_collection_doc_unq": {
+          "name": "documents_site_collection_doc_unq",
+          "columns": [
+            "siteId",
+            "collection",
+            "docId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "documents_siteId_sites_id_fk": {
+          "name": "documents_siteId_sites_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "siteId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "documents_createdBy_users_id_fk": {
+          "name": "documents_createdBy_users_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "siteId": {
+          "name": "siteId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "siteLabel": {
+          "name": "siteLabel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cliVersion": {
+          "name": "cliVersion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "events_type_created": {
+          "name": "events_type_created",
+          "columns": [
+            "type",
+            "createdAt"
+          ],
+          "isUnique": false
+        },
+        "events_site_created": {
+          "name": "events_site_created",
+          "columns": [
+            "siteId",
+            "createdAt"
+          ],
+          "isUnique": false
+        },
+        "events_user_created": {
+          "name": "events_user_created",
+          "columns": [
+            "userId",
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "events_userId_users_id_fk": {
+          "name": "events_userId_users_id_fk",
+          "tableFrom": "events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "events_siteId_sites_id_fk": {
+          "name": "events_siteId_sites_id_fk",
+          "tableFrom": "events",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "siteId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "files": {
+      "name": "files",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "siteId": {
+          "name": "siteId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "storageKey": {
+          "name": "storageKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mimeType": {
+          "name": "mimeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "contentHash": {
+          "name": "contentHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "files_storageKey_unique": {
+          "name": "files_storageKey_unique",
+          "columns": [
+            "storageKey"
+          ],
+          "isUnique": true
+        },
+        "files_site_path_unq": {
+          "name": "files_site_path_unq",
+          "columns": [
+            "siteId",
+            "path"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "files_siteId_sites_id_fk": {
+          "name": "files_siteId_sites_id_fk",
+          "tableFrom": "files",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "siteId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notifications": {
+      "name": "notifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recipientId": {
+          "name": "recipientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actorId": {
+          "name": "actorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "siteId": {
+          "name": "siteId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "siteLabel": {
+          "name": "siteLabel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "threadId": {
+          "name": "threadId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "commentId": {
+          "name": "commentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "filePath": {
+          "name": "filePath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "snippet": {
+          "name": "snippet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "readAt": {
+          "name": "readAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "notifications_recipient_read_created": {
+          "name": "notifications_recipient_read_created",
+          "columns": [
+            "recipientId",
+            "readAt",
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "notifications_recipientId_users_id_fk": {
+          "name": "notifications_recipientId_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recipientId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_actorId_users_id_fk": {
+          "name": "notifications_actorId_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "notifications_siteId_sites_id_fk": {
+          "name": "notifications_siteId_sites_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "siteId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "notifications_threadId_comment_threads_id_fk": {
+          "name": "notifications_threadId_comment_threads_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "comment_threads",
+          "columnsFrom": [
+            "threadId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "notifications_commentId_comments_id_fk": {
+          "name": "notifications_commentId_comments_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "comments",
+          "columnsFrom": [
+            "commentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "site_group_shares": {
+      "name": "site_group_shares",
+      "columns": {
+        "siteId": {
+          "name": "siteId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "spaceId": {
+          "name": "spaceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "site_group_shares_space": {
+          "name": "site_group_shares_space",
+          "columns": [
+            "spaceId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "site_group_shares_siteId_sites_id_fk": {
+          "name": "site_group_shares_siteId_sites_id_fk",
+          "tableFrom": "site_group_shares",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "siteId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "site_group_shares_spaceId_spaces_id_fk": {
+          "name": "site_group_shares_spaceId_spaces_id_fk",
+          "tableFrom": "site_group_shares",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "spaceId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "site_group_shares_siteId_spaceId_pk": {
+          "columns": [
+            "siteId",
+            "spaceId"
+          ],
+          "name": "site_group_shares_siteId_spaceId_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "site_summaries": {
+      "name": "site_summaries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "siteId": {
+          "name": "siteId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "contentVersion": {
+          "name": "contentVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "promptVersion": {
+          "name": "promptVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "generatedBy": {
+          "name": "generatedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "truncated": {
+          "name": "truncated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "site_summaries_siteId_unique": {
+          "name": "site_summaries_siteId_unique",
+          "columns": [
+            "siteId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "site_summaries_siteId_sites_id_fk": {
+          "name": "site_summaries_siteId_sites_id_fk",
+          "tableFrom": "site_summaries",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "siteId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "site_summaries_generatedBy_users_id_fk": {
+          "name": "site_summaries_generatedBy_users_id_fk",
+          "tableFrom": "site_summaries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "generatedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "site_user_shares": {
+      "name": "site_user_shares",
+      "columns": {
+        "siteId": {
+          "name": "siteId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'viewer'"
+        }
+      },
+      "indexes": {
+        "site_user_shares_user": {
+          "name": "site_user_shares_user",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "site_user_shares_siteId_sites_id_fk": {
+          "name": "site_user_shares_siteId_sites_id_fk",
+          "tableFrom": "site_user_shares",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "siteId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "site_user_shares_userId_users_id_fk": {
+          "name": "site_user_shares_userId_users_id_fk",
+          "tableFrom": "site_user_shares",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "site_user_shares_siteId_userId_pk": {
+          "columns": [
+            "siteId",
+            "userId"
+          ],
+          "name": "site_user_shares_siteId_userId_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sites": {
+      "name": "sites",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "spaceId": {
+          "name": "spaceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'team'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "contentVersion": {
+          "name": "contentVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "lastReplacedBy": {
+          "name": "lastReplacedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "forkedFrom": {
+          "name": "forkedFrom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "sites_owner": {
+          "name": "sites_owner",
+          "columns": [
+            "ownerId"
+          ],
+          "isUnique": false
+        },
+        "sites_space_slug_unq": {
+          "name": "sites_space_slug_unq",
+          "columns": [
+            "spaceId",
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "sites_spaceId_spaces_id_fk": {
+          "name": "sites_spaceId_spaces_id_fk",
+          "tableFrom": "sites",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "spaceId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sites_ownerId_users_id_fk": {
+          "name": "sites_ownerId_users_id_fk",
+          "tableFrom": "sites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "ownerId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sites_forkedFrom_sites_id_fk": {
+          "name": "sites_forkedFrom_sites_id_fk",
+          "tableFrom": "sites",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "forkedFrom"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "space_members": {
+      "name": "space_members",
+      "columns": {
+        "spaceId": {
+          "name": "spaceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "space_members_user": {
+          "name": "space_members_user",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "space_members_spaceId_spaces_id_fk": {
+          "name": "space_members_spaceId_spaces_id_fk",
+          "tableFrom": "space_members",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "spaceId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "space_members_userId_users_id_fk": {
+          "name": "space_members_userId_users_id_fk",
+          "tableFrom": "space_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "space_members_spaceId_userId_pk": {
+          "columns": [
+            "spaceId",
+            "userId"
+          ],
+          "name": "space_members_spaceId_userId_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "spaces": {
+      "name": "spaces",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "spaces_slug_unique": {
+          "name": "spaces_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "spaces_createdBy_users_id_fk": {
+          "name": "spaces_createdBy_users_id_fk",
+          "tableFrom": "spaces",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "googleId": {
+          "name": "googleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lastSeenReleaseAt": {
+          "name": "lastSeenReleaseAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "users_googleId_unique": {
+          "name": "users_googleId_unique",
+          "columns": [
+            "googleId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/api/drizzle/meta/0016_snapshot.json
+++ b/packages/api/drizzle/meta/0016_snapshot.json
@@ -1,0 +1,1443 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "ac643143-b7b4-45ba-a6a2-20075a341649",
+  "prevId": "d2df699e-3cd8-4e09-90b6-9736036db24d",
+  "tables": {
+    "comment_threads": {
+      "name": "comment_threads",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "siteId": {
+          "name": "siteId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "filePath": {
+          "name": "filePath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "anchorType": {
+          "name": "anchorType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'text'"
+        },
+        "quote": {
+          "name": "quote",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "anchor": {
+          "name": "anchor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "contentHash": {
+          "name": "contentHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "anchorStatus": {
+          "name": "anchorStatus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'anchored'"
+        },
+        "start": {
+          "name": "start",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "end": {
+          "name": "end",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'open'"
+        },
+        "resolvedBy": {
+          "name": "resolvedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolvedAt": {
+          "name": "resolvedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "threads_site_file_status": {
+          "name": "threads_site_file_status",
+          "columns": [
+            "siteId",
+            "filePath",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "threads_site_status_updated": {
+          "name": "threads_site_status_updated",
+          "columns": [
+            "siteId",
+            "status",
+            "updatedAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "comment_threads_siteId_sites_id_fk": {
+          "name": "comment_threads_siteId_sites_id_fk",
+          "tableFrom": "comment_threads",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "siteId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "comment_threads_resolvedBy_users_id_fk": {
+          "name": "comment_threads_resolvedBy_users_id_fk",
+          "tableFrom": "comment_threads",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolvedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "comment_threads_createdBy_users_id_fk": {
+          "name": "comment_threads_createdBy_users_id_fk",
+          "tableFrom": "comment_threads",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comments": {
+      "name": "comments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "threadId": {
+          "name": "threadId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "authorId": {
+          "name": "authorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "editedAt": {
+          "name": "editedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "audioKey": {
+          "name": "audioKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "comments_thread_created": {
+          "name": "comments_thread_created",
+          "columns": [
+            "threadId",
+            "createdAt"
+          ],
+          "isUnique": false
+        },
+        "comments_author_deleted_created": {
+          "name": "comments_author_deleted_created",
+          "columns": [
+            "authorId",
+            "deletedAt",
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "comments_threadId_comment_threads_id_fk": {
+          "name": "comments_threadId_comment_threads_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "comment_threads",
+          "columnsFrom": [
+            "threadId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "comments_authorId_users_id_fk": {
+          "name": "comments_authorId_users_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "authorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "documents": {
+      "name": "documents",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "siteId": {
+          "name": "siteId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "collection": {
+          "name": "collection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "docId": {
+          "name": "docId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "json": {
+          "name": "json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "documents_site_collection_creator": {
+          "name": "documents_site_collection_creator",
+          "columns": [
+            "siteId",
+            "collection",
+            "createdBy"
+          ],
+          "isUnique": false
+        },
+        "documents_site_collection_doc_unq": {
+          "name": "documents_site_collection_doc_unq",
+          "columns": [
+            "siteId",
+            "collection",
+            "docId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "documents_siteId_sites_id_fk": {
+          "name": "documents_siteId_sites_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "siteId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "documents_createdBy_users_id_fk": {
+          "name": "documents_createdBy_users_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "siteId": {
+          "name": "siteId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "siteLabel": {
+          "name": "siteLabel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cliVersion": {
+          "name": "cliVersion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "events_type_created": {
+          "name": "events_type_created",
+          "columns": [
+            "type",
+            "createdAt"
+          ],
+          "isUnique": false
+        },
+        "events_site_created": {
+          "name": "events_site_created",
+          "columns": [
+            "siteId",
+            "createdAt"
+          ],
+          "isUnique": false
+        },
+        "events_user_created": {
+          "name": "events_user_created",
+          "columns": [
+            "userId",
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "events_userId_users_id_fk": {
+          "name": "events_userId_users_id_fk",
+          "tableFrom": "events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "events_siteId_sites_id_fk": {
+          "name": "events_siteId_sites_id_fk",
+          "tableFrom": "events",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "siteId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "files": {
+      "name": "files",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "siteId": {
+          "name": "siteId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "storageKey": {
+          "name": "storageKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mimeType": {
+          "name": "mimeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "contentHash": {
+          "name": "contentHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "files_storageKey_unique": {
+          "name": "files_storageKey_unique",
+          "columns": [
+            "storageKey"
+          ],
+          "isUnique": true
+        },
+        "files_site_path_unq": {
+          "name": "files_site_path_unq",
+          "columns": [
+            "siteId",
+            "path"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "files_siteId_sites_id_fk": {
+          "name": "files_siteId_sites_id_fk",
+          "tableFrom": "files",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "siteId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notifications": {
+      "name": "notifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recipientId": {
+          "name": "recipientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actorId": {
+          "name": "actorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "siteId": {
+          "name": "siteId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "siteLabel": {
+          "name": "siteLabel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "threadId": {
+          "name": "threadId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "commentId": {
+          "name": "commentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "filePath": {
+          "name": "filePath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "snippet": {
+          "name": "snippet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "readAt": {
+          "name": "readAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "notifications_recipient_read_created": {
+          "name": "notifications_recipient_read_created",
+          "columns": [
+            "recipientId",
+            "readAt",
+            "createdAt"
+          ],
+          "isUnique": false
+        },
+        "notifications_comment": {
+          "name": "notifications_comment",
+          "columns": [
+            "commentId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "notifications_recipientId_users_id_fk": {
+          "name": "notifications_recipientId_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recipientId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_actorId_users_id_fk": {
+          "name": "notifications_actorId_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "notifications_siteId_sites_id_fk": {
+          "name": "notifications_siteId_sites_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "siteId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "notifications_threadId_comment_threads_id_fk": {
+          "name": "notifications_threadId_comment_threads_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "comment_threads",
+          "columnsFrom": [
+            "threadId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "notifications_commentId_comments_id_fk": {
+          "name": "notifications_commentId_comments_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "comments",
+          "columnsFrom": [
+            "commentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "site_group_shares": {
+      "name": "site_group_shares",
+      "columns": {
+        "siteId": {
+          "name": "siteId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "spaceId": {
+          "name": "spaceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "site_group_shares_space": {
+          "name": "site_group_shares_space",
+          "columns": [
+            "spaceId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "site_group_shares_siteId_sites_id_fk": {
+          "name": "site_group_shares_siteId_sites_id_fk",
+          "tableFrom": "site_group_shares",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "siteId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "site_group_shares_spaceId_spaces_id_fk": {
+          "name": "site_group_shares_spaceId_spaces_id_fk",
+          "tableFrom": "site_group_shares",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "spaceId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "site_group_shares_siteId_spaceId_pk": {
+          "columns": [
+            "siteId",
+            "spaceId"
+          ],
+          "name": "site_group_shares_siteId_spaceId_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "site_summaries": {
+      "name": "site_summaries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "siteId": {
+          "name": "siteId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "contentVersion": {
+          "name": "contentVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "promptVersion": {
+          "name": "promptVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "generatedBy": {
+          "name": "generatedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "truncated": {
+          "name": "truncated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "site_summaries_siteId_unique": {
+          "name": "site_summaries_siteId_unique",
+          "columns": [
+            "siteId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "site_summaries_siteId_sites_id_fk": {
+          "name": "site_summaries_siteId_sites_id_fk",
+          "tableFrom": "site_summaries",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "siteId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "site_summaries_generatedBy_users_id_fk": {
+          "name": "site_summaries_generatedBy_users_id_fk",
+          "tableFrom": "site_summaries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "generatedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "site_user_shares": {
+      "name": "site_user_shares",
+      "columns": {
+        "siteId": {
+          "name": "siteId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'viewer'"
+        }
+      },
+      "indexes": {
+        "site_user_shares_user": {
+          "name": "site_user_shares_user",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "site_user_shares_siteId_sites_id_fk": {
+          "name": "site_user_shares_siteId_sites_id_fk",
+          "tableFrom": "site_user_shares",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "siteId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "site_user_shares_userId_users_id_fk": {
+          "name": "site_user_shares_userId_users_id_fk",
+          "tableFrom": "site_user_shares",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "site_user_shares_siteId_userId_pk": {
+          "columns": [
+            "siteId",
+            "userId"
+          ],
+          "name": "site_user_shares_siteId_userId_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sites": {
+      "name": "sites",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "spaceId": {
+          "name": "spaceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'team'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "contentVersion": {
+          "name": "contentVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "lastReplacedBy": {
+          "name": "lastReplacedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "forkedFrom": {
+          "name": "forkedFrom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "sites_owner": {
+          "name": "sites_owner",
+          "columns": [
+            "ownerId"
+          ],
+          "isUnique": false
+        },
+        "sites_space_slug_unq": {
+          "name": "sites_space_slug_unq",
+          "columns": [
+            "spaceId",
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "sites_spaceId_spaces_id_fk": {
+          "name": "sites_spaceId_spaces_id_fk",
+          "tableFrom": "sites",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "spaceId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sites_ownerId_users_id_fk": {
+          "name": "sites_ownerId_users_id_fk",
+          "tableFrom": "sites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "ownerId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sites_forkedFrom_sites_id_fk": {
+          "name": "sites_forkedFrom_sites_id_fk",
+          "tableFrom": "sites",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "forkedFrom"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "space_members": {
+      "name": "space_members",
+      "columns": {
+        "spaceId": {
+          "name": "spaceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "space_members_user": {
+          "name": "space_members_user",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "space_members_spaceId_spaces_id_fk": {
+          "name": "space_members_spaceId_spaces_id_fk",
+          "tableFrom": "space_members",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "spaceId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "space_members_userId_users_id_fk": {
+          "name": "space_members_userId_users_id_fk",
+          "tableFrom": "space_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "space_members_spaceId_userId_pk": {
+          "columns": [
+            "spaceId",
+            "userId"
+          ],
+          "name": "space_members_spaceId_userId_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "spaces": {
+      "name": "spaces",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "spaces_slug_unique": {
+          "name": "spaces_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "spaces_createdBy_users_id_fk": {
+          "name": "spaces_createdBy_users_id_fk",
+          "tableFrom": "spaces",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "googleId": {
+          "name": "googleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lastSeenReleaseAt": {
+          "name": "lastSeenReleaseAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "users_googleId_unique": {
+          "name": "users_googleId_unique",
+          "columns": [
+            "googleId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/api/drizzle/meta/_journal.json
+++ b/packages/api/drizzle/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1784215079675,
       "tag": "0015_notifications_comment_id",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "6",
+      "when": 1784221237892,
+      "tag": "0016_notifications_comment_index",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/drizzle/meta/_journal.json
+++ b/packages/api/drizzle/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1784160000000,
       "tag": "0014_site_summaries",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "6",
+      "when": 1784215079675,
+      "tag": "0015_notifications_comment_id",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/src/db/comment-feed.test.ts
+++ b/packages/api/src/db/comment-feed.test.ts
@@ -17,9 +17,10 @@ import {
 import {
   assembleCommentFeed,
   authoredCandidatesStmt,
-  type AuthoredCandidateRow,
+  type CommentCandidateRow,
   mentionCandidatesStmt,
   type MentionCandidateRow,
+  ownedCandidatesStmt,
 } from './comment-feed'
 import { foldSharedSiteRoles } from './repo'
 
@@ -85,7 +86,7 @@ describe('comments feed candidate statements', () => {
 
     const [authored] = await db.batch([authoredCandidatesStmt(db, userId)])
 
-    expect(authored.map((row) => row.id)).toEqual([liveId])
+    expect(authored.map((row) => row.commentId)).toEqual([liveId])
   })
 
   test('C2.3 mention candidates preserve named, email-only, and deleted actor states', async () => {
@@ -190,9 +191,9 @@ describe('comments feed candidate statements', () => {
     const [authoredRows] = await db.batch([authoredCandidatesStmt(db, userId)])
     expect(authoredRows.length).toBe(200)
     for (let n = 0; n < 5; n++) {
-      expect(authoredRows.some((row) => row.id === authoredByN.get(n))).toBe(false)
+      expect(authoredRows.some((row) => row.commentId === authoredByN.get(n))).toBe(false)
     }
-    expect(authoredRows.map((row) => row.id)).toEqual(expectedIds(authoredSeeded))
+    expect(authoredRows.map((row) => row.commentId)).toEqual(expectedIds(authoredSeeded))
 
     const mentionByN = new Map<number, string>()
     const mentionSeeded: Seeded[] = []
@@ -229,13 +230,15 @@ function makeUser(overrides: Partial<SessionUser> = {}): SessionUser {
   }
 }
 
-function authoredRow(overrides: Partial<AuthoredCandidateRow> = {}): AuthoredCandidateRow {
+function authoredRow(overrides: Partial<CommentCandidateRow> = {}): CommentCandidateRow {
   return {
-    id: 'authored-1',
+    commentId: 'authored-1',
     body: 'Authored comment',
     createdAt: '2026-07-11T10:00:00.000Z',
     editedAt: null,
     rowid: 1,
+    actorName: null,
+    actorEmail: null,
     threadId: 'thread-1',
     threadStatus: 'open',
     filePath: 'index.html',
@@ -254,6 +257,7 @@ function authoredRow(overrides: Partial<AuthoredCandidateRow> = {}): AuthoredCan
 function mentionRow(overrides: Partial<MentionCandidateRow> = {}): MentionCandidateRow {
   return {
     id: 'mention-1',
+    commentId: null,
     snippet: 'Mention snapshot',
     createdAt: '2026-07-11T10:00:00.000Z',
     rowid: 1,
@@ -274,19 +278,281 @@ function mentionRow(overrides: Partial<MentionCandidateRow> = {}): MentionCandid
   }
 }
 
+function ownedRow(overrides: Partial<CommentCandidateRow> = {}): CommentCandidateRow {
+  return {
+    commentId: 'owned-1',
+    body: 'Owned comment',
+    createdAt: '2026-07-11T10:00:00.000Z',
+    editedAt: null,
+    rowid: 1,
+    actorName: 'Commenter',
+    actorEmail: 'commenter@example.com',
+    threadId: 'thread-1',
+    threadStatus: 'open',
+    filePath: 'index.html',
+    siteId: 'site-1',
+    siteSlug: 'site',
+    siteTitle: 'Site',
+    visibility: 'private',
+    siteStatus: 'active',
+    ownerId: 'user-1',
+    spaceId: 'space-1',
+    spaceSlug: 'space',
+    ...overrides,
+  }
+}
+
+describe('owned comment feed', () => {
+  test('F1 another user comment on an owned site keeps its feed context', async () => {
+    const db = makeDb()
+    const ownerId = await seedUser(db, { id: 'owner', email: 'owner@example.com' })
+    const authorId = await seedUser(db, {
+      id: 'author',
+      email: 'author@example.com',
+      name: 'Other Author',
+    })
+    const spaceId = await seedSpace(db, {
+      id: 'owned-space-id',
+      createdBy: ownerId,
+      slug: 'owned-space',
+    })
+    const siteId = await seedSite(db, {
+      id: 'owned-site-id',
+      spaceId,
+      ownerId,
+      slug: 'owned-site',
+      title: 'Owned Site',
+      visibility: 'private',
+    })
+    const threadId = await seedThread(db, {
+      id: 'owned-thread',
+      siteId,
+      filePath: 'docs/owned.html',
+    })
+    const commentId = await seedComment(db, {
+      id: 'owned-comment',
+      threadId,
+      authorId,
+      body: 'A comment for the owner',
+      createdAt: '2026-07-12T10:00:00.000Z',
+    })
+
+    const [owned] = await db.batch([ownedCandidatesStmt(db, ownerId)])
+    const result = assembleCommentFeed({
+      authored: [],
+      mentions: [],
+      owned,
+      user: makeUser({ id: ownerId }),
+      memberSpaceIds: new Set(),
+      sharedSiteRoles: new Map(),
+    })
+
+    expect(result).toEqual([
+      {
+        kind: 'owned',
+        id: commentId,
+        snippet: 'A comment for the owner',
+        actorName: 'Other Author',
+        spaceSlug: 'owned-space',
+        siteSlug: 'owned-site',
+        siteTitle: 'Owned Site',
+        filePath: 'docs/owned.html',
+        threadId: 'owned-thread',
+        threadStatus: 'open',
+        createdAt: '2026-07-12T10:00:00.000Z',
+        editedAt: null,
+      },
+    ])
+  })
+
+  test('F2 a mention on an owned site wins dedupe by comment id', async () => {
+    const db = makeDb()
+    const ownerId = await seedUser(db, { id: 'owner-f2', email: 'owner-f2@example.com' })
+    const authorId = await seedUser(db, { id: 'author-f2', email: 'author-f2@example.com' })
+    const spaceId = await seedSpace(db, { createdBy: ownerId })
+    const siteId = await seedSite(db, { spaceId, ownerId, visibility: 'private' })
+    const threadId = await seedThread(db, { siteId, filePath: 'dedupe.html' })
+    const commentId = await seedComment(db, {
+      threadId,
+      authorId,
+      body: 'The live comment body',
+      createdAt: '2026-07-12T11:00:00.000Z',
+    })
+    const notificationId = await seedNotification(db, {
+      recipientId: ownerId,
+      actorId: authorId,
+      siteId,
+      threadId,
+      commentId,
+      snippet: 'The mention snapshot',
+      createdAt: '2026-07-12T11:00:00.000Z',
+    })
+
+    const [owned, mentions] = await db.batch([
+      ownedCandidatesStmt(db, ownerId),
+      mentionCandidatesStmt(db, ownerId),
+    ])
+    const result = assembleCommentFeed({
+      authored: [],
+      mentions,
+      owned,
+      user: makeUser({ id: ownerId }),
+      memberSpaceIds: new Set(),
+      sharedSiteRoles: new Map(),
+    })
+
+    expect(mentions[0]?.commentId).toBe(commentId)
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({
+      kind: 'mention',
+      id: notificationId,
+      snippet: 'The mention snapshot',
+    })
+  })
+
+  test('F3 own comments stay out while null-author comments retain a null actor', async () => {
+    const db = makeDb()
+    const ownerId = await seedUser(db, { id: 'owner-f3', email: 'owner-f3@example.com' })
+    const spaceId = await seedSpace(db, { createdBy: ownerId })
+    const siteId = await seedSite(db, { spaceId, ownerId, visibility: 'private' })
+    const threadId = await seedThread(db, { siteId, filePath: 'authors.html' })
+    const ownCommentId = await seedComment(db, {
+      threadId,
+      authorId: ownerId,
+      body: 'Owner comment',
+    })
+    const nullAuthorCommentId = await seedComment(db, {
+      threadId,
+      authorId: null,
+      body: 'Deleted-user comment',
+    })
+
+    const [owned] = await db.batch([ownedCandidatesStmt(db, ownerId)])
+    const result = assembleCommentFeed({
+      authored: [],
+      mentions: [],
+      owned,
+      user: makeUser({ id: ownerId }),
+      memberSpaceIds: new Set(),
+      sharedSiteRoles: new Map(),
+    })
+
+    expect(owned.some((row) => row.commentId === ownCommentId)).toBe(false)
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({
+      kind: 'owned',
+      id: nullAuthorCommentId,
+      actorName: null,
+    })
+  })
+
+  test('F4 soft-deleted owned comments stay out and another arm cannot crowd out an older owned item', async () => {
+    const db = makeDb()
+    const ownerId = await seedUser(db, { id: 'owner-f4', email: 'owner-f4@example.com' })
+    const otherId = await seedUser(db, { id: 'other-f4', email: 'other-f4@example.com' })
+    const ownedSpaceId = await seedSpace(db, { createdBy: ownerId })
+    const ownedSiteId = await seedSite(db, {
+      spaceId: ownedSpaceId,
+      ownerId,
+      visibility: 'private',
+    })
+    const ownedThreadId = await seedThread(db, { siteId: ownedSiteId, filePath: 'owned-window.html' })
+    const olderOwnedId = await seedComment(db, {
+      threadId: ownedThreadId,
+      authorId: otherId,
+      body: 'Older accessible owned comment',
+      createdAt: '2026-01-01T00:00:00.000Z',
+    })
+    await seedComment(db, {
+      threadId: ownedThreadId,
+      authorId: otherId,
+      body: 'Deleted owned comment',
+      createdAt: '2026-01-01T00:04:00.000Z',
+      deletedAt: '2026-01-01T00:05:00.000Z',
+    })
+
+    const inaccessibleSpaceId = await seedSpace(db, { createdBy: otherId })
+    const inaccessibleSiteId = await seedSite(db, {
+      spaceId: inaccessibleSpaceId,
+      ownerId: otherId,
+      visibility: 'private',
+    })
+    const inaccessibleThreadId = await seedThread(db, {
+      siteId: inaccessibleSiteId,
+      filePath: 'inaccessible-window.html',
+    })
+    for (let i = 0; i < 200; i++) {
+      await seedComment(db, {
+        threadId: inaccessibleThreadId,
+        authorId: ownerId,
+        body: `Inaccessible authored comment ${i}`,
+        createdAt: new Date(Date.UTC(2026, 0, 1, 0, 0, i + 1)).toISOString(),
+      })
+    }
+
+    const [authored, owned] = await db.batch([
+      authoredCandidatesStmt(db, ownerId),
+      ownedCandidatesStmt(db, ownerId),
+    ])
+    const result = assembleCommentFeed({
+      authored,
+      mentions: [],
+      owned,
+      user: makeUser({ id: ownerId }),
+      memberSpaceIds: new Set(),
+      sharedSiteRoles: new Map(),
+    })
+
+    expect(authored).toHaveLength(200)
+    expect(owned.map((row) => row.commentId)).toEqual([olderOwnedId])
+    expect(result.map((row) => row.id)).toEqual([olderOwnedId])
+  })
+
+  test('F5 equal timestamps rank mention then authored then owned with rowid ties inside each kind', () => {
+    const createdAt = '2026-07-12T12:00:00.000Z'
+    const result = assembleCommentFeed({
+      mentions: [
+        mentionRow({ id: 'mention-low', createdAt, rowid: 1 }),
+        mentionRow({ id: 'mention-high', createdAt, rowid: 6 }),
+      ],
+      authored: [
+        authoredRow({ commentId: 'authored-low', createdAt, rowid: 2 }),
+        authoredRow({ commentId: 'authored-high', createdAt, rowid: 7 }),
+      ],
+      owned: [
+        ownedRow({ commentId: 'owned-low', createdAt, rowid: 3 }),
+        ownedRow({ commentId: 'owned-high', createdAt, rowid: 8 }),
+      ],
+      user: makeUser(),
+      memberSpaceIds: new Set(),
+      sharedSiteRoles: new Map(),
+    })
+
+    expect(result.map((row) => row.id)).toEqual([
+      'mention-high',
+      'mention-low',
+      'authored-high',
+      'authored-low',
+      'owned-high',
+      'owned-low',
+    ])
+  })
+})
+
 describe('assembleCommentFeed', () => {
   test('C3.1 merges candidates by timestamp, kind rank, then same-kind rowid', () => {
     const result = assembleCommentFeed({
       authored: [
-        authoredRow({ id: 'authored-tie-low', createdAt: '2026-07-11T11:00:00.000Z', rowid: 3 }),
-        authoredRow({ id: 'authored-kind-tie', createdAt: '2026-07-11T12:00:00.000Z', rowid: 99 }),
-        authoredRow({ id: 'authored-oldest', createdAt: '2026-07-11T10:00:00.000Z', rowid: 100 }),
-        authoredRow({ id: 'authored-tie-high', createdAt: '2026-07-11T11:00:00.000Z', rowid: 8 }),
+        authoredRow({ commentId: 'authored-tie-low', createdAt: '2026-07-11T11:00:00.000Z', rowid: 3 }),
+        authoredRow({ commentId: 'authored-kind-tie', createdAt: '2026-07-11T12:00:00.000Z', rowid: 99 }),
+        authoredRow({ commentId: 'authored-oldest', createdAt: '2026-07-11T10:00:00.000Z', rowid: 100 }),
+        authoredRow({ commentId: 'authored-tie-high', createdAt: '2026-07-11T11:00:00.000Z', rowid: 8 }),
       ],
       mentions: [
         mentionRow({ id: 'mention-newest', createdAt: '2026-07-11T13:00:00.000Z', rowid: 1 }),
         mentionRow({ id: 'mention-kind-tie', createdAt: '2026-07-11T12:00:00.000Z', rowid: 1 }),
       ],
+      owned: [],
       user: makeUser(),
       memberSpaceIds: new Set(),
       sharedSiteRoles: new Map(),
@@ -314,20 +580,20 @@ describe('assembleCommentFeed', () => {
     const plainUserResult = assembleCommentFeed({
       authored: [
         authoredRow({
-          id: 'members-member',
+          commentId: 'members-member',
           siteId: 'site-members-keep',
           spaceId: 'space-member',
           visibility: 'members',
           ownerId: 'someone-else',
         }),
         authoredRow({
-          id: 'private-group',
+          commentId: 'private-group',
           siteId: 'site-private-group',
           visibility: 'private',
           ownerId: 'someone-else',
         }),
         authoredRow({
-          id: 'private-no-grant',
+          commentId: 'private-no-grant',
           siteId: 'site-private-none',
           visibility: 'private',
           ownerId: 'someone-else',
@@ -355,6 +621,7 @@ describe('assembleCommentFeed', () => {
           ownerId: 'someone-else',
         }),
       ],
+      owned: [],
       user: makeUser(),
       memberSpaceIds: new Set(['space-member']),
       sharedSiteRoles: new Map([...groupRoles, ...directRoles]),
@@ -362,7 +629,7 @@ describe('assembleCommentFeed', () => {
     const superadminResult = assembleCommentFeed({
       authored: [
         authoredRow({
-          id: 'archived-superadmin',
+          commentId: 'archived-superadmin',
           siteId: 'site-archived-superadmin',
           visibility: 'private',
           siteStatus: 'archived',
@@ -370,6 +637,7 @@ describe('assembleCommentFeed', () => {
         }),
       ],
       mentions: [],
+      owned: [],
       user: makeUser({ role: 'superadmin' }),
       memberSpaceIds: new Set(),
       sharedSiteRoles: new Map(),
@@ -387,7 +655,7 @@ describe('assembleCommentFeed', () => {
     const shuffledRanks = Array.from({ length: 60 }, (_, index) => ((index * 17) % 60) + 1)
     const distinctRows = shuffledRanks.map((rank) =>
       authoredRow({
-        id: `authored-${String(rank).padStart(2, '0')}`,
+        commentId: `authored-${String(rank).padStart(2, '0')}`,
         createdAt: `2026-07-11T10:${String(rank - 1).padStart(2, '0')}:00.000Z`,
         rowid: rank,
       }),
@@ -400,6 +668,7 @@ describe('assembleCommentFeed', () => {
     const distinctResult = assembleCommentFeed({
       authored: distinctRows,
       mentions: [],
+      owned: [],
       user: makeUser(),
       memberSpaceIds: new Set(),
       sharedSiteRoles: new Map(),
@@ -408,11 +677,11 @@ describe('assembleCommentFeed', () => {
     expect(distinctResult.map((row) => row.id)).toEqual(expectedNewest)
 
     const boundaryRows = distinctRows.map((row) => {
-      if (row.id === 'authored-10') {
-        return { ...row, id: 'boundary-high', createdAt: '2026-07-11T10:10:00.000Z', rowid: 900 }
+      if (row.commentId === 'authored-10') {
+        return { ...row, commentId: 'boundary-high', createdAt: '2026-07-11T10:10:00.000Z', rowid: 900 }
       }
-      if (row.id === 'authored-11') {
-        return { ...row, id: 'boundary-low', createdAt: '2026-07-11T10:10:00.000Z', rowid: 100 }
+      if (row.commentId === 'authored-11') {
+        return { ...row, commentId: 'boundary-low', createdAt: '2026-07-11T10:10:00.000Z', rowid: 100 }
       }
       return row
     })
@@ -422,6 +691,7 @@ describe('assembleCommentFeed', () => {
     const boundaryResult = assembleCommentFeed({
       authored: boundaryRows,
       mentions: [],
+      owned: [],
       user: makeUser(),
       memberSpaceIds: new Set(),
       sharedSiteRoles: new Map(),
@@ -435,7 +705,7 @@ describe('assembleCommentFeed', () => {
     const [authored] = assembleCommentFeed({
       authored: [
         authoredRow({
-          id: 'authored-payload',
+          commentId: 'authored-payload',
           body: authoredBody,
           createdAt: '2026-07-11T14:00:00.000Z',
           editedAt: '2026-07-11T14:05:00.000Z',
@@ -451,6 +721,7 @@ describe('assembleCommentFeed', () => {
         }),
       ],
       mentions: [],
+      owned: [],
       user: makeUser(),
       memberSpaceIds: new Set(),
       sharedSiteRoles: new Map(),
@@ -475,6 +746,7 @@ describe('assembleCommentFeed', () => {
       const [item] = assembleCommentFeed({
         authored: [authoredRow({ body })],
         mentions: [],
+        owned: [],
         user: makeUser(),
         memberSpaceIds: new Set(),
         sharedSiteRoles: new Map(),
@@ -486,6 +758,7 @@ describe('assembleCommentFeed', () => {
     const [surrogateItem] = assembleCommentFeed({
       authored: [authoredRow({ body: surrogateBody })],
       mentions: [],
+      owned: [],
       user: makeUser(),
       memberSpaceIds: new Set(),
       sharedSiteRoles: new Map(),
@@ -515,6 +788,7 @@ describe('assembleCommentFeed', () => {
           rowid: 88,
         }),
       ],
+      owned: [],
       user: makeUser(),
       memberSpaceIds: new Set(),
       sharedSiteRoles: new Map(),

--- a/packages/api/src/db/comment-feed.ts
+++ b/packages/api/src/db/comment-feed.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, isNull, sql } from 'drizzle-orm'
+import { and, desc, eq, isNull, ne, or, sql, type SQL } from 'drizzle-orm'
 import type { DrizzleD1Database } from 'drizzle-orm/d1'
 import { checkAccess } from '../lib/access'
 import type { SessionUser } from '../types'
@@ -18,11 +18,14 @@ type SiteStatus = (typeof sites.$inferSelect)['status']
 // Access filtering runs AFTER this newest-per-arm window, so a user whose newest 200
 // candidates are inaccessible sees an under-filled feed (accepted contract, pinned later
 // by route case C4.9; fix would be a bigger cap, never cursors).
+// The owned arm cannot walk an index for its ORDER BY because sites.ownerId is two joins away,
+// so it fully materializes and sorts its matches. Escape hatches are denormalizing ownerId onto
+// comments or adding a per-site cap.
 const FEED_SCAN_WINDOW = 200
 const FEED_LIMIT = 50
 const FEED_SNIPPET_LENGTH = 200
 
-// Thread/site/space columns shared by both candidate arms. Every column is aliased with .as() —
+// Thread/site/space columns shared by all candidate arms. Every column is aliased with .as() —
 // D1 batch results map by result-column NAME, so unaliased join columns would silently collide.
 const THREAD_SITE_COLUMNS = {
   threadId: sql<string>`${commentThreads.id}`.as('threadId'),
@@ -41,29 +44,48 @@ const THREAD_SITE_COLUMNS = {
 const commentsRowid = sql<number>`"comments".rowid`
 const notificationsRowid = sql<number>`"notifications".rowid`
 
-export function authoredCandidatesStmt(db: DrizzleD1Database, userId: string) {
+function commentCandidatesStmt(db: DrizzleD1Database, where: SQL | undefined) {
   return db
     .select({
-      id: sql<string>`${comments.id}`.as('id'),
+      commentId: sql<string>`${comments.id}`.as('commentId'),
       body: sql<string>`${comments.body}`.as('body'),
       createdAt: sql<string>`${comments.createdAt}`.as('createdAt'),
       editedAt: sql<string | null>`${comments.editedAt}`.as('editedAt'),
       rowid: commentsRowid.as('rowid'),
+      actorName: sql<string | null>`${users.name}`.as('actorName'),
+      actorEmail: sql<string | null>`${users.email}`.as('actorEmail'),
       ...THREAD_SITE_COLUMNS,
     })
     .from(comments)
     .innerJoin(commentThreads, eq(comments.threadId, commentThreads.id))
     .innerJoin(sites, eq(commentThreads.siteId, sites.id))
     .innerJoin(spaces, eq(sites.spaceId, spaces.id))
-    .where(and(eq(comments.authorId, userId), isNull(comments.deletedAt)))
+    .leftJoin(users, eq(comments.authorId, users.id))
+    .where(where)
     .orderBy(desc(comments.createdAt), desc(commentsRowid))
     .limit(FEED_SCAN_WINDOW)
+}
+
+export function authoredCandidatesStmt(db: DrizzleD1Database, userId: string) {
+  return commentCandidatesStmt(db, and(eq(comments.authorId, userId), isNull(comments.deletedAt)))
+}
+
+export function ownedCandidatesStmt(db: DrizzleD1Database, userId: string) {
+  return commentCandidatesStmt(
+    db,
+    and(
+      eq(sites.ownerId, userId),
+      isNull(comments.deletedAt),
+      or(isNull(comments.authorId), ne(comments.authorId, userId)),
+    ),
+  )
 }
 
 export function mentionCandidatesStmt(db: DrizzleD1Database, userId: string) {
   return db
     .select({
       id: sql<string>`${notifications.id}`.as('id'),
+      commentId: sql<string | null>`${notifications.commentId}`.as('commentId'),
       snippet: sql<string | null>`${notifications.snippet}`.as('snippet'),
       createdAt: sql<string>`${notifications.createdAt}`.as('createdAt'),
       rowid: notificationsRowid.as('rowid'),
@@ -81,11 +103,11 @@ export function mentionCandidatesStmt(db: DrizzleD1Database, userId: string) {
     .limit(FEED_SCAN_WINDOW)
 }
 
-export type AuthoredCandidateRow = Awaited<ReturnType<typeof authoredCandidatesStmt>>[number]
+export type CommentCandidateRow = Awaited<ReturnType<typeof authoredCandidatesStmt>>[number]
 export type MentionCandidateRow = Awaited<ReturnType<typeof mentionCandidatesStmt>>[number]
 
 export type CommentFeedItem = {
-  kind: 'mention' | 'authored'
+  kind: 'mention' | 'authored' | 'owned'
   id: string
   snippet: string | null
   actorName: string | null
@@ -101,9 +123,9 @@ export type CommentFeedItem = {
 
 type FeedCandidate =
   | { kind: 'mention'; row: MentionCandidateRow }
-  | { kind: 'authored'; row: AuthoredCandidateRow }
+  | { kind: 'authored' | 'owned'; row: CommentCandidateRow }
 
-const KIND_RANK = { mention: 0, authored: 1 } as const
+const KIND_RANK = { mention: 0, authored: 1, owned: 2 } as const
 
 export function truncateSnippet(body: string): string {
   const s = body.slice(0, FEED_SNIPPET_LENGTH)
@@ -121,7 +143,6 @@ function compareFeedCandidates(a: FeedCandidate, b: FeedCandidate): number {
 function toCommentFeedItem(candidate: FeedCandidate): CommentFeedItem {
   const { row } = candidate
   const common = {
-    id: row.id,
     spaceSlug: row.spaceSlug,
     siteSlug: row.siteSlug,
     siteTitle: row.siteTitle,
@@ -130,33 +151,42 @@ function toCommentFeedItem(candidate: FeedCandidate): CommentFeedItem {
     threadStatus: row.threadStatus,
     createdAt: row.createdAt,
   }
-  return candidate.kind === 'authored'
-    ? {
-        kind: 'authored',
-        ...common,
-        snippet: truncateSnippet(candidate.row.body),
-        actorName: null,
-        editedAt: candidate.row.editedAt,
-      }
-    : {
-        kind: 'mention',
-        ...common,
-        snippet: candidate.row.snippet,
-        actorName: candidate.row.actorName ?? candidate.row.actorEmail ?? null,
-        editedAt: null,
-      }
+  if (candidate.kind === 'mention') {
+    return {
+      kind: 'mention',
+      id: candidate.row.id,
+      ...common,
+      snippet: candidate.row.snippet,
+      actorName: candidate.row.actorName ?? candidate.row.actorEmail,
+      editedAt: null,
+    }
+  }
+  return {
+    kind: candidate.kind,
+    id: candidate.row.commentId,
+    ...common,
+    snippet: truncateSnippet(candidate.row.body),
+    actorName: candidate.kind === 'owned' ? (candidate.row.actorName ?? candidate.row.actorEmail) : null,
+    editedAt: candidate.row.editedAt,
+  }
 }
 
 export function assembleCommentFeed(input: {
-  authored: AuthoredCandidateRow[]
+  authored: CommentCandidateRow[]
   mentions: MentionCandidateRow[]
+  owned: CommentCandidateRow[]
   user: SessionUser
   memberSpaceIds: Set<string>
   sharedSiteRoles: { has(siteId: string): boolean }
 }): CommentFeedItem[] {
+  // Legacy mention rows have a null commentId, which can never match an owned comment's id.
+  const mentionedCommentIds = new Set(input.mentions.map((row) => row.commentId))
+  const owned = input.owned.filter((row) => !mentionedCommentIds.has(row.commentId))
+
   return [
     ...input.mentions.map((row) => ({ kind: 'mention' as const, row })),
     ...input.authored.map((row) => ({ kind: 'authored' as const, row })),
+    ...owned.map((row) => ({ kind: 'owned' as const, row })),
   ]
     .filter(({ row }) =>
       checkAccess(

--- a/packages/api/src/db/notifications.test.ts
+++ b/packages/api/src/db/notifications.test.ts
@@ -3,13 +3,14 @@ import { eq } from 'drizzle-orm'
 import {
   makeDb,
   seedComment,
+  seedMember,
   seedNotification,
   seedSite,
   seedSpace,
   seedThread,
   seedUser,
 } from '../test/harness'
-import { createNotifications, listNotifications, markRead } from './notifications'
+import { createNotifications, listNotifications, markRead, resolveCommentAudience } from './notifications'
 import { comments } from './schema'
 
 // Notifications repo over the S-D harness: batch create, recipient-scoped list (+ unread count),
@@ -21,11 +22,14 @@ describe('C1 — createNotifications inserts N rows; listNotifications returns t
     const me = await seedUser(db, { name: 'Me' })
     const actor = await seedUser(db, { name: 'Ava' })
     await createNotifications(db, [
-      { recipientId: me, type: 'mention', actorId: actor, siteLabel: 's/a', createdAt: '2026-01-01T00:00:00.000Z', snippet: 'first' },
-      { recipientId: me, type: 'mention', actorId: actor, siteLabel: 's/a', createdAt: '2026-01-02T00:00:00.000Z', snippet: 'second' },
-      { recipientId: me, type: 'mention', actorId: actor, siteLabel: 's/a', createdAt: '2026-01-03T00:00:00.000Z', snippet: 'third' },
+      { recipientId: me, type: 'mention', actorId: actor, siteLabel: 's/a', snippet: 'first' },
+      { recipientId: me, type: 'mention', actorId: actor, siteLabel: 's/a', snippet: 'second' },
+      { recipientId: me, type: 'mention', actorId: actor, siteLabel: 's/a', snippet: 'third' },
     ])
+    // The single multi-values insert gives these rows the same millisecond timestamp; newest-first
+    // is therefore made deterministic by listNotifications' rowid-desc tiebreaker.
     const { items } = await listNotifications(db, me)
+    expect(new Set(items.map((n) => n.createdAt)).size).toBe(1)
     expect(items.map((n) => n.snippet)).toEqual(['third', 'second', 'first'])
     expect(items[0].type).toBe('mention')
     expect(items[0].actorName).toBe('Ava')
@@ -39,6 +43,22 @@ describe('C1 — createNotifications inserts N rows; listNotifications returns t
     const { items, unreadCount } = await listNotifications(db, me)
     expect(items).toEqual([])
     expect(unreadCount).toBe(0)
+  })
+
+  test('ten recipients stay under D1 bind limits via two inserts in one batch', async () => {
+    const db = makeDb()
+    const recipients: string[] = []
+    for (let i = 0; i < 10; i++) recipients.push(await seedUser(db))
+    db.resetCounters()
+
+    await createNotifications(
+      db,
+      recipients.map((recipientId) => ({ recipientId, type: 'comment' })),
+    )
+
+    expect(db.counters).toEqual({ batches: 1, loose: 0, batchStmts: 2, insert: 2, update: 0, delete: 0 })
+    const listed = await Promise.all(recipients.map((recipientId) => listNotifications(db, recipientId)))
+    expect(listed.every(({ items }) => items.length === 1)).toBe(true)
   })
 })
 
@@ -100,6 +120,31 @@ describe('C4 — list/markRead are recipient-scoped', () => {
     await markRead(db, me, [theirs]) // even naming their id must not cross the boundary
     const { unreadCount } = await listNotifications(db, other)
     expect(unreadCount).toBe(1)
+  })
+})
+
+describe('comment audience stays within D1 bind limits', () => {
+  test('resolves one hundred member participants in bounded access-fact statements', async () => {
+    const db = makeDb()
+    const ownerId = await seedUser(db)
+    const spaceId = await seedSpace(db, { createdBy: ownerId })
+    const siteId = await seedSite(db, { spaceId, ownerId, visibility: 'members' })
+    const threadId = await seedThread(db, { siteId, filePath: 'index.html', createdBy: ownerId })
+    const participants: string[] = []
+    for (let i = 0; i < 100; i++) {
+      const participant = await seedUser(db)
+      participants.push(participant)
+      await seedMember(db, spaceId, participant)
+      await seedComment(db, { threadId, authorId: participant })
+    }
+
+    const audience = await resolveCommentAudience(
+      db,
+      { id: siteId, spaceId, ownerId, visibility: 'members', status: 'active' },
+      { threadId, isReply: true, exclude: new Set([ownerId]) },
+    )
+
+    expect(new Set(audience)).toEqual(new Set(participants))
   })
 })
 

--- a/packages/api/src/db/notifications.test.ts
+++ b/packages/api/src/db/notifications.test.ts
@@ -1,6 +1,16 @@
 import { describe, expect, test } from 'bun:test'
-import { makeDb, seedNotification, seedUser } from '../test/harness'
+import { eq } from 'drizzle-orm'
+import {
+  makeDb,
+  seedComment,
+  seedNotification,
+  seedSite,
+  seedSpace,
+  seedThread,
+  seedUser,
+} from '../test/harness'
 import { createNotifications, listNotifications, markRead } from './notifications'
+import { comments } from './schema'
 
 // Notifications repo over the S-D harness: batch create, recipient-scoped list (+ unread count),
 // and mark-read. Pure D1 — no R2, no external calls.
@@ -11,9 +21,9 @@ describe('C1 — createNotifications inserts N rows; listNotifications returns t
     const me = await seedUser(db, { name: 'Me' })
     const actor = await seedUser(db, { name: 'Ava' })
     await createNotifications(db, [
-      { recipientId: me, actorId: actor, siteLabel: 's/a', createdAt: '2026-01-01T00:00:00.000Z', snippet: 'first' },
-      { recipientId: me, actorId: actor, siteLabel: 's/a', createdAt: '2026-01-02T00:00:00.000Z', snippet: 'second' },
-      { recipientId: me, actorId: actor, siteLabel: 's/a', createdAt: '2026-01-03T00:00:00.000Z', snippet: 'third' },
+      { recipientId: me, type: 'mention', actorId: actor, siteLabel: 's/a', createdAt: '2026-01-01T00:00:00.000Z', snippet: 'first' },
+      { recipientId: me, type: 'mention', actorId: actor, siteLabel: 's/a', createdAt: '2026-01-02T00:00:00.000Z', snippet: 'second' },
+      { recipientId: me, type: 'mention', actorId: actor, siteLabel: 's/a', createdAt: '2026-01-03T00:00:00.000Z', snippet: 'third' },
     ])
     const { items } = await listNotifications(db, me)
     expect(items.map((n) => n.snippet)).toEqual(['third', 'second', 'first'])
@@ -90,5 +100,37 @@ describe('C4 — list/markRead are recipient-scoped', () => {
     await markRead(db, me, [theirs]) // even naming their id must not cross the boundary
     const { unreadCount } = await listNotifications(db, other)
     expect(unreadCount).toBe(1)
+  })
+})
+
+describe('S1 — createNotifications persists type comment + commentId; comment delete nulls commentId', () => {
+  test('S1 — createNotifications persists type comment + commentId; comment delete nulls commentId', async () => {
+    const db = makeDb()
+    const me = await seedUser(db, { name: 'Me' })
+    const actor = await seedUser(db, { name: 'Ava' })
+    const spaceId = await seedSpace(db, { createdBy: actor })
+    const siteId = await seedSite(db, { spaceId, ownerId: actor })
+    const threadId = await seedThread(db, { siteId, filePath: 'index.html', createdBy: actor })
+    const commentId = await seedComment(db, { threadId, authorId: actor, body: 'hey' })
+    await createNotifications(db, [
+      {
+        recipientId: me,
+        type: 'comment',
+        actorId: actor,
+        siteId,
+        siteLabel: 'sp/site',
+        threadId,
+        commentId,
+        snippet: 'hey',
+      },
+    ])
+    const { items } = await listNotifications(db, me)
+    expect(items[0].type).toBe('comment')
+    expect(items[0].commentId).toBe(commentId)
+
+    await db.delete(comments).where(eq(comments.id, commentId))
+    const after = await listNotifications(db, me)
+    expect(after.items.length).toBe(1)
+    expect(after.items[0].commentId).toBeNull()
   })
 })

--- a/packages/api/src/db/notifications.ts
+++ b/packages/api/src/db/notifications.ts
@@ -1,6 +1,17 @@
-import { and, desc, eq, inArray, isNull, sql } from 'drizzle-orm'
+import { and, desc, eq, inArray, isNotNull, isNull, sql } from 'drizzle-orm'
 import type { DrizzleD1Database } from 'drizzle-orm/d1'
-import { type NotificationType, notifications, users } from './schema'
+import { checkAccess } from '../lib/access'
+import { batchAll } from '../lib/d1'
+import {
+  comments,
+  type NotificationType,
+  notifications,
+  type Site,
+  siteGroupShares,
+  siteUserShares,
+  spaceMembers,
+  users,
+} from './schema'
 
 // Notifications repo: batch create (off the comment path, fire-and-forget), recipient-scoped list
 // (+ unread count), and mark-read. Pure D1 — no R2, no anchor resolution. Every function is
@@ -8,16 +19,17 @@ import { type NotificationType, notifications, users } from './schema'
 
 const now = () => new Date().toISOString()
 
-/** One row to raise. `type` defaults to 'mention'; id + createdAt are generated. All targets are
- *  optional so a row survives (via denormalized `siteLabel`) after the site/thread it points at is
- *  gone — see the SET NULL FKs in schema. */
+/** One row to raise. `type` is required ('mention' | 'comment'); id + createdAt are generated.
+ *  All targets are optional so a row survives (via denormalized `siteLabel`) after the site/thread/
+ *  comment it points at is gone — see the SET NULL FKs in schema. */
 export type NotificationInput = {
   recipientId: string
-  type?: NotificationType
+  type: NotificationType
   actorId?: string | null
   siteId?: string | null
   siteLabel?: string | null
   threadId?: string | null
+  commentId?: string | null
   filePath?: string | null
   snippet?: string | null
 }
@@ -30,6 +42,7 @@ export type NotificationView = {
   siteLabel: string | null
   filePath: string | null
   threadId: string | null
+  commentId: string | null
   snippet: string | null
   read: boolean
   readAt: string | null
@@ -42,15 +55,85 @@ export async function createNotifications(db: DrizzleD1Database, rows: Notificat
   await db.insert(notifications).values(
     rows.map((r) => ({
       recipientId: r.recipientId,
-      type: r.type ?? 'mention',
+      type: r.type,
       actorId: r.actorId ?? null,
       siteId: r.siteId ?? null,
       siteLabel: r.siteLabel ?? null,
       threadId: r.threadId ?? null,
+      commentId: r.commentId ?? null,
       filePath: r.filePath ?? null,
       snippet: r.snippet ?? null,
     })),
   )
+}
+
+/** Resolve the normal comment audience from targeted facts, excluding the actor and any mention
+ *  recipients. Prior participants join the owner and direct shares only for replies; every
+ *  candidate is re-authorized against the site's current tier/share policy before notification. */
+export async function resolveCommentAudience(
+  db: DrizzleD1Database,
+  site: Pick<Site, 'id' | 'spaceId' | 'visibility' | 'ownerId' | 'status'>,
+  opts: { threadId: string; isReply: boolean; exclude: Set<string> | string[] },
+): Promise<string[]> {
+  if (site.status === 'archived') return []
+
+  const directSharesStmt = db
+    .select({ userId: siteUserShares.userId })
+    .from(siteUserShares)
+    .where(eq(siteUserShares.siteId, site.id))
+  const participantsStmt = db
+    .selectDistinct({ authorId: comments.authorId })
+    .from(comments)
+    .where(and(eq(comments.threadId, opts.threadId), isNotNull(comments.authorId)))
+  const audienceFacts = async (): Promise<{
+    directRows: { userId: string }[]
+    participantRows: { authorId: string | null }[]
+  }> => {
+    if (opts.isReply) {
+      const [directRows, participantRows] = await batchAll(db, [directSharesStmt, participantsStmt])
+      return { directRows, participantRows }
+    }
+    const [directRows] = await batchAll(db, [directSharesStmt])
+    return { directRows, participantRows: [] }
+  }
+  const { directRows, participantRows } = await audienceFacts()
+  const directShares = new Set(directRows.map((row) => row.userId))
+  // TS-only narrowing; the SQL isNotNull predicate already excludes null authors.
+  const participantIds = participantRows
+    .map((row) => row.authorId)
+    .filter((authorId): authorId is string => authorId !== null)
+  const audience = new Set<string>([site.ownerId, ...directShares, ...participantIds])
+  const excluded = opts.exclude instanceof Set ? opts.exclude : new Set(opts.exclude)
+  for (const id of excluded) audience.delete(id)
+  const candidates = [...audience]
+  if (candidates.length === 0) return []
+
+  const groupSharesStmt = db
+    .selectDistinct({ userId: spaceMembers.userId })
+    .from(spaceMembers)
+    .innerJoin(siteGroupShares, eq(spaceMembers.spaceId, siteGroupShares.spaceId))
+    .where(and(eq(siteGroupShares.siteId, site.id), inArray(spaceMembers.userId, candidates)))
+  const membersStmt = db
+    .select({ userId: spaceMembers.userId })
+    .from(spaceMembers)
+    .where(and(eq(spaceMembers.spaceId, site.spaceId), inArray(spaceMembers.userId, candidates)))
+  const accessStatements =
+    site.visibility === 'members'
+      ? [groupSharesStmt, membersStmt]
+      : site.visibility === 'private'
+        ? [groupSharesStmt]
+        : []
+  const accessRows = await batchAll(db, accessStatements)
+  const groupRows = accessRows[0] ?? []
+  const memberRows = site.visibility === 'members' ? (accessRows[1] ?? []) : []
+  const groupSharedIds = new Set(groupRows.map((row) => row.userId))
+  const memberIds = new Set(memberRows.map((row) => row.userId))
+
+  return candidates.filter((id) => {
+    // Recipient role is deliberately not consulted — superadmins need normal tier/share access to be notified.
+    const recipient = { id, role: 'member' as const }
+    return checkAccess(site, recipient, memberIds.has(id), directShares.has(id) || groupSharedIds.has(id)).ok
+  })
 }
 
 /** A recipient's notifications, newest-first, plus the FULL unread count (independent of `limit`).
@@ -70,6 +153,7 @@ export async function listNotifications(
       siteLabel: notifications.siteLabel,
       filePath: notifications.filePath,
       threadId: notifications.threadId,
+      commentId: notifications.commentId,
       snippet: notifications.snippet,
       readAt: notifications.readAt,
       createdAt: notifications.createdAt,
@@ -93,6 +177,7 @@ export async function listNotifications(
     siteLabel: r.siteLabel,
     filePath: r.filePath,
     threadId: r.threadId,
+    commentId: r.commentId,
     snippet: r.snippet,
     read: r.readAt !== null,
     readAt: r.readAt,

--- a/packages/api/src/db/notifications.ts
+++ b/packages/api/src/db/notifications.ts
@@ -1,7 +1,7 @@
 import { and, desc, eq, inArray, isNotNull, isNull, sql } from 'drizzle-orm'
 import type { DrizzleD1Database } from 'drizzle-orm/d1'
 import { checkAccess } from '../lib/access'
-import { batchAll } from '../lib/d1'
+import { batchAll, chunk, D1_MAX_BOUND_PARAMETERS, D1_MAX_IN } from '../lib/d1'
 import {
   comments,
   type NotificationType,
@@ -18,6 +18,11 @@ import {
 // exported so the S-D harness drives it directly.
 
 const now = () => new Date().toISOString()
+
+// Drizzle binds every insert column, including the generated id and createdAt defaults. Keep each
+// multi-values INSERT below D1's 100-parameter cap: floor(100 / 11) = 9 rows per statement.
+const NOTIFICATION_INSERT_COLUMN_COUNT = 11
+const NOTIFICATION_ROWS_PER_INSERT = Math.floor(D1_MAX_BOUND_PARAMETERS / NOTIFICATION_INSERT_COLUMN_COUNT)
 
 /** One row to raise. `type` is required ('mention' | 'comment'); id + createdAt are generated.
  *  All targets are optional so a row survives (via denormalized `siteLabel`) after the site/thread/
@@ -49,22 +54,25 @@ export type NotificationView = {
   createdAt: string
 }
 
-/** Insert a batch of notifications in one statement. Empty batch is a no-op (never touches D1). */
+/** Insert notifications in one D1 batch of bind-safe statements. Empty input never touches D1. */
 export async function createNotifications(db: DrizzleD1Database, rows: NotificationInput[]): Promise<void> {
   if (rows.length === 0) return
-  await db.insert(notifications).values(
-    rows.map((r) => ({
-      recipientId: r.recipientId,
-      type: r.type,
-      actorId: r.actorId ?? null,
-      siteId: r.siteId ?? null,
-      siteLabel: r.siteLabel ?? null,
-      threadId: r.threadId ?? null,
-      commentId: r.commentId ?? null,
-      filePath: r.filePath ?? null,
-      snippet: r.snippet ?? null,
-    })),
+  const inserts = chunk(rows, NOTIFICATION_ROWS_PER_INSERT).map((batch) =>
+    db.insert(notifications).values(
+      batch.map((r) => ({
+        recipientId: r.recipientId,
+        type: r.type,
+        actorId: r.actorId ?? null,
+        siteId: r.siteId ?? null,
+        siteLabel: r.siteLabel ?? null,
+        threadId: r.threadId ?? null,
+        commentId: r.commentId ?? null,
+        filePath: r.filePath ?? null,
+        snippet: r.snippet ?? null,
+      })),
+    ),
   )
+  await batchAll(db, inserts)
 }
 
 /** Resolve the normal comment audience from targeted facts, excluding the actor and any mention
@@ -73,7 +81,7 @@ export async function createNotifications(db: DrizzleD1Database, rows: Notificat
 export async function resolveCommentAudience(
   db: DrizzleD1Database,
   site: Pick<Site, 'id' | 'spaceId' | 'visibility' | 'ownerId' | 'status'>,
-  opts: { threadId: string; isReply: boolean; exclude: Set<string> | string[] },
+  opts: { threadId: string; isReply: boolean; exclude: Set<string> },
 ): Promise<string[]> {
   if (site.status === 'archived') return []
 
@@ -103,29 +111,37 @@ export async function resolveCommentAudience(
     .map((row) => row.authorId)
     .filter((authorId): authorId is string => authorId !== null)
   const audience = new Set<string>([site.ownerId, ...directShares, ...participantIds])
-  const excluded = opts.exclude instanceof Set ? opts.exclude : new Set(opts.exclude)
-  for (const id of excluded) audience.delete(id)
+  for (const id of opts.exclude) audience.delete(id)
   const candidates = [...audience]
   if (candidates.length === 0) return []
+  // Every candidate is an authenticated user id from an FK-backed audience fact. Team visibility
+  // admits all of them, so no access-fact queries are needed.
+  if (site.visibility === 'team') return candidates
 
-  const groupSharesStmt = db
-    .selectDistinct({ userId: spaceMembers.userId })
-    .from(spaceMembers)
-    .innerJoin(siteGroupShares, eq(spaceMembers.spaceId, siteGroupShares.spaceId))
-    .where(and(eq(siteGroupShares.siteId, site.id), inArray(spaceMembers.userId, candidates)))
-  const membersStmt = db
-    .select({ userId: spaceMembers.userId })
-    .from(spaceMembers)
-    .where(and(eq(spaceMembers.spaceId, site.spaceId), inArray(spaceMembers.userId, candidates)))
-  const accessStatements =
-    site.visibility === 'members'
-      ? [groupSharesStmt, membersStmt]
-      : site.visibility === 'private'
-        ? [groupSharesStmt]
-        : []
-  const accessRows = await batchAll(db, accessStatements)
-  const groupRows = accessRows[0] ?? []
-  const memberRows = site.visibility === 'members' ? (accessRows[1] ?? []) : []
+  const accessFactStatements = chunk(candidates, D1_MAX_IN).flatMap((ids) => [
+    {
+      name: 'groupRows' as const,
+      statement: db
+        .selectDistinct({ userId: spaceMembers.userId })
+        .from(spaceMembers)
+        .innerJoin(siteGroupShares, eq(spaceMembers.spaceId, siteGroupShares.spaceId))
+        .where(and(eq(siteGroupShares.siteId, site.id), inArray(spaceMembers.userId, ids))),
+    },
+    {
+      name: 'memberRows' as const,
+      statement: db
+        .select({ userId: spaceMembers.userId })
+        .from(spaceMembers)
+        .where(and(eq(spaceMembers.spaceId, site.spaceId), inArray(spaceMembers.userId, ids))),
+    },
+  ])
+  const accessRowChunks = await batchAll(
+    db,
+    accessFactStatements.map(({ statement }) => statement),
+  )
+  const accessRows = { groupRows: [] as { userId: string }[], memberRows: [] as { userId: string }[] }
+  for (const [index, { name }] of accessFactStatements.entries()) accessRows[name].push(...accessRowChunks[index])
+  const { groupRows, memberRows } = accessRows
   const groupSharedIds = new Set(groupRows.map((row) => row.userId))
   const memberIds = new Set(memberRows.map((row) => row.userId))
 

--- a/packages/api/src/db/schema.ts
+++ b/packages/api/src/db/schema.ts
@@ -251,8 +251,12 @@ export const notifications = sqliteTable(
     readAt: text('readAt'),
     createdAt: text('createdAt').notNull().$defaultFn(() => new Date().toISOString()),
   },
-  // Unread count + list for one recipient in a single index scan, newest-first.
-  (t) => [index('notifications_recipient_read_created').on(t.recipientId, t.readAt, t.createdAt)],
+  (t) => [
+    // Unread count + list for one recipient in a single index scan, newest-first.
+    index('notifications_recipient_read_created').on(t.recipientId, t.readAt, t.createdAt),
+    // Supports comment FK maintenance when a comment is hard-deleted through a site/thread cascade.
+    index('notifications_comment').on(t.commentId),
+  ],
 )
 
 // One row per site (`siteId` unique): site deletion cascades, while `generatedBy` is SET NULL so

--- a/packages/api/src/db/schema.ts
+++ b/packages/api/src/db/schema.ts
@@ -225,9 +225,10 @@ export const events = sqliteTable(
   ],
 )
 
-// Homepage notifications. v1 carries a single `type` ('mention') raised when a user is @-tagged in
-// a review comment. FK durability mirrors `events`/`comments`: the RECIPIENT cascades (a deleted
-// user's notifications are meaningless), but actor/site/thread are SET NULL so the row survives the
+// Homepage notifications. Notifications carry type 'mention' (@-tag) or 'comment' (activity on your
+// sites / threads you participate in); `commentId` identifies the triggering comment for feed
+// dedupe. FK durability mirrors `events`/`comments`: the RECIPIENT cascades (a deleted user's
+// notifications are meaningless), but actor/site/thread/comment are SET NULL so the row survives the
 // deletion of what it points at — `siteLabel` denormalizes "space/slug" (captured from route params
 // at insert time; the site row only has slug+spaceId, not the space slug) so the deep-link stays
 // readable. Inserts are fire-and-forget off the comment path, so a write here never blocks/faults a
@@ -237,12 +238,13 @@ export const notifications = sqliteTable(
   {
     id: text('id').primaryKey().$defaultFn(() => crypto.randomUUID()),
     recipientId: text('recipientId').notNull().references(() => users.id, { onDelete: 'cascade' }),
-    type: text('type', { enum: ['mention'] }).notNull(),
+    type: text('type', { enum: ['mention', 'comment'] }).notNull(),
     actorId: text('actorId').references(() => users.id, { onDelete: 'set null' }),
     siteId: text('siteId').references(() => sites.id, { onDelete: 'set null' }),
     // Denormalized "space/slug" from the route params at insert — survives a site delete.
     siteLabel: text('siteLabel'),
     threadId: text('threadId').references(() => commentThreads.id, { onDelete: 'set null' }),
+    commentId: text('commentId').references(() => comments.id, { onDelete: 'set null' }),
     filePath: text('filePath'),
     snippet: text('snippet'),
     // Null = unread; set to an ISO timestamp when marked read.

--- a/packages/api/src/lib/access.ts
+++ b/packages/api/src/lib/access.ts
@@ -21,7 +21,7 @@ const ALLOW: AccessResult = { ok: true }
  */
 export function checkAccess(
   site: Pick<Site, 'visibility' | 'status' | 'ownerId'>,
-  user: SessionUser | null,
+  user: Pick<SessionUser, 'id' | 'role'> | null,
   isMember: boolean,
   isShared = false,
 ): AccessResult {

--- a/packages/api/src/lib/d1.ts
+++ b/packages/api/src/lib/d1.ts
@@ -7,6 +7,7 @@ import type { DrizzleD1Database } from 'drizzle-orm/d1'
 // be split into chunks and the per-chunk results unioned — otherwise a large member-space /
 // shared-site list throws. Kept under 100 to leave room for a statement's other bound values
 // (e.g. pureAudioSql's per-audio-extension binds).
+export const D1_MAX_BOUND_PARAMETERS = 100
 export const D1_MAX_IN = 90
 
 /** Split xs into runs of at most `size` (the last run may be shorter). */
@@ -17,9 +18,8 @@ export function chunk<T>(xs: T[], size: number): T[][] {
 }
 
 /** `db.batch` over a statement ARRAY: owns the non-empty tuple cast D1's batch signature
- *  demands, so call sites assembling dynamic statement lists don't each repeat it. Empty input
- *  resolves to `[]` without touching D1 (a zero-statement batch would throw; no current call
- *  site can produce one, so this is a safe no-op rather than a reachable branch).
+ *  demands, so call sites assembling dynamic statement lists don't each repeat it. Empty input is
+ *  handled defensively without touching D1; current callers all guard or construct non-empty lists.
  *
  *  TWO RULES bind every statement placed in a batch (here or via raw `db.batch`):
  *  1. Result column names must be UNIQUE and expression columns must carry `.as(...)` — real

--- a/packages/api/src/routes/comment-feed.test.ts
+++ b/packages/api/src/routes/comment-feed.test.ts
@@ -75,7 +75,8 @@ function kindIds(items: unknown): Array<{ kind: string; id: string }> {
 }
 
 function expectRequestBudget(db: RouteApp['db']) {
-  expect(db.counters).toEqual({ loose: 1, batches: 1, batchStmts: 5, insert: 0, update: 0, delete: 0 })
+  // 6 batch stmts: authored, mentions, owned, memberSpaces, shares(direct+viaGroup)
+  expect(db.counters).toEqual({ loose: 1, batches: 1, batchStmts: 6, insert: 0, update: 0, delete: 0 })
 }
 
 describe('comment feed route — C4.1 auth', () => {
@@ -158,10 +159,64 @@ describe('comment feed route — C4.2 golden contract', () => {
       },
     ])
   })
+
+  test("another user's comment on a site the caller owns appears as owned", async () => {
+    const { app, env, db, kv } = makeRouteApp()
+    const ownerId = await mintUser(db, kv, 'owned-owner')
+    const authorId = await mintUser(db, kv, 'owned-author', { email: 'commenter@example.com' })
+    const spaceId = await seedSpace(db, {
+      id: 'space-owned-route',
+      createdBy: ownerId,
+      slug: 'owned-space',
+      name: 'Owned Space',
+    })
+    const siteId = await seedSite(db, {
+      id: 'site-owned-route',
+      spaceId,
+      ownerId,
+      slug: 'owned-site',
+      title: 'Owned Site',
+      visibility: 'private',
+    })
+    const threadId = await seedThread(db, {
+      id: 'thread-owned-route',
+      siteId,
+      filePath: 'docs/owned.html',
+      status: 'open',
+      createdBy: authorId,
+    })
+    await seedComment(db, {
+      id: 'comment-owned-route',
+      threadId,
+      authorId,
+      body: 'A comment for the owner',
+      createdAt: at(5),
+    })
+
+    const res = await app.request(FEED_URL, { headers: auth(ownerId) }, env)
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual([
+      {
+        kind: 'owned',
+        id: 'comment-owned-route',
+        snippet: 'A comment for the owner',
+        actorName: 'commenter@example.com',
+        spaceSlug: 'owned-space',
+        siteSlug: 'owned-site',
+        siteTitle: 'Owned Site',
+        filePath: 'docs/owned.html',
+        threadId: 'thread-owned-route',
+        threadStatus: 'open',
+        createdAt: '2026-01-01T00:00:05.000Z',
+        editedAt: null,
+      },
+    ])
+  })
 })
 
 describe('comment feed route — C4.4 request budget', () => {
-  test('a populated feed uses one auth read and one five-statement batch with no writes', async () => {
+  test('a populated feed uses one auth read and one six-statement batch with no writes', async () => {
     const { app, env, db, kv } = makeRouteApp()
     const userId = await seedGoldenFeed(db, kv)
     db.resetCounters()
@@ -377,7 +432,7 @@ describe('comment feed route — C4.5 moved site', () => {
 })
 
 describe('comment feed route — C4.7 caller isolation', () => {
-  test("returns only the caller's authored comments and mention notifications", async () => {
+  test("returns the caller's authored, mention, and owned rows — never another caller's mentions", async () => {
     const { app, env, db, kv } = makeRouteApp()
     const userId = await mintUser(db, kv, 'isolation-me')
     const otherUserId = await mintUser(db, kv, 'isolation-other')
@@ -450,6 +505,7 @@ describe('comment feed route — C4.7 caller isolation', () => {
 
     expect(res.status).toBe(200)
     expect(kindIds(await res.json())).toEqual([
+      { kind: 'owned', id: 'comment-isolation-other-authored' },
       { kind: 'mention', id: 'notification-isolation-my-mention' },
       { kind: 'authored', id: 'comment-isolation-my-authored' },
     ])

--- a/packages/api/src/routes/comment-feed.ts
+++ b/packages/api/src/routes/comment-feed.ts
@@ -1,5 +1,10 @@
 import { Hono } from 'hono'
-import { assembleCommentFeed, authoredCandidatesStmt, mentionCandidatesStmt } from '../db/comment-feed'
+import {
+  assembleCommentFeed,
+  authoredCandidatesStmt,
+  mentionCandidatesStmt,
+  ownedCandidatesStmt,
+} from '../db/comment-feed'
 import { foldMemberSpaceIds, foldSharedSiteRoles, memberSpaceIdsStmt, sharedSiteRoleStmts } from '../db/repo'
 import { batchAll } from '../lib/d1'
 import { requireAuth } from '../middleware/auth'
@@ -12,14 +17,15 @@ commentFeed.use('*', requireAuth)
 commentFeed.get('/feed', async (c) => {
   const db = c.get('db')
   const user = c.get('user')
-  const [authored, mentions, memberSpaces, direct, viaGroup] = await batchAll(db, [
+  const [authored, mentions, owned, memberSpaces, direct, viaGroup] = await batchAll(db, [
     authoredCandidatesStmt(db, user.id),
     mentionCandidatesStmt(db, user.id),
+    ownedCandidatesStmt(db, user.id),
     memberSpaceIdsStmt(db, user.id),
     ...sharedSiteRoleStmts(db, user.id),
   ])
   const memberSpaceIds = foldMemberSpaceIds(memberSpaces)
   const sharedSiteRoles = foldSharedSiteRoles(direct, viaGroup)
 
-  return c.json(assembleCommentFeed({ authored, mentions, user, memberSpaceIds, sharedSiteRoles }))
+  return c.json(assembleCommentFeed({ authored, mentions, owned, user, memberSpaceIds, sharedSiteRoles }))
 })

--- a/packages/api/src/routes/comments-access.test.ts
+++ b/packages/api/src/routes/comments-access.test.ts
@@ -346,7 +346,7 @@ describe('comments routes — T9.5 mutations fuse target reads into the access b
     expect(db.counters.batchStmts).toBe(batchStmts)
   }
 
-  test('reply = gate + write + notify(reads, 1 insert); denial stops unchanged at the gate', async () => {
+  test('reply = gate + write + notify(reads, batched insert); denial stops unchanged at the gate', async () => {
     const { app, env, db, kv } = makeRouteApp()
     const owner = await mintUser(db, kv, 'owner')
     const commenter = await mintUser(db, kv, 'commenter')
@@ -358,8 +358,10 @@ describe('comments routes — T9.5 mutations fuse target reads into the access b
     db.resetCounters()
     expect((await reply(threadId)).status).toBe(201)
     // The harness drains post-response waitUntil work inline, so the observed reply shape is auth
-    // (1 loose) + gate batch (6) + write batch (2) + notify batch (2) + notification INSERT (loose).
-    shape(db, 2, 3, 10)
+    // (1 loose) + gate batch (6) + write batch (2) + notify-read batch (2) + notification batch (1).
+    // Even one insert chunk is batched so 10+ recipients can split under D1's 100-param cap in the
+    // same round trip.
+    shape(db, 1, 4, 11)
 
     db.resetCounters()
     expect((await reply(foreign.threadId)).status).toBe(404)

--- a/packages/api/src/routes/comments-access.test.ts
+++ b/packages/api/src/routes/comments-access.test.ts
@@ -336,9 +336,9 @@ describe('comments routes — T9.4 relationship denials are side-effect-free', (
 
 // T9.5 (S9c): every mutation's PRE-WRITE reads are exactly requireAuth's 1 loose read + ONE fused
 // db.batch — the 5 access facts plus the URL-id-keyed target rows (thread and/or comment). The
-// write, when reached, is the only further request. Denial paths stop at the fused batch, so
-// their counts ARE the pre-write shape. The voice-audio GET does no writes: its ENTIRE pre-R2 D1
-// bill is 2 requests.
+// write, when reached, is the only further request on the response path; notification work runs
+// post-response through waitUntil. Denial paths stop at the fused batch, so their counts ARE the
+// pre-write shape. The voice-audio GET does no writes: its ENTIRE pre-R2 D1 bill is 2 requests.
 describe('comments routes — T9.5 mutations fuse target reads into the access batch', () => {
   const shape = (db: ReturnType<typeof makeRouteApp>['db'], loose: number, batches: number, batchStmts: number) => {
     expect(db.counters.loose).toBe(loose)
@@ -346,17 +346,20 @@ describe('comments routes — T9.5 mutations fuse target reads into the access b
     expect(db.counters.batchStmts).toBe(batchStmts)
   }
 
-  test('reply: gate batch of 6 (5 facts + thread), then ONLY the write batch of 2; denial stops at the gate', async () => {
+  test('reply = gate + write + notify(reads, 1 insert); denial stops unchanged at the gate', async () => {
     const { app, env, db, kv } = makeRouteApp()
     const owner = await mintUser(db, kv, 'owner')
+    const commenter = await mintUser(db, kv, 'commenter')
     const { threadId } = await seedCommentedSite(db, owner)
     const foreign = await seedForeignSite(db, owner)
     const reply = (tid: string) =>
-      app.request(url('acme', 'doc', `/${tid}/replies`), { method: 'POST', headers: auth(owner), body: JSON.stringify({ body: 'hi' }) }, env)
+      app.request(url('acme', 'doc', `/${tid}/replies`), { method: 'POST', headers: auth(commenter), body: JSON.stringify({ body: 'hi' }) }, env)
 
     db.resetCounters()
     expect((await reply(threadId)).status).toBe(201)
-    shape(db, 1, 2, 8) // 1 auth read; fused gate (6) + addComment's write batch (2)
+    // The harness drains post-response waitUntil work inline, so the observed reply shape is auth
+    // (1 loose) + gate batch (6) + write batch (2) + notify batch (2) + notification INSERT (loose).
+    shape(db, 2, 3, 10)
 
     db.resetCounters()
     expect((await reply(foreign.threadId)).status).toBe(404)

--- a/packages/api/src/routes/comments.ts
+++ b/packages/api/src/routes/comments.ts
@@ -158,7 +158,7 @@ function cleanBody(v: unknown): string | null {
  *  mentions are deduped, self-skipped, and intersected against the autocomplete's access set.
  *  The comment audience is the owner + direct shares + (for replies) prior participants, then
  *  re-authorized from targeted membership/group-share facts; mentions win over comment rows.
- *  Every recipient is inserted in one statement. Fully guarded and fire-and-forget: notification
+ *  Every recipient is inserted in one bind-safe batch. Fully guarded and fire-and-forget: notification
  *  reads or writes must NEVER fail or block the comment that already committed. */
 async function notifyForComment(
   c: Context<AppEnv>,
@@ -222,17 +222,19 @@ async function notifyForComment(
 function notifyThreadCreated(
   c: Context<AppEnv>,
   site: ResolvedSite,
-  out: Awaited<ReturnType<typeof createThread>>,
-  filePath: string,
-  snippet: string,
-  rawMentions: unknown = undefined,
+  opts: {
+    out: Pick<Awaited<ReturnType<typeof createThread>>, 'threadId' | 'openingCommentId'>
+    filePath: string
+    snippet: string
+    rawMentions?: unknown
+  },
 ): Promise<void> {
   return notifyForComment(c, site, {
-    rawMentions,
-    threadId: out.threadId,
-    commentId: out.openingCommentId,
-    filePath,
-    snippet,
+    rawMentions: opts.rawMentions,
+    threadId: opts.out.threadId,
+    commentId: opts.out.openingCommentId,
+    filePath: opts.filePath,
+    snippet: opts.snippet,
     isReply: false,
   })
 }
@@ -240,17 +242,19 @@ function notifyThreadCreated(
 function notifyReply(
   c: Context<AppEnv>,
   site: ResolvedSite,
-  thread: Pick<CommentThread, 'id' | 'filePath'>,
-  commentId: string,
-  snippet: string,
-  rawMentions: unknown = undefined,
+  opts: {
+    thread: Pick<CommentThread, 'id' | 'filePath'>
+    commentId: string
+    snippet: string
+    rawMentions?: unknown
+  },
 ): Promise<void> {
   return notifyForComment(c, site, {
-    rawMentions,
-    threadId: thread.id,
-    commentId,
-    filePath: thread.filePath,
-    snippet,
+    rawMentions: opts.rawMentions,
+    threadId: opts.thread.id,
+    commentId: opts.commentId,
+    filePath: opts.thread.filePath,
+    snippet: opts.snippet,
     isReply: true,
   })
 }
@@ -429,7 +433,7 @@ comments.post('/:space/:site/comments', async (c) => {
     quote: fields.quote,
     anchor: fields.anchor,
   })
-  await notifyThreadCreated(c, site, out, fields.filePath, body, raw?.mentions)
+  await notifyThreadCreated(c, site, { out, filePath: fields.filePath, snippet: body, rawMentions: raw?.mentions })
   return c.json(out, 201)
 })
 
@@ -479,7 +483,7 @@ async function createVoiceThread(c: Context<AppEnv>, site: ResolvedSite): Promis
     await deleteKeys(c.env.GLANCE_FILES, [audioKey]) // compensation: don't orphan the R2 object
     throw e
   }
-  await notifyThreadCreated(c, site, out, fields.filePath, body)
+  await notifyThreadCreated(c, site, { out, filePath: fields.filePath, snippet: body })
   return c.json(out, 201)
 }
 
@@ -496,7 +500,7 @@ comments.post('/:space/:site/comments/:threadId/replies', async (c) => {
   const body = cleanBody(raw?.body)
   if (!body) return c.json({ error: 'invalid body' }, 400)
   const id = await addComment(c.get('db'), { threadId: thread.id, authorId: c.get('user').id, body })
-  await notifyReply(c, site, thread, id, body, raw?.mentions)
+  await notifyReply(c, site, { thread, commentId: id, snippet: body, rawMentions: raw?.mentions })
   return c.json({ id }, 201)
 })
 
@@ -515,7 +519,7 @@ async function replyVoiceComment(c: Context<AppEnv>, site: ResolvedSite, thread:
     await deleteKeys(c.env.GLANCE_FILES, [audioKey]) // compensation: don't orphan the R2 object
     throw e
   }
-  await notifyReply(c, site, thread, id, body)
+  await notifyReply(c, site, { thread, commentId: id, snippet: body })
   return c.json({ id }, 201)
 }
 

--- a/packages/api/src/routes/comments.ts
+++ b/packages/api/src/routes/comments.ts
@@ -16,7 +16,7 @@ import {
   threadsWithUsersBySlugsStmt,
 } from '../db/comments'
 import { truncateSnippet } from '../db/comment-feed'
-import { createNotifications } from '../db/notifications'
+import { createNotifications, type NotificationInput, resolveCommentAudience } from '../db/notifications'
 import type { Comment, CommentThread } from '../db/schema'
 import { listMentionableUsers } from '../db/repo'
 import { fireAndForget } from '../lib/events'
@@ -154,48 +154,105 @@ function cleanBody(v: unknown): string | null {
   return body
 }
 
-/** Raise mention notifications for a just-written comment. Explicit selections only (client sends
- *  ids from the autocomplete): dedup, drop self, then INTERSECT against `listMentionableUsers` —
- *  the same access set the autocomplete drew from — so a forged id for someone without access is
- *  dropped server-side. Fire-and-forget and fully guarded: a failure here (or an empty/absent
- *  selection) must NEVER fail or block the comment that already committed. */
-async function notifyMentions(
+/** Raise mention + comment-audience notifications for a just-written comment. Explicit
+ *  mentions are deduped, self-skipped, and intersected against the autocomplete's access set.
+ *  The comment audience is the owner + direct shares + (for replies) prior participants, then
+ *  re-authorized from targeted membership/group-share facts; mentions win over comment rows.
+ *  Every recipient is inserted in one statement. Fully guarded and fire-and-forget: notification
+ *  reads or writes must NEVER fail or block the comment that already committed. */
+async function notifyForComment(
   c: Context<AppEnv>,
   site: ResolvedSite,
-  opts: { rawMentions: unknown; threadId: string; filePath: string; snippet: string },
+  opts: {
+    rawMentions: unknown
+    threadId: string
+    commentId: string
+    filePath: string
+    snippet: string
+    isReply: boolean
+  },
 ): Promise<void> {
-  try {
-    const callerId = c.get('user').id
-    const requested = Array.isArray(opts.rawMentions)
-      ? [...new Set(opts.rawMentions.filter((m): m is string => typeof m === 'string' && m !== callerId))]
-      : []
-    if (requested.length === 0) return
-    const db = c.get('db')
-    const allowed = new Set((await listMentionableUsers(db, site, callerId)).map((u) => u.id))
-    const recipients = requested.filter((id) => allowed.has(id))
-    if (recipients.length === 0) return
-    const { space, site: siteSlug } = c.req.param()
-    const siteLabel = `${space}/${siteSlug}`
-    const snippet = truncateSnippet(opts.snippet)
-    await fireAndForget(
-      c,
-      createNotifications(
-        db,
-        recipients.map((recipientId) => ({
+  const callerId = c.get('user').id
+  const db = c.get('db')
+  const { space, site: siteSlug } = c.req.param()
+  const siteLabel = `${space}/${siteSlug}`
+  await fireAndForget(
+    c,
+    (async () => {
+      try {
+        const requested = Array.isArray(opts.rawMentions)
+          ? [...new Set(opts.rawMentions.filter((m): m is string => typeof m === 'string' && m !== callerId))]
+          : []
+        let mentionRecipients: string[] = []
+        if (requested.length > 0) {
+          const allowed = new Set((await listMentionableUsers(db, site, callerId)).map((u) => u.id))
+          mentionRecipients = requested.filter((id) => allowed.has(id))
+        }
+
+        const commentRecipients = await resolveCommentAudience(db, site, {
+          threadId: opts.threadId,
+          isReply: opts.isReply,
+          exclude: new Set([callerId, ...mentionRecipients]),
+        })
+        if (mentionRecipients.length === 0 && commentRecipients.length === 0) return
+
+        const snippet = truncateSnippet(opts.snippet)
+        const toRow = (recipientId: string, type: NotificationInput['type']): NotificationInput => ({
           recipientId,
-          type: 'mention' as const,
+          type,
           actorId: callerId,
           siteId: site.id,
           siteLabel,
           threadId: opts.threadId,
+          commentId: opts.commentId,
           filePath: opts.filePath,
           snippet,
-        })),
-      ),
-    )
-  } catch {
-    // Notifications are best-effort — never surface to the caller (mirrors recordEvent).
-  }
+        })
+        await createNotifications(db, [
+          ...mentionRecipients.map((id) => toRow(id, 'mention')),
+          ...commentRecipients.map((id) => toRow(id, 'comment')),
+        ])
+      } catch {
+        // Notifications are best-effort — never surface to the caller (mirrors recordEvent).
+      }
+    })(),
+  )
+}
+
+function notifyThreadCreated(
+  c: Context<AppEnv>,
+  site: ResolvedSite,
+  out: Awaited<ReturnType<typeof createThread>>,
+  filePath: string,
+  snippet: string,
+  rawMentions: unknown = undefined,
+): Promise<void> {
+  return notifyForComment(c, site, {
+    rawMentions,
+    threadId: out.threadId,
+    commentId: out.openingCommentId,
+    filePath,
+    snippet,
+    isReply: false,
+  })
+}
+
+function notifyReply(
+  c: Context<AppEnv>,
+  site: ResolvedSite,
+  thread: Pick<CommentThread, 'id' | 'filePath'>,
+  commentId: string,
+  snippet: string,
+  rawMentions: unknown = undefined,
+): Promise<void> {
+  return notifyForComment(c, site, {
+    rawMentions,
+    threadId: thread.id,
+    commentId,
+    filePath: thread.filePath,
+    snippet,
+    isReply: true,
+  })
 }
 
 type ThreadFields = {
@@ -372,7 +429,7 @@ comments.post('/:space/:site/comments', async (c) => {
     quote: fields.quote,
     anchor: fields.anchor,
   })
-  await notifyMentions(c, site, { rawMentions: raw?.mentions, threadId: out.threadId, filePath: fields.filePath, snippet: body })
+  await notifyThreadCreated(c, site, out, fields.filePath, body, raw?.mentions)
   return c.json(out, 201)
 })
 
@@ -405,8 +462,9 @@ async function createVoiceThread(c: Context<AppEnv>, site: ResolvedSite): Promis
   const ingested = await ingestVoiceComment(c, form)
   if (ingested instanceof Response) return ingested
   const { commentId, audioKey, body } = ingested
+  let out: Awaited<ReturnType<typeof createThread>>
   try {
-    const out = await createThread(c.get('db'), {
+    out = await createThread(c.get('db'), {
       siteId: site.id,
       filePath: fields.filePath,
       createdBy: c.get('user').id,
@@ -417,11 +475,12 @@ async function createVoiceThread(c: Context<AppEnv>, site: ResolvedSite): Promis
       commentId,
       audioKey,
     })
-    return c.json(out, 201)
   } catch (e) {
     await deleteKeys(c.env.GLANCE_FILES, [audioKey]) // compensation: don't orphan the R2 object
     throw e
   }
+  await notifyThreadCreated(c, site, out, fields.filePath, body)
+  return c.json(out, 201)
 }
 
 // POST — flat reply to a thread. S9c: the thread read rides the access batch (siteWithUrlThread),
@@ -431,31 +490,33 @@ comments.post('/:space/:site/comments/:threadId/replies', async (c) => {
   if (gate instanceof Response) return gate
   const { site, thread } = gate
   if (!threadInSite(thread, site.id)) return c.json({ error: 'not found' }, 404)
-  if (isMultipart(c)) return replyVoiceComment(c, thread.id)
+  if (isMultipart(c)) return replyVoiceComment(c, site, thread)
 
   const raw = await c.req.json().catch(() => null)
   const body = cleanBody(raw?.body)
   if (!body) return c.json({ error: 'invalid body' }, 400)
   const id = await addComment(c.get('db'), { threadId: thread.id, authorId: c.get('user').id, body })
-  await notifyMentions(c, site, { rawMentions: raw?.mentions, threadId: thread.id, filePath: thread.filePath, snippet: body })
+  await notifyReply(c, site, thread, id, body, raw?.mentions)
   return c.json({ id }, 201)
 })
 
 /** Multipart (voice) reply: ingest the audio (transcript is the whole body — a reply has no anchor
  *  fields), then append the comment, compensating the R2 object if the D1 write fails. */
-async function replyVoiceComment(c: Context<AppEnv>, threadId: string): Promise<Response> {
+async function replyVoiceComment(c: Context<AppEnv>, site: ResolvedSite, thread: CommentThread): Promise<Response> {
   const form = await c.req.formData().catch(() => null)
   if (!form) return c.json({ error: 'invalid form' }, 400)
   const ingested = await ingestVoiceComment(c, form)
   if (ingested instanceof Response) return ingested
   const { commentId, audioKey, body } = ingested
+  let id: string
   try {
-    const id = await addComment(c.get('db'), { threadId, authorId: c.get('user').id, body, commentId, audioKey })
-    return c.json({ id }, 201)
+    id = await addComment(c.get('db'), { threadId: thread.id, authorId: c.get('user').id, body, commentId, audioKey })
   } catch (e) {
     await deleteKeys(c.env.GLANCE_FILES, [audioKey]) // compensation: don't orphan the R2 object
     throw e
   }
+  await notifyReply(c, site, thread, id, body)
+  return c.json({ id }, 201)
 }
 
 // PATCH — resolve / reopen a thread (owner or superadmin only). S9c fused pre-write batch; the

--- a/packages/api/src/routes/mentions.test.ts
+++ b/packages/api/src/routes/mentions.test.ts
@@ -1,20 +1,25 @@
 import { describe, expect, test } from 'bun:test'
+import { and, eq } from 'drizzle-orm'
 import { Hono } from 'hono'
 import { listNotifications } from '../db/notifications'
-import { notifications as notificationsTable } from '../db/schema'
+import { notifications as notificationsTable, siteUserShares } from '../db/schema'
 import { requireSameOrigin } from '../middleware/auth'
 import {
   makeDb,
   makeKv,
   makeR2,
+  seedComment,
   seedFile,
   seedGroupShare,
   seedMember,
   seedSite,
   seedSpace,
+  seedThread,
   seedUser,
+  seedUserShare,
 } from '../test/harness'
 import type { AppEnv } from '../types'
+import { commentFeed } from './comment-feed'
 import { comments } from './comments'
 import { notifications } from './notifications'
 import { sites } from './sites'
@@ -38,13 +43,20 @@ async function setup() {
   })
   app.route('/api/sites', sites)
   app.route('/api/sites', comments)
+  app.route('/api/comments', commentFeed)
   app.route('/api/notifications', notifications)
   return { db, r2, kv, app, env }
 }
 
-async function mintUser(db: ReturnType<typeof makeDb>, kv: ReturnType<typeof makeKv>, id: string) {
-  await seedUser(db, { id, name: id })
-  await kv.put(`cli:tok-${id}`, JSON.stringify({ id, email: `${id}@example.com`, name: id, role: 'member' }))
+async function mintUser(
+  db: ReturnType<typeof makeDb>,
+  kv: ReturnType<typeof makeKv>,
+  id: string,
+  opts: { role?: 'member' | 'superadmin' } = {},
+) {
+  const role = opts.role ?? 'member'
+  await seedUser(db, { id, name: id, role })
+  await kv.put(`cli:tok-${id}`, JSON.stringify({ id, email: `${id}@example.com`, name: id, role }))
   return id
 }
 
@@ -56,9 +68,10 @@ async function seedSiteWithFile(
   r2: ReturnType<typeof makeR2>,
   ownerId: string,
   visibility: 'private' | 'members' | 'team' = 'team',
+  status: 'active' | 'archived' = 'active',
 ) {
   const spaceId = await seedSpace(db, { createdBy: ownerId, slug: 'acme' })
-  const siteId = await seedSite(db, { spaceId, ownerId, slug: 'doc', visibility })
+  const siteId = await seedSite(db, { spaceId, ownerId, slug: 'doc', visibility, status })
   await seedFile(db, r2, siteId, { path: 'index.html', text: '<p>The quick brown fox jumps.</p>' })
   return { spaceId, siteId }
 }
@@ -71,6 +84,43 @@ const postThread = (id: string, body: Record<string, unknown>) => ({
   headers: auth(id),
   body: JSON.stringify({ filePath: 'index.html', quote: 'fox', ...body }),
 })
+
+const aiEnv = (base: AppEnv['Bindings'], text: string) =>
+  ({ ...base, AI: { run: async () => ({ text }) } }) as unknown as AppEnv['Bindings']
+
+const audioForm = (bytes: Uint8Array, extra: Record<string, string> = {}) => {
+  const form = new FormData()
+  form.set('audio', new Blob([bytes], { type: 'audio/webm' }), 'take.webm')
+  for (const [key, value] of Object.entries(extra)) form.set(key, value)
+  return form
+}
+
+const voice = (id: string, body: FormData) => ({
+  method: 'POST',
+  headers: { Authorization: `Bearer tok-${id}`, Origin: APP_URL },
+  body,
+})
+
+function failNotificationInserts(db: ReturnType<typeof makeDb>) {
+  const originalInsert = db.insert.bind(db)
+  const seam = db as unknown as { insert: (table: unknown) => unknown }
+  let attempts = 0
+  seam.insert = (table: unknown) => {
+    if (table === notificationsTable) {
+      attempts++
+      throw new Error('boom')
+    }
+    return originalInsert(table as Parameters<typeof originalInsert>[0])
+  }
+  return {
+    get attempts() {
+      return attempts
+    },
+    restore() {
+      seam.insert = originalInsert
+    },
+  }
+}
 
 // --- C8: mentionable route ---
 
@@ -194,21 +244,18 @@ describe('C13 — reply mentions[] → notification created', () => {
   })
 })
 
-describe('C14 — voice thread/reply ignore mentions (v1 hole, pinned)', () => {
-  test('a voice thread with a mentions part raises nothing', async () => {
+describe('C14 — voice multipart mentions remain ignored', () => {
+  test('a forged mentions part does not create a mention notification', async () => {
     const { app, env, db, r2, kv } = await setup()
     const owner = await mintUser(db, kv, 'owner')
     const target = await mintUser(db, kv, 'target')
     await seedSiteWithFile(db, r2, owner, 'team')
-    const aiEnv = { ...env, AI: { run: async () => ({ text: 'transcribed' }) } } as unknown as AppEnv['Bindings']
-    const fd = new FormData()
-    fd.set('audio', new Blob([new Uint8Array([1, 2, 3])], { type: 'audio/webm' }), 'take.webm')
-    fd.set('filePath', 'index.html')
-    fd.set('mentions', JSON.stringify([target])) // voice path never reads this
+    // Voice notifications deliberately pass rawMentions: undefined; multipart mentions are unsupported.
+    const fd = audioForm(new Uint8Array([1, 2, 3]), { filePath: 'index.html', mentions: JSON.stringify([target]) })
     const res = await app.request(
       commentsUrl,
-      { method: 'POST', headers: { Authorization: `Bearer tok-${owner}`, Origin: APP_URL }, body: fd },
-      aiEnv,
+      voice(owner, fd),
+      aiEnv(env, 'transcribed'),
     )
     expect(res.status).toBe(201)
     expect((await listNotifications(db, target)).unreadCount).toBe(0)
@@ -222,15 +269,10 @@ describe('C15 — notify failure does NOT fail the comment (fire-and-forget)', (
     const target = await mintUser(db, kv, 'target')
     await seedSiteWithFile(db, r2, owner, 'team')
     // Make ONLY the notifications insert throw; the comment insert path is untouched.
-    const origInsert = db.insert.bind(db)
-    const seam = db as unknown as { insert: (table: unknown) => unknown }
-    seam.insert = (table: unknown) => {
-      if (table === notificationsTable) throw new Error('boom')
-      return origInsert(table as Parameters<typeof origInsert>[0])
-    }
+    const failure = failNotificationInserts(db)
     const res = await app.request(commentsUrl, postThread(owner, { body: 'still commits', mentions: [target] }), env)
     expect(res.status).toBe(201)
-    seam.insert = origInsert
+    failure.restore()
     // the comment landed…
     const list = await (await app.request(`${commentsUrl}?filePath=index.html`, { headers: auth(owner) }, env)).json()
     expect((list as unknown[]).length).toBe(1)
@@ -269,5 +311,463 @@ describe('C16 — GET /api/notifications caller-scoped + unreadCount; POST /read
     // mark all read (no ids)
     await app.request('/api/notifications/read', { method: 'POST', headers: auth(target), body: '{}' }, env)
     expect((await (await app.request('/api/notifications', { headers: auth(target) }, env)).json()).unreadCount).toBe(0)
+  })
+})
+
+// --- S2: comment-audience notifications (JSON create + reply only) ---
+
+describe('S2 C1 TRACER — JSON thread without mentions notifies the owner', () => {
+  test('owner receives one truncated comment notification tied to the opening comment', async () => {
+    const { app, env, db, r2, kv } = await setup()
+    const owner = await mintUser(db, kv, 'owner')
+    const commenter = await mintUser(db, kv, 'commenter')
+    await seedSiteWithFile(db, r2, owner, 'team')
+    const body = 'x'.repeat(205)
+
+    const res = await app.request(commentsUrl, postThread(commenter, { body }), env)
+    expect(res.status).toBe(201)
+    const created = (await res.json()) as { threadId: string; openingCommentId: string }
+    const listed = await listNotifications(db, owner)
+    expect(listed.unreadCount).toBe(1)
+    expect(listed.items).toHaveLength(1)
+    expect(listed.items[0]).toMatchObject({
+      type: 'comment',
+      actorName: commenter,
+      siteLabel: 'acme/doc',
+      filePath: 'index.html',
+      threadId: created.threadId,
+      commentId: created.openingCommentId,
+      snippet: body.slice(0, 200),
+    })
+  })
+})
+
+describe('S2 C2 — owner mention preserves the mention recipient and skips self', () => {
+  test('mentioned user gets exactly one mention while owner gets none', async () => {
+    const { app, env, db, r2, kv } = await setup()
+    const owner = await mintUser(db, kv, 'owner')
+    const target = await mintUser(db, kv, 'target')
+    await seedSiteWithFile(db, r2, owner, 'team')
+
+    const res = await app.request(commentsUrl, postThread(owner, { body: 'ping', mentions: [target] }), env)
+    const created = (await res.json()) as { openingCommentId: string }
+    const forTarget = await listNotifications(db, target)
+    expect(forTarget.items).toHaveLength(1)
+    expect(forTarget.items[0]).toMatchObject({ type: 'mention', commentId: created.openingCommentId })
+    expect((await listNotifications(db, owner)).unreadCount).toBe(0)
+  })
+})
+
+describe('S2 C3 — mentioning the owner wins over owner audience membership', () => {
+  test('owner receives exactly one mention row', async () => {
+    const { app, env, db, r2, kv } = await setup()
+    const owner = await mintUser(db, kv, 'owner')
+    const commenter = await mintUser(db, kv, 'commenter')
+    await seedSiteWithFile(db, r2, owner, 'team')
+
+    await app.request(commentsUrl, postThread(commenter, { body: '@owner', mentions: [owner] }), env)
+    const listed = await listNotifications(db, owner)
+    expect(listed.items).toHaveLength(1)
+    expect(listed.items[0].type).toBe('mention')
+  })
+})
+
+describe('S2 C4 — JSON reply notifies the owner with the reply identity', () => {
+  test('owner receives one comment row for the reply comment and thread', async () => {
+    const { app, env, db, r2, kv } = await setup()
+    const owner = await mintUser(db, kv, 'owner')
+    const commenter = await mintUser(db, kv, 'commenter')
+    await seedSiteWithFile(db, r2, owner, 'team')
+    const created = (await (await app.request(commentsUrl, postThread(owner, { body: 'root' }), env)).json()) as {
+      threadId: string
+    }
+
+    const res = await app.request(
+      `${commentsUrl}/${created.threadId}/replies`,
+      { method: 'POST', headers: auth(commenter), body: JSON.stringify({ body: 'reply' }) },
+      env,
+    )
+    expect(res.status).toBe(201)
+    const reply = (await res.json()) as { id: string }
+    const listed = await listNotifications(db, owner)
+    expect(listed.items).toHaveLength(1)
+    expect(listed.items[0]).toMatchObject({ type: 'comment', threadId: created.threadId, commentId: reply.id })
+  })
+})
+
+describe('S3 C5 — voice thread notifies the owner with the transcript', () => {
+  test('owner receives one comment row tied to the opening voice comment', async () => {
+    const { app, env, db, r2, kv } = await setup()
+    const owner = await mintUser(db, kv, 'owner')
+    const commenter = await mintUser(db, kv, 'commenter')
+    await seedSiteWithFile(db, r2, owner, 'team')
+    const transcript = 'spoken thread transcript'
+
+    const res = await app.request(
+      commentsUrl,
+      voice(commenter, audioForm(new Uint8Array([1, 2, 3]), { filePath: 'index.html', quote: 'fox' })),
+      aiEnv(env, transcript),
+    )
+    expect(res.status).toBe(201)
+    const created = (await res.json()) as { threadId: string; openingCommentId: string }
+    const listed = await listNotifications(db, owner)
+    expect(listed.items).toHaveLength(1)
+    expect(listed.items[0]).toMatchObject({
+      type: 'comment',
+      threadId: created.threadId,
+      commentId: created.openingCommentId,
+      snippet: transcript,
+    })
+  })
+})
+
+describe('S3 C6 — voice reply ignores forged mentions and notifies the owner', () => {
+  test('target receives no mention while owner receives one comment row for the voice reply', async () => {
+    const { app, env, db, r2, kv } = await setup()
+    const owner = await mintUser(db, kv, 'owner')
+    const commenter = await mintUser(db, kv, 'commenter')
+    const target = await mintUser(db, kv, 'target')
+    await seedSiteWithFile(db, r2, owner, 'team')
+    const created = (await (await app.request(commentsUrl, postThread(owner, { body: 'root' }), env)).json()) as {
+      threadId: string
+    }
+    const form = audioForm(new Uint8Array([4, 5, 6]), { mentions: JSON.stringify([target]) })
+
+    const res = await app.request(
+      `${commentsUrl}/${created.threadId}/replies`,
+      voice(commenter, form),
+      aiEnv(env, 'spoken reply transcript'),
+    )
+    expect(res.status).toBe(201)
+    const reply = (await res.json()) as { id: string }
+    expect((await listNotifications(db, target)).items).toHaveLength(0)
+    expect((await listNotifications(db, owner)).items).toEqual([
+      expect.objectContaining({ type: 'comment', threadId: created.threadId, commentId: reply.id }),
+    ])
+  })
+})
+
+describe('S2 C7 — mention and owner audience rows share the comment identity', () => {
+  test('mentioned user gets mention and owner gets comment', async () => {
+    const { app, env, db, r2, kv } = await setup()
+    const owner = await mintUser(db, kv, 'owner')
+    const target = await mintUser(db, kv, 'target')
+    const commenter = await mintUser(db, kv, 'commenter')
+    await seedSiteWithFile(db, r2, owner, 'team')
+
+    const res = await app.request(commentsUrl, postThread(commenter, { body: 'ping', mentions: [target] }), env)
+    const created = (await res.json()) as { openingCommentId: string }
+    expect((await listNotifications(db, target)).items).toEqual([
+      expect.objectContaining({ type: 'mention', commentId: created.openingCommentId }),
+    ])
+    expect((await listNotifications(db, owner)).items).toEqual([
+      expect.objectContaining({ type: 'comment', commentId: created.openingCommentId }),
+    ])
+  })
+})
+
+describe('S2 C8 — direct share is part of the comment audience', () => {
+  test('owner thread on a private shared site notifies the directly shared user', async () => {
+    const { app, env, db, r2, kv } = await setup()
+    const owner = await mintUser(db, kv, 'owner')
+    const target = await mintUser(db, kv, 'target')
+    const { siteId } = await seedSiteWithFile(db, r2, owner, 'private')
+    await seedUserShare(db, siteId, target)
+
+    await app.request(commentsUrl, postThread(owner, { body: 'shared update' }), env)
+    const listed = await listNotifications(db, target)
+    expect(listed.items).toHaveLength(1)
+    expect(listed.items[0].type).toBe('comment')
+  })
+})
+
+describe('S2 C9 — team visibility does not make every user comment audience', () => {
+  test('an unrelated bystander receives nothing', async () => {
+    const { app, env, db, r2, kv } = await setup()
+    const owner = await mintUser(db, kv, 'owner')
+    const commenter = await mintUser(db, kv, 'commenter')
+    const bystander = await mintUser(db, kv, 'bystander')
+    await seedSiteWithFile(db, r2, owner, 'team')
+
+    await app.request(commentsUrl, postThread(commenter, { body: 'update' }), env)
+    expect((await listNotifications(db, bystander)).unreadCount).toBe(0)
+  })
+})
+
+describe('S2 C10 — group-share reach alone is not comment audience', () => {
+  test('a group-shared member who did not participate receives nothing', async () => {
+    const { app, env, db, r2, kv } = await setup()
+    const owner = await mintUser(db, kv, 'owner')
+    const member = await mintUser(db, kv, 'member')
+    const { siteId } = await seedSiteWithFile(db, r2, owner, 'private')
+    const groupId = await seedSpace(db, { createdBy: member, slug: 'group' })
+    await seedMember(db, groupId, member)
+    await seedGroupShare(db, siteId, groupId)
+
+    await app.request(commentsUrl, postThread(owner, { body: 'update' }), env)
+    expect((await listNotifications(db, member)).unreadCount).toBe(0)
+  })
+})
+
+describe('S2 C11 — prior thread participants join the reply audience', () => {
+  test('prior replier and owner both receive comment notifications', async () => {
+    const { app, env, db, r2, kv } = await setup()
+    const owner = await mintUser(db, kv, 'owner')
+    const prior = await mintUser(db, kv, 'prior')
+    const commenter = await mintUser(db, kv, 'commenter')
+    const { siteId } = await seedSiteWithFile(db, r2, owner, 'team')
+    const threadId = await seedThread(db, { siteId, filePath: 'index.html', createdBy: owner })
+    await seedComment(db, { threadId, authorId: owner, body: 'root' })
+    await seedComment(db, { threadId, authorId: prior, body: 'earlier reply' })
+
+    await app.request(
+      `${commentsUrl}/${threadId}/replies`,
+      { method: 'POST', headers: auth(commenter), body: JSON.stringify({ body: 'new reply' }) },
+      env,
+    )
+    expect((await listNotifications(db, prior)).items).toEqual([expect.objectContaining({ type: 'comment' })])
+    expect((await listNotifications(db, owner)).items).toEqual([expect.objectContaining({ type: 'comment' })])
+  })
+})
+
+describe('S2 C12 — revoked private access removes a participant from reply audience', () => {
+  test('revoked participant is dropped while owner is notified', async () => {
+    const { app, env, db, r2, kv } = await setup()
+    const owner = await mintUser(db, kv, 'owner')
+    const prior = await mintUser(db, kv, 'prior')
+    const commenter = await mintUser(db, kv, 'commenter')
+    const { siteId } = await seedSiteWithFile(db, r2, owner, 'private')
+    await seedUserShare(db, siteId, prior)
+    await seedUserShare(db, siteId, commenter)
+    const threadId = await seedThread(db, { siteId, filePath: 'index.html', createdBy: owner })
+    await seedComment(db, { threadId, authorId: owner, body: 'root' })
+    await seedComment(db, { threadId, authorId: prior, body: 'earlier reply' })
+    await db.delete(siteUserShares).where(and(eq(siteUserShares.siteId, siteId), eq(siteUserShares.userId, prior)))
+
+    await app.request(
+      `${commentsUrl}/${threadId}/replies`,
+      { method: 'POST', headers: auth(commenter), body: JSON.stringify({ body: 'new reply' }) },
+      env,
+    )
+    expect((await listNotifications(db, prior)).unreadCount).toBe(0)
+    expect((await listNotifications(db, owner)).items).toEqual([expect.objectContaining({ type: 'comment' })])
+  })
+})
+
+describe('S2 C13 — comment-audience notification failure is isolated', () => {
+  test('a real notifications insert attempt may throw without failing the comment POST', async () => {
+    const { app, env, db, r2, kv } = await setup()
+    const owner = await mintUser(db, kv, 'owner')
+    const commenter = await mintUser(db, kv, 'commenter')
+    await seedSiteWithFile(db, r2, owner, 'team')
+    const failure = failNotificationInserts(db)
+
+    const res = await app.request(commentsUrl, postThread(commenter, { body: 'still commits' }), env)
+    failure.restore()
+    expect(res.status).toBe(201)
+    expect(failure.attempts).toBe(1)
+  })
+})
+
+describe('S2 C17 — soft-deleted participants stay in reply audience and null authors are skipped', () => {
+  test('soft-deleted author is notified without a null-recipient failure', async () => {
+    const { app, env, db, r2, kv } = await setup()
+    const owner = await mintUser(db, kv, 'owner')
+    const prior = await mintUser(db, kv, 'prior')
+    const commenter = await mintUser(db, kv, 'commenter')
+    const { siteId } = await seedSiteWithFile(db, r2, owner, 'team')
+    const threadId = await seedThread(db, { siteId, filePath: 'index.html', createdBy: owner })
+    await seedComment(db, { threadId, authorId: owner, body: 'root' })
+    await seedComment(db, { threadId, authorId: prior, body: 'deleted reply', deletedAt: new Date().toISOString() })
+    await seedComment(db, { threadId, authorId: null, body: 'deleted user' })
+
+    const res = await app.request(
+      `${commentsUrl}/${threadId}/replies`,
+      { method: 'POST', headers: auth(commenter), body: JSON.stringify({ body: 'new reply' }) },
+      env,
+    )
+    expect(res.status).toBe(201)
+    expect((await listNotifications(db, prior)).items).toEqual([expect.objectContaining({ type: 'comment' })])
+    expect((await listNotifications(db, owner)).items).toEqual([expect.objectContaining({ type: 'comment' })])
+  })
+})
+
+describe('S2 C18 — a participating group-share user is eligible', () => {
+  test('group-share access admits the participant on a later private-site reply', async () => {
+    const { app, env, db, r2, kv } = await setup()
+    const owner = await mintUser(db, kv, 'owner')
+    const participant = await mintUser(db, kv, 'participant')
+    const { siteId } = await seedSiteWithFile(db, r2, owner, 'private')
+    const groupId = await seedSpace(db, { createdBy: participant, slug: 'group' })
+    await seedMember(db, groupId, participant)
+    await seedGroupShare(db, siteId, groupId)
+    const threadId = await seedThread(db, { siteId, filePath: 'index.html', createdBy: owner })
+    await seedComment(db, { threadId, authorId: owner, body: 'root' })
+    await seedComment(db, { threadId, authorId: participant, body: 'earlier reply' })
+
+    await app.request(
+      `${commentsUrl}/${threadId}/replies`,
+      { method: 'POST', headers: auth(owner), body: JSON.stringify({ body: 'new reply' }) },
+      env,
+    )
+    expect((await listNotifications(db, participant)).items).toEqual([expect.objectContaining({ type: 'comment' })])
+  })
+})
+
+describe('S2 C19 — direct-share participant mention dedupes to one mention', () => {
+  test('the same user receives exactly one row with mention precedence', async () => {
+    const { app, env, db, r2, kv } = await setup()
+    const owner = await mintUser(db, kv, 'owner')
+    const target = await mintUser(db, kv, 'target')
+    const { siteId } = await seedSiteWithFile(db, r2, owner, 'private')
+    await seedUserShare(db, siteId, target)
+    const threadId = await seedThread(db, { siteId, filePath: 'index.html', createdBy: owner })
+    await seedComment(db, { threadId, authorId: owner, body: 'root' })
+    await seedComment(db, { threadId, authorId: target, body: 'earlier reply' })
+
+    await app.request(
+      `${commentsUrl}/${threadId}/replies`,
+      { method: 'POST', headers: auth(owner), body: JSON.stringify({ body: '@target', mentions: [target] }) },
+      env,
+    )
+    const listed = await listNotifications(db, target)
+    expect(listed.items).toHaveLength(1)
+    expect(listed.items[0].type).toBe('mention')
+  })
+})
+
+describe('S2 C20 — archived sites suppress comment audience notifications', () => {
+  test('a superadmin may comment but the normal owner receives nothing', async () => {
+    const { app, env, db, r2, kv } = await setup()
+    const owner = await mintUser(db, kv, 'owner')
+    const admin = await mintUser(db, kv, 'admin', { role: 'superadmin' })
+    await seedSiteWithFile(db, r2, owner, 'team', 'archived')
+
+    const res = await app.request(commentsUrl, postThread(admin, { body: 'admin note' }), env)
+    expect(res.status).toBe(201)
+    expect((await listNotifications(db, owner)).unreadCount).toBe(0)
+  })
+})
+
+describe('S3 C21 — voice notification failure preserves the committed comment and audio', () => {
+  test('a throwing notification insert leaves the 201, comment, and R2 object intact', async () => {
+    const { app, env, db, r2, kv } = await setup()
+    const owner = await mintUser(db, kv, 'owner')
+    const commenter = await mintUser(db, kv, 'commenter')
+    await seedSiteWithFile(db, r2, owner, 'team')
+    const failure = failNotificationInserts(db)
+
+    const res = await app.request(
+      commentsUrl,
+      voice(commenter, audioForm(new Uint8Array([7, 8, 9]), { filePath: 'index.html' })),
+      aiEnv(env, 'committed voice transcript'),
+    )
+    failure.restore()
+    expect(res.status).toBe(201)
+    expect(failure.attempts).toBe(1)
+    const created = (await res.json()) as { openingCommentId: string }
+    const threads = (await (
+      await app.request(`${commentsUrl}?filePath=index.html`, { headers: auth(owner) }, env)
+    ).json()) as { comments: { id: string; body: string }[] }[]
+    expect(threads[0].comments).toContainEqual(
+      expect.objectContaining({ id: created.openingCommentId, body: 'committed voice transcript' }),
+    )
+    expect(r2.store.has(`comment-audio/${created.openingCommentId}.webm`)).toBe(true)
+    expect((await listNotifications(db, owner)).items).toHaveLength(0)
+  })
+})
+
+describe('S2 C22 — one notification insert statement serves every recipient', () => {
+  test('owner, direct share, and mention rows are written in one insert and carry commentId', async () => {
+    const { app, env, db, r2, kv } = await setup()
+    const owner = await mintUser(db, kv, 'owner')
+    const shared = await mintUser(db, kv, 'shared')
+    const mentioned = await mintUser(db, kv, 'mentioned')
+    const commenter = await mintUser(db, kv, 'commenter')
+    const { siteId } = await seedSiteWithFile(db, r2, owner, 'team')
+    await seedUserShare(db, siteId, shared)
+    db.resetCounters()
+
+    const res = await app.request(commentsUrl, postThread(commenter, { body: 'ping', mentions: [mentioned] }), env)
+    const created = (await res.json()) as { openingCommentId: string }
+    // Insert budget: createThread writes thread + opening comment (2), then notifyForComment
+    // writes every notification row through one multi-values INSERT (1).
+    expect(db.counters.insert).toBe(3)
+    const rows = [
+      ...(await listNotifications(db, owner)).items,
+      ...(await listNotifications(db, shared)).items,
+      ...(await listNotifications(db, mentioned)).items,
+    ]
+    expect(rows).toHaveLength(3)
+    expect(rows.every((row) => row.commentId === created.openingCommentId)).toBe(true)
+  })
+})
+
+describe('S2 C14 — comment edit and thread resolve do not notify', () => {
+  test('owner unread state is unchanged by editing and resolving', async () => {
+    const { app, env, db, r2, kv } = await setup()
+    const owner = await mintUser(db, kv, 'owner')
+    const commenter = await mintUser(db, kv, 'commenter')
+    await seedSiteWithFile(db, r2, owner, 'team')
+    const created = (await (await app.request(commentsUrl, postThread(commenter, { body: 'root' }), env)).json()) as {
+      threadId: string
+      openingCommentId: string
+    }
+    const before = await listNotifications(db, owner)
+    expect(before.unreadCount).toBe(1)
+
+    const edit = await app.request(
+      `${commentsUrl}/${created.threadId}/messages/${created.openingCommentId}`,
+      { method: 'PATCH', headers: auth(commenter), body: JSON.stringify({ body: 'edited' }) },
+      env,
+    )
+    const resolve = await app.request(
+      `${commentsUrl}/${created.threadId}`,
+      { method: 'PATCH', headers: auth(owner), body: JSON.stringify({ status: 'resolved' }) },
+      env,
+    )
+    expect(edit.status).toBe(200)
+    expect(resolve.status).toBe(200)
+    const after = await listNotifications(db, owner)
+    expect(after.unreadCount).toBe(1)
+    expect(after.items.map((item) => item.id)).toEqual(before.items.map((item) => item.id))
+  })
+})
+
+describe('S2 C16 — mark-all-read covers mixed mention and comment notifications', () => {
+  test('POST /read with an empty body marks both types read', async () => {
+    const { app, env, db, r2, kv } = await setup()
+    const owner = await mintUser(db, kv, 'owner')
+    const target = await mintUser(db, kv, 'target')
+    const { siteId } = await seedSiteWithFile(db, r2, owner, 'private')
+    await seedUserShare(db, siteId, target)
+    await app.request(commentsUrl, postThread(owner, { body: '@target', mentions: [target] }), env)
+    await app.request(commentsUrl, postThread(owner, { body: 'plain update' }), env)
+    const before = await listNotifications(db, target)
+    expect(new Set(before.items.map((item) => item.type))).toEqual(new Set(['mention', 'comment']))
+    expect(before.unreadCount).toBe(2)
+
+    const read = await app.request('/api/notifications/read', { method: 'POST', headers: auth(target), body: '{}' }, env)
+    expect(read.status).toBe(200)
+    expect((await listNotifications(db, target)).unreadCount).toBe(0)
+  })
+})
+
+describe('S-A + S2 C15 — comment notifications do not leak into the feed mention arm', () => {
+  test('recipient feed excludes an existing comment notification', async () => {
+    const { app, env, db, r2, kv } = await setup()
+    const owner = await mintUser(db, kv, 'owner')
+    const commenter = await mintUser(db, kv, 'commenter')
+    await seedSiteWithFile(db, r2, owner, 'team')
+    await app.request(commentsUrl, postThread(commenter, { body: 'plain update' }), env)
+    const notification = (await listNotifications(db, owner)).items[0]
+    expect(notification.type).toBe('comment')
+
+    const feed = (await (await app.request('/api/comments/feed', { headers: auth(owner) }, env)).json()) as {
+      kind: string
+      id: string
+    }[]
+    expect(feed.some((item) => item.id === notification.id)).toBe(false)
+    expect(feed.some((item) => item.kind === 'mention')).toBe(false)
   })
 })

--- a/packages/api/src/routes/mentions.test.ts
+++ b/packages/api/src/routes/mentions.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'bun:test'
 import { and, eq } from 'drizzle-orm'
 import { Hono } from 'hono'
 import { listNotifications } from '../db/notifications'
-import { notifications as notificationsTable, siteUserShares } from '../db/schema'
+import { notifications as notificationsTable, siteUserShares, spaceMembers } from '../db/schema'
 import { requireSameOrigin } from '../middleware/auth'
 import {
   makeDb,
@@ -554,6 +554,61 @@ describe('S2 C12 — revoked private access removes a participant from reply aud
   })
 })
 
+describe('S2 — members visibility re-authorizes reply participants', () => {
+  test('a participant who is still a space member receives a comment row', async () => {
+    const { app, env, db, r2, kv } = await setup()
+    const owner = await mintUser(db, kv, 'owner')
+    const participant = await mintUser(db, kv, 'participant')
+    const { siteId, spaceId } = await seedSiteWithFile(db, r2, owner, 'members')
+    await seedMember(db, spaceId, participant)
+    const threadId = await seedThread(db, { siteId, filePath: 'index.html', createdBy: owner })
+    await seedComment(db, { threadId, authorId: participant, body: 'earlier reply' })
+
+    const reply = await app.request(
+      `${commentsUrl}/${threadId}/replies`,
+      { method: 'POST', headers: auth(owner), body: JSON.stringify({ body: 'new reply' }) },
+      env,
+    )
+
+    expect(reply.status).toBe(201)
+    expect((await listNotifications(db, participant)).items).toEqual([expect.objectContaining({ type: 'comment' })])
+  })
+
+  test('a participant who left the space is dropped from the reply audience', async () => {
+    const { app, env, db, r2, kv } = await setup()
+    const owner = await mintUser(db, kv, 'owner')
+    const participant = await mintUser(db, kv, 'participant')
+    const { siteId, spaceId } = await seedSiteWithFile(db, r2, owner, 'members')
+    await seedMember(db, spaceId, participant)
+    const threadId = await seedThread(db, { siteId, filePath: 'index.html', createdBy: owner })
+    await seedComment(db, { threadId, authorId: participant, body: 'earlier reply' })
+
+    // Control: while membership exists, this same audience path admits the participant through
+    // the member fact. Removing that fact makes this assertion fail, so the leave check below is
+    // not merely observing an unrelated empty audience.
+    const beforeLeaving = await app.request(
+      `${commentsUrl}/${threadId}/replies`,
+      { method: 'POST', headers: auth(owner), body: JSON.stringify({ body: 'before leaving' }) },
+      env,
+    )
+    expect(beforeLeaving.status).toBe(201)
+    expect((await listNotifications(db, participant)).items).toHaveLength(1)
+    await db.delete(notificationsTable).where(eq(notificationsTable.recipientId, participant))
+    await db
+      .delete(spaceMembers)
+      .where(and(eq(spaceMembers.spaceId, spaceId), eq(spaceMembers.userId, participant)))
+
+    const afterLeaving = await app.request(
+      `${commentsUrl}/${threadId}/replies`,
+      { method: 'POST', headers: auth(owner), body: JSON.stringify({ body: 'after leaving' }) },
+      env,
+    )
+
+    expect(afterLeaving.status).toBe(201)
+    expect((await listNotifications(db, participant)).items).toHaveLength(0)
+  })
+})
+
 describe('S2 C13 — comment-audience notification failure is isolated', () => {
   test('a real notifications insert attempt may throw without failing the comment POST', async () => {
     const { app, env, db, r2, kv } = await setup()
@@ -677,8 +732,8 @@ describe('S3 C21 — voice notification failure preserves the committed comment 
   })
 })
 
-describe('S2 C22 — one notification insert statement serves every recipient', () => {
-  test('owner, direct share, and mention rows are written in one insert and carry commentId', async () => {
+describe('S2 C22 — one notification batch serves every recipient', () => {
+  test('owner, direct share, and mention rows are written in one batch and carry commentId', async () => {
     const { app, env, db, r2, kv } = await setup()
     const owner = await mintUser(db, kv, 'owner')
     const shared = await mintUser(db, kv, 'shared')
@@ -690,9 +745,10 @@ describe('S2 C22 — one notification insert statement serves every recipient', 
 
     const res = await app.request(commentsUrl, postThread(commenter, { body: 'ping', mentions: [mentioned] }), env)
     const created = (await res.json()) as { openingCommentId: string }
-    // Insert budget: createThread writes thread + opening comment (2), then notifyForComment
-    // writes every notification row through one multi-values INSERT (1).
-    expect(db.counters.insert).toBe(3)
+    // Observed route budget: two loose createThread inserts, then one notification INSERT inside
+    // the final batch. The write stays batched for one chunk because 10+ rows must split under
+    // D1's 100-bound-parameter cap without adding a round trip.
+    expect(db.counters).toEqual({ batches: 4, loose: 2, batchStmts: 9, insert: 3, update: 0, delete: 0 })
     const rows = [
       ...(await listNotifications(db, owner)).items,
       ...(await listNotifications(db, shared)).items,

--- a/packages/api/src/test/harness.ts
+++ b/packages/api/src/test/harness.ts
@@ -46,6 +46,7 @@ const MIGRATIONS = [
   'drizzle/0013_fork_site.sql',
   'drizzle/0014_site_summaries.sql',
   'drizzle/0015_notifications_comment_id.sql',
+  'drizzle/0016_notifications_comment_index.sql',
 ]
 
 // --- S0 recorder: one shared, ordered timeline across D1/R2/cache mocks so perf specs can

--- a/packages/api/src/test/harness.ts
+++ b/packages/api/src/test/harness.ts
@@ -45,6 +45,7 @@ const MIGRATIONS = [
   'drizzle/0012_comments_author_index.sql',
   'drizzle/0013_fork_site.sql',
   'drizzle/0014_site_summaries.sql',
+  'drizzle/0015_notifications_comment_id.sql',
 ]
 
 // --- S0 recorder: one shared, ordered timeline across D1/R2/cache mocks so perf specs can

--- a/packages/api/src/test/harness.ts
+++ b/packages/api/src/test/harness.ts
@@ -431,6 +431,7 @@ export async function seedNotification(
     siteId: o.siteId ?? null,
     siteLabel: o.siteLabel ?? null,
     threadId: o.threadId ?? null,
+    commentId: o.commentId ?? null,
     filePath: o.filePath ?? null,
     snippet: o.snippet ?? null,
     readAt: o.readAt ?? null,

--- a/packages/cli/SKILL.md
+++ b/packages/cli/SKILL.md
@@ -38,6 +38,7 @@ Put it in your shell profile to make it permanent. Token + URL are saved to `~/.
 | `glance comments <space/slug> [--file <path>] [--open] [--json]` | prints a site's review comments as a markdown digest (or raw JSON) |
 | `glance reply <space/slug> <threadId> [message] [--tag <label>\|--no-tag]` | posts a reply to a comment thread (get the `threadId` from `glance comments`) |
 | `glance read <space/slug> [--file <path>] [--pull <dir>]` | prints a file to stdout, or `--pull` downloads the whole site's source into a folder to edit + redeploy |
+| `glance notifications [--read] [--json]` | shows your notifications — mentions and comments on your sites (or raw JSON); `--read` marks them all read |
 | `glance logout` | revokes the server session and removes the local token |
 
 ### login
@@ -144,6 +145,24 @@ glance comments docs/api-reference --open                 # find the threadId on
 echo "reworded the intro as requested" | glance reply docs/api-reference k3f9q2
 glance reply docs/api-reference k3f9q2 "typo fixed" --no-tag
 ```
+
+### notifications
+Shows your notifications, newest first — who mentioned you and who commented on your sites — without opening the browser.
+
+```
+$ glance notifications
+2 unread · 3 shown
+● Priya N commented on eng/perf-dashboard (index.html, 2h ago)
+  “The p95 chart hides the cold-start spike, can we…”
+● Dev R mentioned you on design/onboarding-v2 (flows/step-3.html, 1d ago)
+✓ Someone commented on eng/perf-dashboard (index.html, 3d ago)
+```
+
+- The header always shows your **true unread total**, even when there are more notifications than the list window shows.
+- `●` = unread, `✓` = read. A deleted account shows as “Someone”.
+- `--read` marks everything read and prints a confirmation.
+- `--json` prints the raw server response instead — for piping into `jq` or an agent loop.
+- Follow up from the same terminal: `glance comments <space/slug>` to read the full thread, `glance reply <space/slug> <threadId>` to answer.
 
 ### read
 Prints a deployed file's contents to stdout.

--- a/packages/cli/main.go
+++ b/packages/cli/main.go
@@ -53,7 +53,7 @@ func dispatch(cmd string, rest []string) error {
 			base, token = cfg.ApiUrl, cfg.Token
 		}
 		return newClient(base, token, os.Stdout).logout()
-	case "deploy", "list", "delete", "move", "fork", "comments", "read", "reply":
+	case "deploy", "list", "delete", "move", "fork", "comments", "read", "reply", "notifications":
 		// Authed commands resolve the instance from the STORED config (not the env override) - the
 		// per-command requireAuth() inside each handler produces the clean "Not logged in" message.
 		cfg := readConfig()
@@ -79,6 +79,8 @@ func dispatch(cmd string, rest []string) error {
 			return c.read(rest)
 		case "reply":
 			return c.reply(rest)
+		case "notifications":
+			return c.notifications(rest)
 		}
 	}
 	printHelp()
@@ -101,6 +103,7 @@ func printHelp() {
 	fmt.Println("  glance comments <space/slug> [--file <path>] [--open] [--json]")
 	fmt.Println("  glance reply <space/slug> <threadId> [message] [--tag <label> | --no-tag]")
 	fmt.Println("  glance read <space/slug> [--file <path>] [--pull <dir>]")
+	fmt.Println("  glance notifications [--read] [--json]")
 	fmt.Println("  glance skill install")
 	fmt.Println("  glance upgrade")
 	fmt.Println("  glance version")

--- a/packages/cli/notifications.go
+++ b/packages/cli/notifications.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+)
+
+type notificationItem struct {
+	Type      string  `json:"type"` // "mention" | "comment"
+	ActorName *string `json:"actorName"`
+	SiteLabel *string `json:"siteLabel"`
+	FilePath  *string `json:"filePath"`
+	Snippet   *string `json:"snippet"`
+	Read      bool    `json:"read"`
+	CreatedAt string  `json:"createdAt"`
+}
+
+type notificationsResponse struct {
+	Items       []notificationItem `json:"items"`
+	UnreadCount int                `json:"unreadCount"`
+}
+
+func (c *client) notifications(args []string) error {
+	_, flags := parseArgs(args, boolSet("json", "read"))
+	if flags["read"] == true && flags["json"] == true {
+		return fmt.Errorf("--read and --json cannot be combined")
+	}
+	if err := c.requireAuth(); err != nil {
+		return err
+	}
+	if flags["read"] == true {
+		return c.markNotificationsRead()
+	}
+
+	resp, err := c.authed("GET", "/api/notifications", nil, nil)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if !ok(resp) {
+		return fmt.Errorf("Failed to fetch notifications (%d): %s", resp.StatusCode, bodySlice(resp))
+	}
+	if flags["json"] == true {
+		_, err := io.Copy(c.out, resp.Body)
+		return err
+	}
+
+	var data notificationsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return err
+	}
+	if len(data.Items) == 0 {
+		fmt.Fprintln(c.out, "No notifications.")
+		return nil
+	}
+	fmt.Fprintf(c.out, "%d unread · %d shown\n", data.UnreadCount, len(data.Items))
+	now := time.Now()
+	for _, item := range data.Items {
+		fmt.Fprint(c.out, renderNotification(item, now))
+	}
+	return nil
+}
+
+func (c *client) markNotificationsRead() error {
+	resp, err := c.authed("POST", "/api/notifications/read", strings.NewReader("{}"),
+		map[string]string{"Content-Type": "application/json"})
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if !ok(resp) {
+		return fmt.Errorf("Failed to mark notifications read (%d): %s", resp.StatusCode, bodySlice(resp))
+	}
+	fmt.Fprintln(c.out, "✓ Marked all notifications read")
+	return nil
+}
+
+// strOr returns *p when non-nil and non-empty, else fallback.
+func strOr(p *string, fallback string) string {
+	if p != nil && *p != "" {
+		return *p
+	}
+	return fallback
+}
+
+func renderNotification(item notificationItem, now time.Time) string {
+	marker := "✓"
+	if !item.Read {
+		marker = "●"
+	}
+	verb := "commented on"
+	if item.Type == "mention" {
+		verb = "mentioned you on"
+	}
+	paren := timeAgo(item.CreatedAt, now)
+	if fp := strOr(item.FilePath, ""); fp != "" {
+		paren = fp + ", " + paren
+	}
+	s := fmt.Sprintf("%s %s %s %s (%s)\n",
+		marker, strOr(item.ActorName, "Someone"), verb, strOr(item.SiteLabel, "a site"), paren)
+	if snip := strOr(item.Snippet, ""); snip != "" {
+		s += fmt.Sprintf("  “%s”\n", snip)
+	}
+	return s
+}
+
+// timeAgo formats createdAt as a short relative string. Unknown/unparseable times fall back to
+// the raw value so a bad timestamp never blanks the line.
+func timeAgo(createdAt string, now time.Time) string {
+	t, err := time.Parse(time.RFC3339, createdAt)
+	if err != nil {
+		return createdAt
+	}
+	d := now.Sub(t)
+	if d < 0 {
+		d = 0
+	}
+	switch {
+	case d < time.Minute:
+		return "just now"
+	case d < time.Hour:
+		return fmt.Sprintf("%dm ago", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh ago", int(d.Hours()))
+	default:
+		return fmt.Sprintf("%dd ago", int(d.Hours()/24))
+	}
+}

--- a/packages/cli/notifications_test.go
+++ b/packages/cli/notifications_test.go
@@ -1,0 +1,205 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNotificationsCommand(t *testing.T) {
+	fixtureBody := `{
+  "items": [
+    {
+      "id": "n1",
+      "type": "mention",
+      "actorId": "u1",
+      "actorName": "Ada",
+      "siteLabel": "docs",
+      "filePath": "index.md",
+      "threadId": "t1",
+      "commentId": "c1",
+      "snippet": "hello there",
+      "read": false,
+      "readAt": null,
+      "createdAt": "2026-07-16T12:00:00Z"
+    },
+    {
+      "id": "n2",
+      "type": "comment",
+      "actorId": "u2",
+      "actorName": null,
+      "siteLabel": null,
+      "filePath": null,
+      "threadId": "t2",
+      "commentId": null,
+      "snippet": null,
+      "read": true,
+      "readAt": "2026-07-16T13:00:00Z",
+      "createdAt": "2026-07-16T11:00:00Z"
+    }
+  ],
+  "unreadCount": 1
+}`
+
+	t.Run("G-1", func(t *testing.T) {
+		srv, _ := recordingServer(t, func(r *capturedReq) (int, string) {
+			return 200, fixtureBody
+		})
+		c, out := newTestClient(srv.URL, "tok")
+		if err := c.notifications(nil); err != nil {
+			t.Fatalf("notifications: %v", err)
+		}
+		got := out.String()
+		if !strings.Contains(got, "1 unread · 2 shown") {
+			t.Fatalf("want '1 unread · 2 shown' in %q", got)
+		}
+		if !strings.Contains(got, "●") {
+			t.Fatalf("want unread marker ● in %q", got)
+		}
+		if !strings.Contains(got, "✓") {
+			t.Fatalf("want read marker ✓ in %q", got)
+		}
+		if !strings.Contains(got, "mentioned you on") {
+			t.Fatalf("want mention verb in %q", got)
+		}
+		if !strings.Contains(got, "commented on") {
+			t.Fatalf("want comment verb in %q", got)
+		}
+		if !strings.Contains(got, "Someone") {
+			t.Fatalf("want null actorName → Someone in %q", got)
+		}
+		if !strings.Contains(got, "a site") {
+			t.Fatalf("want null siteLabel → a site in %q", got)
+		}
+	})
+
+	t.Run("G-6", func(t *testing.T) {
+		items := make([]string, 30)
+		for i := range items {
+			items[i] = fmt.Sprintf(`{"id":"n%d","type":"comment","actorId":"u","actorName":"A","siteLabel":"s","filePath":null,"threadId":"t","commentId":null,"snippet":null,"read":false,"readAt":null,"createdAt":"2026-07-16T12:00:00Z"}`, i)
+		}
+		body := `{"items":[` + strings.Join(items, ",") + `],"unreadCount":31}`
+		srv, _ := recordingServer(t, func(r *capturedReq) (int, string) {
+			return 200, body
+		})
+		c, out := newTestClient(srv.URL, "tok")
+		if err := c.notifications(nil); err != nil {
+			t.Fatalf("notifications: %v", err)
+		}
+		got := out.String()
+		if !strings.Contains(got, "31 unread · 30 shown") {
+			t.Fatalf("want header with true unreadCount, got %q", got)
+		}
+		if n := strings.Count(got, "●"); n != 30 {
+			t.Fatalf("want 30 rendered items, got %d markers in %q", n, got)
+		}
+	})
+
+	t.Run("G-2", func(t *testing.T) {
+		c, _ := newTestClient("http://unused", "")
+		err := c.notifications(nil)
+		if err == nil || !strings.Contains(err.Error(), "Not logged in") {
+			t.Fatalf("want Not logged in, got %v", err)
+		}
+	})
+
+	t.Run("G-3", func(t *testing.T) {
+		srv, reqs := recordingServer(t, func(r *capturedReq) (int, string) {
+			return 200, `{}`
+		})
+		c, out := newTestClient(srv.URL, "tok")
+		if err := c.notifications([]string{"--read"}); err != nil {
+			t.Fatalf("notifications --read: %v", err)
+		}
+		if len(*reqs) != 1 {
+			t.Fatalf("want 1 request, got %d", len(*reqs))
+		}
+		r := (*reqs)[0]
+		if r.method != "POST" {
+			t.Fatalf("method = %q", r.method)
+		}
+		if r.path != "/api/notifications/read" {
+			t.Fatalf("path = %q", r.path)
+		}
+		if string(r.body) != "{}" {
+			t.Fatalf("body = %q, want {}", r.body)
+		}
+		if r.auth != "Bearer tok" {
+			t.Fatalf("auth = %q", r.auth)
+		}
+		if r.ct != "application/json" {
+			t.Fatalf("Content-Type = %q", r.ct)
+		}
+		if !strings.Contains(out.String(), "✓ Marked all notifications read") {
+			t.Fatalf("out = %q", out.String())
+		}
+	})
+
+	t.Run("G-4", func(t *testing.T) {
+		srv, _ := recordingServer(t, func(r *capturedReq) (int, string) {
+			return 200, fixtureBody
+		})
+		c, out := newTestClient(srv.URL, "tok")
+		if err := c.notifications([]string{"--json"}); err != nil {
+			t.Fatalf("notifications --json: %v", err)
+		}
+		if out.String() != fixtureBody {
+			t.Fatalf("want byte-equal body\ngot  %q\nwant %q", out.String(), fixtureBody)
+		}
+	})
+
+	t.Run("G-5", func(t *testing.T) {
+		t.Run("GET-500", func(t *testing.T) {
+			srv, _ := recordingServer(t, func(r *capturedReq) (int, string) {
+				return 500, `err`
+			})
+			c, _ := newTestClient(srv.URL, "tok")
+			err := c.notifications(nil)
+			if err == nil || !strings.Contains(err.Error(), "500") {
+				t.Fatalf("want 500 in error, got %v", err)
+			}
+		})
+		t.Run("POST-403", func(t *testing.T) {
+			srv, _ := recordingServer(t, func(r *capturedReq) (int, string) {
+				return 403, `forbidden`
+			})
+			c, _ := newTestClient(srv.URL, "tok")
+			err := c.notifications([]string{"--read"})
+			if err == nil || !strings.Contains(err.Error(), "403") {
+				t.Fatalf("want 403 in error, got %v", err)
+			}
+		})
+	})
+
+	t.Run("read-json-rejected", func(t *testing.T) {
+		c, _ := newTestClient("http://unused", "tok")
+		err := c.notifications([]string{"--read", "--json"})
+		if err == nil || !strings.Contains(err.Error(), "--read and --json cannot be combined") {
+			t.Fatalf("want combine error, got %v", err)
+		}
+	})
+}
+
+func TestTimeAgo(t *testing.T) {
+	now := time.Date(2026, 7, 16, 12, 0, 0, 0, time.UTC)
+	cases := []struct {
+		name      string
+		createdAt string
+		want      string
+	}{
+		{"just now", now.Add(-30 * time.Second).Format(time.RFC3339), "just now"},
+		{"Xm", now.Add(-5 * time.Minute).Format(time.RFC3339), "5m ago"},
+		{"Xh", now.Add(-3 * time.Hour).Format(time.RFC3339), "3h ago"},
+		{"Xd", now.Add(-2 * 24 * time.Hour).Format(time.RFC3339), "2d ago"},
+		{"unparseable", "not-a-time", "not-a-time"},
+		{"future", now.Add(time.Hour).Format(time.RFC3339), "just now"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := timeAgo(tc.createdAt, now); got != tc.want {
+				t.Fatalf("timeAgo(%q) = %q, want %q", tc.createdAt, got, tc.want)
+			}
+		})
+	}
+}

--- a/packages/web/src/components/NotificationsBell.tsx
+++ b/packages/web/src/components/NotificationsBell.tsx
@@ -8,7 +8,7 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { Button } from '@/components/ui/button'
 import { notificationHref } from '@/lib/mentions'
-import { type Notification, type NotificationList, notifications } from '@/lib/notifications'
+import { type Notification, type NotificationList, notificationLabel, notifications } from '@/lib/notifications'
 import { timeAgo } from '@/lib/time'
 import { cn } from '@/lib/utils'
 
@@ -83,29 +83,32 @@ function BellMenu({ initial }: { initial: NotificationList }) {
           <p className="px-3 py-6 text-center text-muted-foreground text-sm">You're all caught up.</p>
         ) : (
           <ul className="max-h-96 overflow-y-auto py-1">
-            {data.items.map((n) => (
-              <li key={n.id}>
-                <button
-                  type="button"
-                  onClick={() => openItem(n)}
-                  className={cn(
-                    'flex w-full items-start gap-2 px-3 py-2 text-left text-sm hover:bg-accent',
-                    !n.read && 'bg-primary/5',
-                  )}
-                >
-                  <span className={cn('mt-1.5 size-1.5 shrink-0 rounded-full', n.read ? 'bg-transparent' : 'bg-primary')} />
-                  <span className="min-w-0 flex-1">
-                    <span className="block truncate">
-                      <span className="font-medium">{n.actorName ?? 'Someone'}</span> mentioned you
+            {data.items.map((n) => {
+              const label = notificationLabel(n)
+              return (
+                <li key={n.id}>
+                  <button
+                    type="button"
+                    onClick={() => openItem(n)}
+                    className={cn(
+                      'flex w-full items-start gap-2 px-3 py-2 text-left text-sm hover:bg-accent',
+                      !n.read && 'bg-primary/5',
+                    )}
+                  >
+                    <span className={cn('mt-1.5 size-1.5 shrink-0 rounded-full', n.read ? 'bg-transparent' : 'bg-primary')} />
+                    <span className="min-w-0 flex-1">
+                      <span className="block truncate">
+                        <span className="font-medium">{label.actor}</span> {label.verb}
+                      </span>
+                      {n.snippet && <span className="block truncate text-muted-foreground text-xs">{n.snippet}</span>}
+                      <span className="block text-muted-foreground text-xs">
+                        {n.siteLabel ?? 'a site'} · {timeAgo(n.createdAt)}
+                      </span>
                     </span>
-                    {n.snippet && <span className="block truncate text-muted-foreground text-xs">{n.snippet}</span>}
-                    <span className="block text-muted-foreground text-xs">
-                      {n.siteLabel ?? 'a site'} · {timeAgo(n.createdAt)}
-                    </span>
-                  </span>
-                </button>
-              </li>
-            ))}
+                  </button>
+                </li>
+              )
+            })}
           </ul>
         )}
       </DropdownMenuContent>

--- a/packages/web/src/lib/notifications.test.ts
+++ b/packages/web/src/lib/notifications.test.ts
@@ -9,10 +9,10 @@ describe('W1 — notificationLabel: actor + verb for mention/comment', () => {
     })
   })
 
-  test('comment → actor name and "commented on"', () => {
+  test('comment → actor name and "commented"', () => {
     expect(notificationLabel({ type: 'comment', actorName: 'Priya N' })).toEqual({
       actor: 'Priya N',
-      verb: 'commented on',
+      verb: 'commented',
     })
   })
 

--- a/packages/web/src/lib/notifications.test.ts
+++ b/packages/web/src/lib/notifications.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from 'bun:test'
+import { notificationLabel } from './notifications'
+
+describe('W1 — notificationLabel: actor + verb for mention/comment', () => {
+  test('mention → actor name and "mentioned you"', () => {
+    expect(notificationLabel({ type: 'mention', actorName: 'Dev R' })).toEqual({
+      actor: 'Dev R',
+      verb: 'mentioned you',
+    })
+  })
+
+  test('comment → actor name and "commented on"', () => {
+    expect(notificationLabel({ type: 'comment', actorName: 'Priya N' })).toEqual({
+      actor: 'Priya N',
+      verb: 'commented on',
+    })
+  })
+
+  test('null actorName → "Someone" for both types', () => {
+    expect(notificationLabel({ type: 'mention', actorName: null }).actor).toBe('Someone')
+    expect(notificationLabel({ type: 'comment', actorName: null }).actor).toBe('Someone')
+  })
+})

--- a/packages/web/src/lib/notifications.ts
+++ b/packages/web/src/lib/notifications.ts
@@ -7,16 +7,24 @@ import type { WhatsNewList } from '@/lib/whatsNew'
 
 export interface Notification {
   id: string
-  type: 'mention'
+  type: 'mention' | 'comment'
   actorId: string | null
   actorName: string | null // display name (name ?? email); null once the actor is deleted
   siteLabel: string | null // "space/slug"
   filePath: string | null
   threadId: string | null
+  commentId: string | null
   snippet: string | null
   read: boolean
   readAt: string | null
   createdAt: string
+}
+
+export function notificationLabel(n: Pick<Notification, 'type' | 'actorName'>): { actor: string; verb: string } {
+  return {
+    actor: n.actorName ?? 'Someone',
+    verb: n.type === 'comment' ? 'commented on' : 'mentioned you',
+  }
 }
 
 export interface NotificationList {

--- a/packages/web/src/lib/notifications.ts
+++ b/packages/web/src/lib/notifications.ts
@@ -23,7 +23,7 @@ export interface Notification {
 export function notificationLabel(n: Pick<Notification, 'type' | 'actorName'>): { actor: string; verb: string } {
   return {
     actor: n.actorName ?? 'Someone',
-    verb: n.type === 'comment' ? 'commented on' : 'mentioned you',
+    verb: n.type === 'comment' ? 'commented' : 'mentioned you',
   }
 }
 

--- a/packages/web/src/lib/types.ts
+++ b/packages/web/src/lib/types.ts
@@ -53,7 +53,7 @@ export interface TeamUpload extends SiteSummary {
 
 // Mirrors the API's CommentFeedItem (packages/api/src/db/comment-feed.ts) field-for-field — keep in sync.
 export interface CommentFeedItem {
-  kind: 'mention' | 'authored'
+  kind: 'mention' | 'authored' | 'owned'
   id: string
   snippet: string | null
   actorName: string | null

--- a/packages/web/src/routes/dashboard.tsx
+++ b/packages/web/src/routes/dashboard.tsx
@@ -395,10 +395,14 @@ function CommentsFeed({ comments }: { comments: CommentFeedItem[] }) {
           filePath: item.filePath,
           threadId: item.threadId,
         })
-        const v =
-          item.kind === 'mention'
-            ? { author: item.actorName ?? 'Someone', verb: ' mentioned you', editedSuffix: false }
-            : { author: 'You', verb: '', editedSuffix: !!item.editedAt }
+        const v = (
+          {
+            mention: { author: item.actorName ?? 'Someone', verb: ' mentioned you' },
+            owned: { author: item.actorName ?? 'Someone', verb: ' commented' },
+            authored: { author: 'You', verb: '' },
+          } as const
+        )[item.kind]
+        const editedSuffix = item.kind !== 'mention' && !!item.editedAt
         return (
           <li key={`${item.kind}:${item.id}`}>
             <Link
@@ -432,7 +436,7 @@ function CommentsFeed({ comments }: { comments: CommentFeedItem[] }) {
                   )}
                   {' · '}
                   {timeAgo(item.createdAt)}
-                  {v.editedSuffix && ' · edited'}
+                  {editedSuffix && ' · edited'}
                 </p>
               </div>
               {item.threadStatus === 'open' ? (


### PR DESCRIPTION
## What

Until now the only way to learn someone commented on your site was to be @-mentioned or to go look. This ships:

1. **Notifications for comments on your sites** — who gets a `comment` notification when a comment lands:
   - the **site owner**, anyone the site is **person-level shared** with, and **prior thread participants** on replies (soft-deleted comments keep their author's subscription; deleted users are skipped)
   - **mention always wins** — one row per person, never two
   - never the whole team, never group-share crowds (though a group-share user who *participated* qualifies), never revoked access, never yourself
   - applies to typed *and* voice comments (voice notify sits outside the R2 compensation path — a notify failure can never delete committed audio)
2. **`glance notifications` CLI** — `N unread · M shown` header (unreadCount is the true total), `●`/`✓` markers, type-keyed verbs, `--json` raw byte passthrough, `--read` POSTs exactly `{}`.
3. **"On my sites" feed arm** — the dashboard Comments tab now shows what others write on sites you own (kind `owned`), deduped against the mention arm on `notifications.commentId`. Feed items only, deliberately not notifications.

## Screenshots

Bell — type-keyed copy, deleted-actor fallback:

![bell](https://github.com/plivo-labs/glance/releases/download/assets-pr-comment-notifications/shot-bell.png)

Comments tab — `owned` rows + deduped mention:

![comments tab](https://github.com/plivo-labs/glance/releases/download/assets-pr-comment-notifications/shot-comments.png)

CLI:

```
$ glance notifications
2 unread · 3 shown
● Priya N commented on eng/perf-dashboard (index.html, 2h ago)
  "The p95 chart hides the cold-start spike, can we…"
● Dev R mentioned you on design/onboarding-v2 (flows/step-3.html, 1d ago)
✓ Someone commented on eng/perf-dashboard (index.html, 3d ago)

$ glance notifications --read
✓ Marked all notifications read
```

## How

- `notifyMentions` → `notifyForComment`: mention path unchanged; the comment audience is resolved in `db/notifications.ts` `resolveCommentAudience` from **targeted facts** (direct shares, thread participants, membership/group-share for just the candidate set) re-authorized per candidate via `checkAccess` — never the full-users team scan. The whole resolution + insert runs post-response inside `fireAndForget`.
- **D1 discipline:** notification inserts chunk at 9 rows/statement and audience `inArray`s chunk at `D1_MAX_IN`, all inside one `db.batch` — D1's 100-bound-param cap breaks unchunked multi-row inserts at ≥10 recipients and bun:sqlite can't catch it (regression test included).
- Migrations: `0015` adds nullable `notifications.commentId` (SET NULL FK, the feed-dedupe identity), `0016` indexes it. Both verified via `wrangler d1 migrations apply --local`.
- Feed: one `commentCandidatesStmt` builder for the authored/owned arms; `KIND_RANK` mention → authored → owned; route batch grows 5 → 6 statements (pin updated).

## Testing

- 35 planned cases landed red→green: recipient truth table (C1–C22), feed arm (F1–F5), CLI (G-1…G-6), plus gate-review additions (members-visibility audience, ≥10-recipient chunking, timeAgo table test).
- Full suites green: **731 api + 175 web bun tests, Go CLI tests, tsc, biome, gofmt/vet**.
- Live-verified on the local full stack (screenshots above; API responses checked for both endpoints, including mention-wins dedupe).
- Every phase passed a simplify → suite → thermo-nuclear review gate; a final whole-change review caught and fixed the D1 param-cap bug.

Tracker: https://glance.plivo.com/samuel-lawerence/comment-notifications-progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016kHAj7fCxpqEmzCAJN3yK4