### PR TITLE
Slack DM notifications for comments

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -58,6 +58,16 @@ echo "$(openssl rand -hex 32)" | wrangler secret put BOOTSTRAP_TOKEN
   tokens; keep distinct from `CONTENT_TOKEN_SECRET`. While unset, `/api/_data` and the token mint
   return 404 — the feature is opt-in per deploy. Enable with:
   `echo "$(openssl rand -hex 32)" | wrangler secret put DATA_TOKEN_SECRET`
+- `SLACK_BOT_TOKEN` (optional, main worker only) — Slack bot token (`xoxb-…`) that mirrors in-app
+  comment notifications as Slack DMs. **Kill-switch: while unset, no Slack DMs are ever sent and the
+  comment path does zero extra work** — removing the secret disables the feature instantly. Set with:
+  `wrangler secret put SLACK_BOT_TOKEN`. Requires a Slack app (install to your workspace) with bot
+  scopes **`chat:write` · `users:read` · `users:read.email`** — `users:read.email` resolves a Glance
+  user's email to a Slack id (cached in KV ~30d; not-found ~1h), and `chat:write` DMs that id directly
+  (the user id doubles as the DM channel). The DM carries the actor, the comment reason (mention /
+  your-site / participant / share), the snippet, and a deep link back to the review thread. Slack DMs
+  are capped at **15 per comment event, mentions first** (bounds blast radius); the in-app bell fan-out
+  is uncapped, so an audience over 15 gets in-app notifications for everyone but Slack DMs for the top 15.
 
 ## 3. Ship
 

--- a/packages/api/src/db/notifications.test.ts
+++ b/packages/api/src/db/notifications.test.ts
@@ -9,6 +9,7 @@ import {
   seedSpace,
   seedThread,
   seedUser,
+  seedUserShare,
 } from '../test/harness'
 import { createNotifications, listNotifications, markRead, resolveCommentAudience } from './notifications'
 import { comments } from './schema'
@@ -144,7 +145,67 @@ describe('comment audience stays within D1 bind limits', () => {
       { threadId, isReply: true, exclude: new Set([ownerId]) },
     )
 
-    expect(new Set(audience)).toEqual(new Set(participants))
+    expect(new Set(audience.map((r) => r.id))).toEqual(new Set(participants))
+    expect(audience.every((r) => r.reason === 'participant')).toBe(true)
+  })
+})
+
+describe('resolveCommentAudience tags each recipient with a reason (owner>participant>share)', () => {
+  const teamSite = (siteId: string, spaceId: string, ownerId: string) =>
+    ({ id: siteId, spaceId, ownerId, visibility: 'team' as const, status: 'active' as const })
+
+  test('V3: reply tags owner/participant/share; a new (non-reply) thread emits no participant', async () => {
+    const db = makeDb()
+    const owner = await seedUser(db)
+    const priorAuthor = await seedUser(db)
+    const shareUser = await seedUser(db)
+    const actor = await seedUser(db)
+    const spaceId = await seedSpace(db, { createdBy: owner })
+    const siteId = await seedSite(db, { spaceId, ownerId: owner, visibility: 'team' })
+    const threadId = await seedThread(db, { siteId, filePath: 'index.html', createdBy: owner })
+    await seedComment(db, { threadId, authorId: priorAuthor }) // prior participant
+    await seedUserShare(db, siteId, shareUser) // direct share, never commented
+
+    const reply = await resolveCommentAudience(db, teamSite(siteId, spaceId, owner), {
+      threadId,
+      isReply: true,
+      exclude: new Set([actor]),
+    })
+    const byId = new Map(reply.map((r) => [r.id, r.reason]))
+    expect(byId.get(owner)).toBe('owner')
+    expect(byId.get(priorAuthor)).toBe('participant')
+    expect(byId.get(shareUser)).toBe('share')
+
+    const fresh = await resolveCommentAudience(db, teamSite(siteId, spaceId, owner), {
+      threadId,
+      isReply: false,
+      exclude: new Set([actor]),
+    })
+    expect(fresh.some((r) => r.reason === 'participant')).toBe(false)
+    expect(new Set(fresh.map((r) => r.reason))).toEqual(new Set(['owner', 'share']))
+  })
+
+  test('V4: precedence — owner+participant → owner, owner+share → owner, share+participant → participant', async () => {
+    const db = makeDb()
+    const owner = await seedUser(db)
+    const shareAndParticipant = await seedUser(db)
+    const actor = await seedUser(db)
+    const spaceId = await seedSpace(db, { createdBy: owner })
+    const siteId = await seedSite(db, { spaceId, ownerId: owner, visibility: 'team' })
+    const threadId = await seedThread(db, { siteId, filePath: 'index.html', createdBy: owner })
+    await seedComment(db, { threadId, authorId: owner }) // owner is ALSO a prior participant
+    await seedComment(db, { threadId, authorId: shareAndParticipant })
+    await seedUserShare(db, siteId, shareAndParticipant) // …and a direct share
+    await seedUserShare(db, siteId, owner) // owner is ALSO a direct share
+
+    const audience = await resolveCommentAudience(db, teamSite(siteId, spaceId, owner), {
+      threadId,
+      isReply: true,
+      exclude: new Set([actor]),
+    })
+    const byId = new Map(audience.map((r) => [r.id, r.reason]))
+    expect(byId.get(owner)).toBe('owner') // owner beats participant AND share
+    expect(byId.get(shareAndParticipant)).toBe('participant') // participant beats share
   })
 })
 

--- a/packages/api/src/db/notifications.ts
+++ b/packages/api/src/db/notifications.ts
@@ -75,14 +75,21 @@ export async function createNotifications(db: DrizzleD1Database, rows: Notificat
   await batchAll(db, inserts)
 }
 
+/** Why a comment recipient is in the audience — drives the Slack verb (the in-app D1 row stays
+ *  `type='comment'`, no migration). Precedence owner > participant > share. */
+export type CommentAudienceReason = 'owner' | 'participant' | 'share'
+export type CommentRecipient = { id: string; reason: CommentAudienceReason }
+
 /** Resolve the normal comment audience from targeted facts, excluding the actor and any mention
- *  recipients. Prior participants join the owner and direct shares only for replies; every
- *  candidate is re-authorized against the site's current tier/share policy before notification. */
+ *  recipients. Prior participants join the owner and direct shares only for replies; every candidate
+ *  is re-authorized against the site's current tier/share policy before notification. Each surviving
+ *  recipient is tagged with its reason by precedence owner > participant > share (owner id first,
+ *  then a prior thread author, else a direct share) — a single reason per recipient. */
 export async function resolveCommentAudience(
   db: DrizzleD1Database,
   site: Pick<Site, 'id' | 'spaceId' | 'visibility' | 'ownerId' | 'status'>,
   opts: { threadId: string; isReply: boolean; exclude: Set<string> },
-): Promise<string[]> {
+): Promise<CommentRecipient[]> {
   if (site.status === 'archived') return []
 
   const directSharesStmt = db
@@ -110,13 +117,19 @@ export async function resolveCommentAudience(
   const participantIds = participantRows
     .map((row) => row.authorId)
     .filter((authorId): authorId is string => authorId !== null)
+  const participantSet = new Set(participantIds)
+  // Precedence owner > participant > share: owner id wins, else a prior thread author, else a direct
+  // share (every candidate is in exactly one of the three source sets after this ordering).
+  const reasonOf = (id: string): CommentAudienceReason =>
+    id === site.ownerId ? 'owner' : participantSet.has(id) ? 'participant' : 'share'
+
   const audience = new Set<string>([site.ownerId, ...directShares, ...participantIds])
   for (const id of opts.exclude) audience.delete(id)
   const candidates = [...audience]
   if (candidates.length === 0) return []
   // Every candidate is an authenticated user id from an FK-backed audience fact. Team visibility
   // admits all of them, so no access-fact queries are needed.
-  if (site.visibility === 'team') return candidates
+  if (site.visibility === 'team') return candidates.map((id) => ({ id, reason: reasonOf(id) }))
 
   const accessFactStatements = chunk(candidates, D1_MAX_IN).flatMap((ids) => [
     {
@@ -145,11 +158,27 @@ export async function resolveCommentAudience(
   const groupSharedIds = new Set(groupRows.map((row) => row.userId))
   const memberIds = new Set(memberRows.map((row) => row.userId))
 
-  return candidates.filter((id) => {
-    // Recipient role is deliberately not consulted — superadmins need normal tier/share access to be notified.
-    const recipient = { id, role: 'member' as const }
-    return checkAccess(site, recipient, memberIds.has(id), directShares.has(id) || groupSharedIds.has(id)).ok
-  })
+  return candidates
+    .filter((id) => {
+      // Recipient role is deliberately not consulted — superadmins need normal tier/share access to be notified.
+      const recipient = { id, role: 'member' as const }
+      return checkAccess(site, recipient, memberIds.has(id), directShares.has(id) || groupSharedIds.has(id)).ok
+    })
+    .map((id) => ({ id, reason: reasonOf(id) }))
+}
+
+/** Resolve `{id → email}` for a set of user ids in bind-safe IN chunks (D1_MAX_IN). Used to hydrate
+ *  the Slack-delivery recipient list off the ids the audience/mention resolve already produced — no
+ *  re-resolve. Empty input never touches D1. */
+export async function usersEmailsByIds(db: DrizzleD1Database, ids: string[]): Promise<Map<string, string>> {
+  if (ids.length === 0) return new Map()
+  const stmts = chunk(ids, D1_MAX_IN).map((idChunk) =>
+    db.select({ id: users.id, email: users.email }).from(users).where(inArray(users.id, idChunk)),
+  )
+  const chunks = await batchAll(db, stmts)
+  const out = new Map<string, string>()
+  for (const rows of chunks) for (const row of rows) out.set(row.id, row.email)
+  return out
 }
 
 /** A recipient's notifications, newest-first, plus the FULL unread count (independent of `limit`).

--- a/packages/api/src/db/notifications.ts
+++ b/packages/api/src/db/notifications.ts
@@ -2,6 +2,7 @@ import { and, desc, eq, inArray, isNotNull, isNull, sql } from 'drizzle-orm'
 import type { DrizzleD1Database } from 'drizzle-orm/d1'
 import { checkAccess } from '../lib/access'
 import { batchAll, chunk, D1_MAX_BOUND_PARAMETERS, D1_MAX_IN } from '../lib/d1'
+import type { SlackReason } from '../lib/slack'
 import {
   comments,
   type NotificationType,
@@ -76,8 +77,11 @@ export async function createNotifications(db: DrizzleD1Database, rows: Notificat
 }
 
 /** Why a comment recipient is in the audience — drives the Slack verb (the in-app D1 row stays
- *  `type='comment'`, no migration). Precedence owner > participant > share. */
-export type CommentAudienceReason = 'owner' | 'participant' | 'share'
+ *  `type='comment'`, no migration). Precedence owner > participant > share. Derived from SlackReason
+ *  minus 'mention' so the "SlackReason ⊇ CommentAudienceReason" invariant (relied on by the audience
+ *  spread in comments.ts) is compiler-guaranteed, not comment-synced. Type-only import — erased at
+ *  runtime, and db→lib is the existing dependency direction (cf. lib/access). */
+export type CommentAudienceReason = Exclude<SlackReason, 'mention'>
 export type CommentRecipient = { id: string; reason: CommentAudienceReason }
 
 /** Resolve the normal comment audience from targeted facts, excluding the actor and any mention

--- a/packages/api/src/lib/notification-link.test.ts
+++ b/packages/api/src/lib/notification-link.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from 'bun:test'
+import { encodePathSegments, notificationLink } from './notification-link'
+
+// S5: the API-mirrored deep link. Absolute URL == join(appUrl, viewer href): encoded path segments,
+// review=1 always, thread= only when set, trailing-slash appUrl never doubles the slash. Mirrors
+// web/src/lib/mentions.ts notificationHref (packages don't cross-import) but joins an absolute APP_URL.
+describe('notificationLink (S5)', () => {
+  const appUrl = 'https://glance.example.com'
+
+  test('encodePathSegments encodes ? and # per segment, keeps slashes', () => {
+    expect(encodePathSegments('Q3?Report.html')).toBe('Q3%3FReport.html')
+    expect(encodePathSegments('notes#draft.html')).toBe('notes%23draft.html')
+    expect(encodePathSegments('my file.html')).toBe('my%20file.html')
+    expect(encodePathSegments('nested/p.html')).toBe('nested/p.html')
+  })
+
+  test('null filePath → site root + review=1, no thread', () => {
+    expect(notificationLink(appUrl, { siteLabel: 'acme/doc', filePath: null, threadId: null })).toBe(
+      'https://glance.example.com/acme/doc?review=1',
+    )
+  })
+
+  test('thread= present only when threadId set', () => {
+    expect(notificationLink(appUrl, { siteLabel: 'acme/doc', filePath: null, threadId: 't1' })).toBe(
+      'https://glance.example.com/acme/doc?thread=t1&review=1',
+    )
+  })
+
+  test('filePath variants are segment-encoded and leading slashes stripped', () => {
+    const cases: Array<[string, string]> = [
+      ['Q3?Report.html', 'Q3%3FReport.html'],
+      ['notes#draft.html', 'notes%23draft.html'],
+      ['my file.html', 'my%20file.html'],
+      ['/nested/p.html', 'nested/p.html'],
+    ]
+    for (const [filePath, encoded] of cases) {
+      expect(notificationLink(appUrl, { siteLabel: 'acme/doc', filePath, threadId: 't1' })).toBe(
+        `https://glance.example.com/acme/doc/${encoded}?thread=t1&review=1`,
+      )
+    }
+  })
+
+  test('trailing-slash appUrl yields no doubled slash', () => {
+    expect(notificationLink('https://glance.example.com/', { siteLabel: 'acme/doc', filePath: null, threadId: null })).toBe(
+      'https://glance.example.com/acme/doc?review=1',
+    )
+  })
+
+  test('missing siteLabel degrades to the absolute root', () => {
+    expect(notificationLink(appUrl, { siteLabel: null, filePath: 'x.html', threadId: 't1' })).toBe(
+      'https://glance.example.com/',
+    )
+  })
+})

--- a/packages/api/src/lib/notification-link.ts
+++ b/packages/api/src/lib/notification-link.ts
@@ -1,0 +1,25 @@
+// Absolute deep-link for a comment notification, for delivery channels that need a full URL (Slack).
+// A behavior-preserving MIRROR of web/src/lib/mentions.ts `notificationHref` + paths.ts
+// `encodePathSegments` — packages don't cross-import (see lib/mime.ts), so the algorithm is
+// duplicated, not shared. Difference from the web helper: it joins an absolute APP_URL (the in-app
+// bell renders the relative form), trailing-slash safe.
+
+/** Encode each path segment so `?`/`#` in a filename can't truncate the pathname into query/
+ *  fragment territory. Mirror of web paths.ts. */
+export const encodePathSegments = (filePath: string): string =>
+  filePath.split('/').map(encodeURIComponent).join('/')
+
+/** Absolute viewer link for a notification: `${APP_URL}/<siteLabel>/<encoded path>?thread=&review=1`.
+ *  `review=1` is always present; `thread=` only when set; a missing site degrades to the app root. */
+export function notificationLink(
+  appUrl: string,
+  n: { siteLabel: string | null; filePath: string | null; threadId: string | null },
+): string {
+  const base = appUrl.replace(/\/+$/, '')
+  if (!n.siteLabel) return `${base}/`
+  const path = n.filePath ? `/${encodePathSegments(n.filePath.replace(/^\/+/, ''))}` : ''
+  const params = new URLSearchParams()
+  if (n.threadId) params.set('thread', n.threadId)
+  params.set('review', '1')
+  return `${base}/${n.siteLabel}${path}?${params.toString()}`
+}

--- a/packages/api/src/lib/slack.test.ts
+++ b/packages/api/src/lib/slack.test.ts
@@ -1,0 +1,250 @@
+import { describe, expect, test } from 'bun:test'
+import { countingKv } from '../test/harness'
+import { deliverSlack, formatSlackMessage, lookupSlackId } from './slack'
+
+// Records every fetch call so specs can assert exact request count, URL, and headers.
+function recordingFetch(handler: (url: string, init?: RequestInit) => Response | Promise<Response>) {
+  const calls: Array<{ url: string; init?: RequestInit }> = []
+  const fetchImpl = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input.toString()
+    calls.push({ url, init })
+    return handler(url, init)
+  }) as unknown as typeof fetch
+  return { fetchImpl, calls }
+}
+
+const bearer = (init?: RequestInit) => new Headers(init?.headers).get('Authorization')
+
+describe('lookupSlackId', () => {
+  test('S2: cache miss → one lookup with email + Bearer, returns user.id, caches 30d', async () => {
+    const kv = countingKv()
+    const { fetchImpl, calls } = recordingFetch(() => Response.json({ ok: true, user: { id: 'U123' } }))
+
+    const id = await lookupSlackId({ kv, token: 'xoxb-tok', fetchImpl }, 'Sam@Plivo.com')
+
+    expect(id).toBe('U123')
+    expect(calls).toHaveLength(1)
+    expect(calls[0].url).toContain(encodeURIComponent('Sam@Plivo.com'))
+    expect(bearer(calls[0].init)).toBe('Bearer xoxb-tok')
+    expect(kv.store.get('slackuid:sam@plivo.com')).toBe('U123')
+    expect(kv.ttls.get('slackuid:sam@plivo.com')).toBe(2_592_000)
+  })
+
+  test('S3: cache hit returns id without fetching; negative marker never returned as a channel', async () => {
+    const kv = countingKv()
+    await kv.put('slackuid:hit@plivo.com', 'Uhit')
+    const { fetchImpl, calls } = recordingFetch(() => {
+      throw new Error('must not fetch on a cache hit')
+    })
+    kv.ops() // reset baseline not needed; count from here
+    const hit = await lookupSlackId({ kv, token: 't', fetchImpl }, 'hit@plivo.com')
+    expect(hit).toBe('Uhit')
+    expect(calls).toHaveLength(0)
+
+    await kv.put('slackuid:none@plivo.com', '-') // NEGATIVE marker
+    const neg = await lookupSlackId({ kv, token: 't', fetchImpl }, 'none@plivo.com')
+    expect(neg).toBeNull()
+    expect(calls).toHaveLength(0)
+  })
+
+  test('S4a: users_not_found → null, negative marker cached 1h', async () => {
+    const kv = countingKv()
+    const { fetchImpl, calls } = recordingFetch(() => Response.json({ ok: false, error: 'users_not_found' }))
+    const id = await lookupSlackId({ kv, token: 't', fetchImpl }, 'ghost@plivo.com')
+    expect(id).toBeNull()
+    expect(calls).toHaveLength(1)
+    expect(kv.store.get('slackuid:ghost@plivo.com')).toBe('-')
+    expect(kv.ttls.get('slackuid:ghost@plivo.com')).toBe(3_600)
+  })
+
+  test('S4b: transient (500 / network / invalid_auth / 429) → null, NO cache, re-attempts next call', async () => {
+    for (const transient of [
+      () => new Response('', { status: 500 }),
+      () => {
+        throw new Error('network down')
+      },
+      () => Response.json({ ok: false, error: 'invalid_auth' }),
+      () => new Response('', { status: 429 }),
+    ]) {
+      const kv = countingKv()
+      const { fetchImpl } = recordingFetch(transient)
+      const id = await lookupSlackId({ kv, token: 't', fetchImpl }, 'x@plivo.com')
+      expect(id).toBeNull()
+      expect(kv.ops().put).toBe(0) // nothing poisoned
+      expect(kv.store.has('slackuid:x@plivo.com')).toBe(false)
+
+      // A follow-up call re-attempts the lookup (no cached marker to short-circuit it).
+      const { fetchImpl: ok, calls } = recordingFetch(() => Response.json({ ok: true, user: { id: 'Ulate' } }))
+      expect(await lookupSlackId({ kv, token: 't', fetchImpl: ok }, 'x@plivo.com')).toBe('Ulate')
+      expect(calls).toHaveLength(1)
+    }
+  })
+
+  test('S8: ok:true but missing user.id → null, no post, no positive cache', async () => {
+    const kv = countingKv()
+    const { fetchImpl } = recordingFetch(() => Response.json({ ok: true, user: {} }))
+    const id = await lookupSlackId({ kv, token: 't', fetchImpl }, 'weird@plivo.com')
+    expect(id).toBeNull()
+    expect(kv.ops().put).toBe(0)
+    expect(kv.store.has('slackuid:weird@plivo.com')).toBe(false)
+  })
+})
+
+describe('formatSlackMessage', () => {
+  const appUrl = 'https://glance.example.com'
+  const base = {
+    siteLabel: 'design/q3-dashboard',
+    actorName: 'Ravi Anand',
+    actorEmail: 'ravi@plivo.com',
+    filePath: 'q3.html',
+    threadId: 't1',
+  } as const
+
+  test('V1: reason=owner says "your site"; reason=share does not', () => {
+    const owner = formatSlackMessage({ ...base, reason: 'owner', snippet: 'hi' }, appUrl)
+    expect(owner).toContain('commented on your site design/q3-dashboard')
+    const share = formatSlackMessage({ ...base, reason: 'share', snippet: 'hi' }, appUrl)
+    expect(share).toContain('commented on design/q3-dashboard')
+    expect(share).not.toContain('your site')
+  })
+
+  test('V2: participant verb + thread= in link; mention verb', () => {
+    const p = formatSlackMessage({ ...base, reason: 'participant', snippet: 'hi' }, appUrl)
+    expect(p).toContain('replied in a thread you commented on')
+    expect(p).toContain('thread=t1')
+    const m = formatSlackMessage({ ...base, reason: 'mention', snippet: 'hi' }, appUrl)
+    expect(m).toContain('mentioned you in a comment on')
+  })
+
+  test('S7: null actorName → email fallback; snippet escapes &/</>; empty/null snippet stays non-empty', () => {
+    const withEmail = formatSlackMessage({ ...base, actorName: null, reason: 'share', snippet: 'a & b < c > d' }, appUrl)
+    expect(withEmail).toContain('ravi@plivo.com')
+    expect(withEmail).toContain('a &amp; b &lt; c &gt; d')
+
+    const empty = formatSlackMessage({ ...base, reason: 'share', snippet: '' }, appUrl)
+    expect(empty.trim().length).toBeGreaterThan(0)
+    expect(empty).toContain('commented on')
+
+    const nullSnippet = formatSlackMessage({ ...base, reason: 'share', snippet: null }, appUrl)
+    expect(nullSnippet.trim().length).toBeGreaterThan(0)
+  })
+
+  test('actor name preferred over email; message carries the absolute deep link', () => {
+    const msg = formatSlackMessage({ ...base, reason: 'mention', snippet: 'hey' }, appUrl)
+    expect(msg).toContain('Ravi Anand')
+    expect(msg).toContain('https://glance.example.com/design/q3-dashboard/q3.html?thread=t1&review=1')
+  })
+})
+
+const EVENT = {
+  actorName: 'Ravi Anand',
+  actorEmail: 'ravi@plivo.com',
+  siteLabel: 'design/q3-dashboard',
+  filePath: 'q3.html',
+  threadId: 't1',
+  snippet: 'take a look',
+} as const
+
+// Parse the JSON body of a recorded chat.postMessage call.
+const postBody = (init?: RequestInit) => JSON.parse(String(init?.body)) as { channel: string; text: string }
+
+describe('deliverSlack', () => {
+  const appUrl = 'https://glance.example.com'
+
+  test('S1: token absent/blank → resolves with zero KV and zero HTTP', async () => {
+    for (const token of [undefined, '', '  ']) {
+      const kv = countingKv()
+      const { fetchImpl, calls } = recordingFetch(() => {
+        throw new Error('must not fetch when token is absent')
+      })
+      await deliverSlack({ kv, token, fetchImpl, appUrl }, EVENT, [
+        { id: 'u1', email: 'a@plivo.com', reason: 'owner' },
+      ])
+      expect(kv.ops()).toEqual({ get: 0, put: 0, delete: 0 })
+      expect(calls).toHaveLength(0)
+    }
+  })
+
+  test('core: one recipient → one post to its resolved channel with verb + snippet + link', async () => {
+    const kv = countingKv()
+    await kv.put('slackuid:owner@plivo.com', 'Uowner')
+    const posts: Array<{ url: string; init?: RequestInit }> = []
+    const { fetchImpl } = recordingFetch((url, init) => {
+      posts.push({ url, init })
+      return Response.json({ ok: true })
+    })
+    await deliverSlack({ kv, token: 'xoxb', fetchImpl, appUrl }, EVENT, [
+      { id: 'u1', email: 'owner@plivo.com', reason: 'owner' },
+    ])
+    expect(posts).toHaveLength(1)
+    expect(posts[0].url).toContain('chat.postMessage')
+    const body = postBody(posts[0].init)
+    expect(body.channel).toBe('Uowner')
+    expect(body.text).toContain('commented on your site design/q3-dashboard')
+    expect(body.text).toContain('take a look')
+    expect(body.text).toContain('https://glance.example.com/design/q3-dashboard/q3.html?thread=t1&review=1')
+  })
+
+  test('cap 15, mention-first regardless of array order (10 mention + 10 comment, comment-first)', async () => {
+    const kv = countingKv()
+    const recipients = [
+      ...Array.from({ length: 10 }, (_, i) => ({ id: `c${i}`, email: `c${i}@plivo.com`, reason: 'share' as const })),
+      ...Array.from({ length: 10 }, (_, i) => ({ id: `m${i}`, email: `m${i}@plivo.com`, reason: 'mention' as const })),
+    ]
+    for (const r of recipients) await kv.put(`slackuid:${r.email}`, `U-${r.id}`)
+    const channels: string[] = []
+    const { fetchImpl } = recordingFetch((_url, init) => {
+      channels.push(postBody(init).channel)
+      return Response.json({ ok: true })
+    })
+    await deliverSlack({ kv, token: 'xoxb', fetchImpl, appUrl }, EVENT, recipients)
+    expect(channels).toHaveLength(15)
+    // First 10 must be the mentions (priority), then 5 comments — never array order.
+    expect(channels.slice(0, 10).sort()).toEqual(Array.from({ length: 10 }, (_, i) => `U-m${i}`).sort())
+    expect(channels.slice(10).every((c) => c.startsWith('U-c'))).toBe(true)
+  })
+
+  test('per-recipient isolation: one failing post never aborts the rest, never throws', async () => {
+    const kv = countingKv()
+    for (const e of ['a@plivo.com', 'b@plivo.com', 'c@plivo.com']) await kv.put(`slackuid:${e}`, `U-${e}`)
+    let n = 0
+    const sent: string[] = []
+    const { fetchImpl } = recordingFetch((_url, init) => {
+      n++
+      if (n === 2) throw new Error('slack down')
+      sent.push(postBody(init).channel)
+      return Response.json({ ok: true })
+    })
+    await deliverSlack({ kv, token: 'xoxb', fetchImpl, appUrl }, EVENT, [
+      { id: 'a', email: 'a@plivo.com', reason: 'owner' },
+      { id: 'b', email: 'b@plivo.com', reason: 'owner' },
+      { id: 'c', email: 'c@plivo.com', reason: 'owner' },
+    ])
+    expect(sent).toEqual(['U-a@plivo.com', 'U-c@plivo.com']) // b threw, a and c still delivered
+  })
+
+  test('recipients with no email are skipped (no lookup, no post)', async () => {
+    const kv = countingKv()
+    const { fetchImpl, calls } = recordingFetch(() => Response.json({ ok: true }))
+    await deliverSlack({ kv, token: 'xoxb', fetchImpl, appUrl }, EVENT, [
+      { id: 'noemail', email: null, reason: 'owner' },
+    ])
+    expect(calls).toHaveLength(0)
+    expect(kv.ops().get).toBe(0)
+  })
+
+  test('a KV cache-put failure after a live lookup still delivers the DM (best-effort cache)', async () => {
+    const kv = countingKv()
+    kv.failNextPut(new Error('kv down'))
+    let posts = 0
+    const { fetchImpl } = recordingFetch((url) => {
+      if (url.includes('lookupByEmail')) return Response.json({ ok: true, user: { id: 'Ulive' } })
+      posts++
+      return Response.json({ ok: true })
+    })
+    await deliverSlack({ kv, token: 'xoxb', fetchImpl, appUrl }, EVENT, [
+      { id: 'u1', email: 'live@plivo.com', reason: 'owner' },
+    ])
+    expect(posts).toBe(1)
+  })
+})

--- a/packages/api/src/lib/slack.ts
+++ b/packages/api/src/lib/slack.ts
@@ -120,8 +120,10 @@ export function formatSlackMessage(input: SlackMessageInput, appUrl: string): st
 }
 
 const POST_URL = 'https://slack.com/api/chat.postMessage'
-// Slack DMs per comment event, mentions first. Bounds the blast radius of a wide @-everyone or a
-// large shared audience — the same cap the in-app fan-out already lives under.
+// Cap on Slack DMs per comment event, mentions first — bounds the blast radius of a wide @-everyone
+// or a large shared audience. Slack-ONLY: the in-app fan-out (createNotifications) is intentionally
+// uncapped, so an audience >15 gets in-app bells for everyone but Slack DMs for the first 15
+// (mentions prioritized).
 const MAX_DMS_PER_EVENT = 15
 
 /** A resolved delivery target: the D1 recipient id, their email (for the Slack lookup — null when

--- a/packages/api/src/lib/slack.ts
+++ b/packages/api/src/lib/slack.ts
@@ -2,6 +2,7 @@
 // unit-testable and nothing here touches global fetch or KV directly. Layered onto the existing
 // comment-notification seam as a DELIVERY channel — no new recipient logic, no schema change.
 
+import type { Bindings } from '../types'
 import { notificationLink } from './notification-link'
 
 /** Why a recipient is being notified — drives the message verb. Precedence (owner > participant >
@@ -15,6 +16,11 @@ export type SlackHttpDeps = {
   token?: string
   fetchImpl?: typeof fetch
 }
+
+/** The Slack kill-switch predicate: a present, non-blank bot token. Shared by deliverSlack's
+ *  line-one no-op and the route's zero-work gate so "off" means the same at both boundaries (a
+ *  whitespace-only token is OFF everywhere, never doing wasted D1/HTTP work). */
+export const slackEnabled = (token?: string): boolean => !!token && token.trim() !== ''
 
 const LOOKUP_URL = 'https://slack.com/api/users.lookupByEmail'
 const CACHE_PREFIX = 'slackuid:'
@@ -125,6 +131,18 @@ export type SlackRecipient = { id: string; email: string | null; reason: SlackRe
 /** deliverSlack's deps: the HTTP/KV handles plus the absolute-link base. */
 export type SlackDeps = SlackHttpDeps & { appUrl: string }
 
+/** Build deliverSlack's deps from the worker env: the sessions KV, the bot token, the app origin,
+ *  and the injected fetch (SLACK_FETCH is the test seam — unset in prod → deliverSlack's global-fetch
+ *  fallback). */
+export const slackDepsFromEnv = (
+  env: Pick<Bindings, 'GLANCE_SESSIONS' | 'SLACK_BOT_TOKEN' | 'APP_URL' | 'SLACK_FETCH'>,
+): SlackDeps => ({
+  kv: env.GLANCE_SESSIONS,
+  token: env.SLACK_BOT_TOKEN,
+  appUrl: env.APP_URL,
+  fetchImpl: env.SLACK_FETCH,
+})
+
 /** Mentions first (priority, NOT array order), de-duplicated by recipient id (mention wins the tie),
  *  then truncated to the per-event cap. */
 function capMentionFirst(recipients: SlackRecipient[]): SlackRecipient[] {
@@ -148,7 +166,7 @@ function capMentionFirst(recipients: SlackRecipient[]): SlackRecipient[] {
  *  failure (429/5xx/{ok:false}/network throw) skips just that recipient and never aborts the fan-out
  *  or surfaces to the caller. Never throws. */
 export async function deliverSlack(deps: SlackDeps, event: SlackEvent, recipients: SlackRecipient[]): Promise<void> {
-  if (!deps.token || deps.token.trim() === '') return
+  if (!slackEnabled(deps.token)) return
   const fetchImpl = deps.fetchImpl ?? globalThis.fetch
   for (const r of capMentionFirst(recipients)) {
     try {

--- a/packages/api/src/lib/slack.ts
+++ b/packages/api/src/lib/slack.ts
@@ -1,0 +1,171 @@
+// Slack delivery lib: pure + dependency-injected (fetchImpl/kv like SummarizeDeps), so routes stay
+// unit-testable and nothing here touches global fetch or KV directly. Layered onto the existing
+// comment-notification seam as a DELIVERY channel — no new recipient logic, no schema change.
+
+import { notificationLink } from './notification-link'
+
+/** Why a recipient is being notified — drives the message verb. Precedence (owner > participant >
+ *  share) is resolved upstream in resolveCommentAudience; here each recipient carries one reason.
+ *  `mention` recipients always carry reason='mention'. */
+export type SlackReason = 'mention' | 'owner' | 'participant' | 'share'
+
+/** KV + token + fetch handle every Slack HTTP helper needs. `token` optional: unset = kill-switch. */
+export type SlackHttpDeps = {
+  kv: KVNamespace
+  token?: string
+  fetchImpl?: typeof fetch
+}
+
+const LOOKUP_URL = 'https://slack.com/api/users.lookupByEmail'
+const CACHE_PREFIX = 'slackuid:'
+// Positive results are stable, so cache ~30d; a definitive not-found only ~1h (the person may join
+// the workspace). TTLs are product-chosen (see tracker 3.1).
+const POSITIVE_TTL = 2_592_000 // 30d
+const NEGATIVE_TTL = 3_600 // 1h
+// Sentinel for a cached "no such Slack user" — a leading '-' is never a valid Slack id (ids are
+// opaque but always alphanumeric, U…/W…), so it can never be mistaken for a DM channel.
+const NEGATIVE_MARKER = '-'
+
+const cacheKey = (email: string) => `${CACHE_PREFIX}${email.toLowerCase()}`
+
+type LookupResponse = { ok?: boolean; error?: string; user?: { id?: unknown } }
+
+/** Resolve a Slack user-id (usable directly as a DM channel) for an email, KV-cached. Cache hit →
+ *  return (a negative marker resolves to null, never leaks as a channel). Miss → Slack
+ *  users.lookupByEmail: a hit caches ~30d, a definitive `users_not_found` caches the negative marker
+ *  ~1h. Transient/auth failures (5xx, network throw, 429, invalid_auth, or a malformed ok body) →
+ *  null WITHOUT caching, so a later call re-attempts and never poisons on a recoverable error.
+ *  Never throws. */
+export async function lookupSlackId(deps: SlackHttpDeps, email: string): Promise<string | null> {
+  const key = cacheKey(email)
+  const cached = await deps.kv.get(key)
+  if (cached !== null) return cached === NEGATIVE_MARKER ? null : cached
+
+  const fetchImpl = deps.fetchImpl ?? globalThis.fetch
+  let data: LookupResponse
+  try {
+    const res = await fetchImpl(`${LOOKUP_URL}?email=${encodeURIComponent(email)}`, {
+      headers: { Authorization: `Bearer ${deps.token ?? ''}` },
+    })
+    // Transient HTTP (rate-limit / server) — retryable, so never cache a negative.
+    if (res.status === 429 || res.status >= 500) return null
+    data = (await res.json()) as LookupResponse
+  } catch {
+    return null // network throw / bad JSON — transient, no cache
+  }
+
+  // Caching is best-effort: a KV put failure must never lose an already-resolved id (nor turn a
+  // clean not-found into a thrown error) — the caller still gets to deliver this event.
+  if (data.ok && typeof data.user?.id === 'string') {
+    await deps.kv.put(key, data.user.id, { expirationTtl: POSITIVE_TTL }).catch(() => {})
+    return data.user.id
+  }
+  if (data.error === 'users_not_found') {
+    await deps.kv.put(key, NEGATIVE_MARKER, { expirationTtl: NEGATIVE_TTL }).catch(() => {})
+    return null
+  }
+  // invalid_auth, other errors, or ok-but-no-id → transient/unknown; return null without caching.
+  return null
+}
+
+/** The per-event context shared by every DM: the actor and the link/snippet fields. */
+export type SlackEvent = {
+  actorName: string | null
+  actorEmail: string | null
+  siteLabel: string
+  filePath: string | null
+  threadId: string | null
+  snippet: string | null
+}
+
+/** Everything the message text needs: the per-event context (SlackEvent) plus the recipient's
+ *  `reason`, which drives the verb. `actorEmail` is the fallback when `actorName` is null; the link
+ *  fields feed notificationLink; `snippet` is the already-truncated comment body (may be null/empty). */
+export type SlackMessageInput = SlackEvent & { reason: SlackReason }
+
+// Slack mrkdwn only reserves &, <, > in message text (order matters — & first).
+const escapeSlack = (s: string): string => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+
+// The verb clause per reason (owner > participant > share precedence is decided upstream). The
+// wording is Slack-only — the in-app bell keeps its terse "commented" (no schema change).
+const VERB: Record<SlackReason, (siteLabel: string) => string> = {
+  mention: (s) => `mentioned you in a comment on ${s}`,
+  owner: (s) => `commented on your site ${s}`,
+  participant: (s) => `replied in a thread you commented on · ${s}`,
+  share: (s) => `commented on ${s}`,
+}
+
+/** Build the Slack DM text: `{actor} {verb clause}`, an optional quoted snippet line, then the
+ *  absolute deep link. Actor falls back name → email → "Someone"; the snippet is HTML-escaped and a
+ *  null/blank snippet simply drops the quote line so the message is never empty (Slack rejects an
+ *  empty `text` with no_text). */
+export function formatSlackMessage(input: SlackMessageInput, appUrl: string): string {
+  const actor = escapeSlack(input.actorName ?? input.actorEmail ?? 'Someone')
+  const link = notificationLink(appUrl, {
+    siteLabel: input.siteLabel,
+    filePath: input.filePath,
+    threadId: input.threadId,
+  })
+  const lines = [`${actor} ${VERB[input.reason](escapeSlack(input.siteLabel))}`]
+  const snippet = input.snippet ? escapeSlack(input.snippet).trim() : ''
+  if (snippet) lines.push(`> ${snippet}`)
+  lines.push(link)
+  return lines.join('\n')
+}
+
+const POST_URL = 'https://slack.com/api/chat.postMessage'
+// Slack DMs per comment event, mentions first. Bounds the blast radius of a wide @-everyone or a
+// large shared audience — the same cap the in-app fan-out already lives under.
+const MAX_DMS_PER_EVENT = 15
+
+/** A resolved delivery target: the D1 recipient id, their email (for the Slack lookup — null when
+ *  unknown), and why they're being notified (drives the verb + mention priority). */
+export type SlackRecipient = { id: string; email: string | null; reason: SlackReason }
+
+/** deliverSlack's deps: the HTTP/KV handles plus the absolute-link base. */
+export type SlackDeps = SlackHttpDeps & { appUrl: string }
+
+/** Mentions first (priority, NOT array order), de-duplicated by recipient id (mention wins the tie),
+ *  then truncated to the per-event cap. */
+function capMentionFirst(recipients: SlackRecipient[]): SlackRecipient[] {
+  const ordered = [
+    ...recipients.filter((r) => r.reason === 'mention'),
+    ...recipients.filter((r) => r.reason !== 'mention'),
+  ]
+  const seen = new Set<string>()
+  const deduped = ordered.filter((r) => {
+    if (seen.has(r.id)) return false
+    seen.add(r.id)
+    return true
+  })
+  return deduped.slice(0, MAX_DMS_PER_EVENT)
+}
+
+/** Fan one comment event out to Slack DMs. Token absent/blank → no-op on line one (0 KV, 0 HTTP),
+ *  so the whole feature is inert without a bot token — this MUST stay first (the test harness awaits
+ *  fireAndForget inline). Otherwise mention-first cap 15, then per recipient: skip if no email,
+ *  resolve the Slack id (skip if unresolvable), post sequentially — EACH in its own try/catch so one
+ *  failure (429/5xx/{ok:false}/network throw) skips just that recipient and never aborts the fan-out
+ *  or surfaces to the caller. Never throws. */
+export async function deliverSlack(deps: SlackDeps, event: SlackEvent, recipients: SlackRecipient[]): Promise<void> {
+  if (!deps.token || deps.token.trim() === '') return
+  const fetchImpl = deps.fetchImpl ?? globalThis.fetch
+  for (const r of capMentionFirst(recipients)) {
+    try {
+      if (!r.email) continue
+      const channel = await lookupSlackId(deps, r.email)
+      if (!channel) continue
+      const text = formatSlackMessage({ ...event, reason: r.reason }, deps.appUrl)
+      // Best-effort post: every non-success outcome (429/5xx or an ok:false body) means "this DM
+      // didn't land" — there's nothing to retry and nothing to do differently, so we just move on.
+      // A network throw lands in the catch below. Neither ever aborts the remaining recipients.
+      await fetchImpl(POST_URL, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${deps.token}`, 'Content-Type': 'application/json; charset=utf-8' },
+        body: JSON.stringify({ channel, text }),
+      })
+    } catch {
+      // Per-recipient isolation — swallow so one bad DM never fails the comment that already committed.
+    }
+  }
+}

--- a/packages/api/src/routes/comments-slack.test.ts
+++ b/packages/api/src/routes/comments-slack.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, test } from 'bun:test'
+import { listNotifications, usersEmailsByIds } from '../db/notifications'
+import { APP_URL, auth, makeRouteApp, mintUser } from '../test/route-fixtures'
+import { countingKv, makeDb, seedSite, seedSpace, seedUser } from '../test/harness'
+import type { AppEnv } from '../types'
+
+// Route-level Slack delivery: comment POST → notifyForComment → deliverSlack, exercised through
+// app.request with an injected SLACK_FETCH (env DI seam) so we capture chat.postMessage / lookup
+// HTTP without touching global fetch. In app.request there is no executionCtx, so fireAndForget
+// awaits inline — the fan-out is complete when the response resolves.
+
+type PostBody = { channel: string; text: string }
+const isLookup = (url: string) => url.includes('users.lookupByEmail')
+const isPost = (url: string) => url.includes('chat.postMessage')
+const bodyOf = (init?: RequestInit): PostBody => JSON.parse(String(init?.body))
+
+/** A recording SLACK_FETCH: `lookups` maps email→id (returns users_not_found otherwise); `onPost`
+ *  can override the postMessage response (throw / 429 / etc). Records every posted body. */
+function slackFetch(opts: {
+  lookups?: Record<string, string>
+  onPost?: (n: number) => Response
+} = {}) {
+  const posts: PostBody[] = []
+  const lookupCalls: string[] = []
+  let n = 0
+  const fetchImpl = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input.toString()
+    if (isLookup(url)) {
+      const email = decodeURIComponent(new URL(url).searchParams.get('email') ?? '')
+      lookupCalls.push(email)
+      const id = opts.lookups?.[email]
+      return id ? Response.json({ ok: true, user: { id } }) : Response.json({ ok: false, error: 'users_not_found' })
+    }
+    if (isPost(url)) {
+      n += 1
+      if (opts.onPost) {
+        const r = opts.onPost(n) // may throw
+        posts.push(bodyOf(init))
+        return r
+      }
+      posts.push(bodyOf(init))
+      return Response.json({ ok: true })
+    }
+    throw new Error(`unexpected slack url: ${url}`)
+  }) as unknown as typeof fetch
+  return { fetchImpl, posts, lookupCalls }
+}
+
+/** Seed an owner + team site + a commenter session; return the app, env-builder, and ids. */
+async function seedCommentApp(opts: { ownerEmail: string; commenterEmail: string }) {
+  const route = makeRouteApp()
+  const owner = await seedUser(route.db, { id: 'owner', email: opts.ownerEmail })
+  const commenter = await mintUser(route.db, route.kv, 'commenter', { email: opts.commenterEmail })
+  const spaceId = await seedSpace(route.db, { createdBy: owner, slug: 'acme' })
+  await seedSite(route.db, { id: 'site-1', spaceId, ownerId: owner, slug: 'doc', visibility: 'team' })
+  return { ...route, owner, commenter }
+}
+
+const bindings = (env: AppEnv['Bindings'], extra: Record<string, unknown>) =>
+  ({ ...env, ...extra }) as unknown as AppEnv['Bindings']
+
+const postComment = (app: ReturnType<typeof makeRouteApp>['app'], env: AppEnv['Bindings'], body: unknown) =>
+  app.request(
+    '/api/sites/acme/doc/comments',
+    { method: 'POST', headers: auth('commenter'), body: JSON.stringify(body) },
+    env,
+  )
+
+describe('W — comment route fans out to Slack', () => {
+  test('W1: comment on an owned team site → one post to the cached owner id, owner verb + snippet + link', async () => {
+    const { app, env, kv } = await seedCommentApp({ ownerEmail: 'owner@x.com', commenterEmail: 'c@x.com' })
+    await kv.put('slackuid:owner@x.com', 'Uowner')
+    const { fetchImpl, posts, lookupCalls } = slackFetch()
+    const res = await postComment(app, bindings(env, { SLACK_BOT_TOKEN: 'xoxb', SLACK_FETCH: fetchImpl }), {
+      body: 'hello world',
+      filePath: 'index.html',
+    })
+    expect(res.status).toBe(201)
+    expect(lookupCalls).toHaveLength(0) // owner was cached
+    expect(posts).toHaveLength(1)
+    expect(posts[0].channel).toBe('Uowner')
+    expect(posts[0].text).toContain('commented on your site acme/doc')
+    expect(posts[0].text).toContain('hello world')
+    expect(posts[0].text).toContain(`${APP_URL}/acme/doc/index.html?thread=`)
+    expect(posts[0].text).toContain('review=1')
+  })
+
+  test('W2: 1 mention + 1 comment recipient → 2 posts, mention body first', async () => {
+    const { app, env, db, kv } = await seedCommentApp({ ownerEmail: 'owner@x.com', commenterEmail: 'c@x.com' })
+    const mentioned = await seedUser(db, { id: 'mtn', email: 'mtn@x.com' })
+    await kv.put('slackuid:owner@x.com', 'Uowner')
+    await kv.put('slackuid:mtn@x.com', 'Umtn')
+    const { fetchImpl, posts } = slackFetch()
+    const res = await postComment(app, bindings(env, { SLACK_BOT_TOKEN: 'xoxb', SLACK_FETCH: fetchImpl }), {
+      body: 'ping',
+      filePath: 'index.html',
+      mentions: [mentioned],
+    })
+    expect(res.status).toBe(201)
+    expect(posts).toHaveLength(2)
+    expect(posts[0].channel).toBe('Umtn') // mention first
+    expect(posts[0].text).toContain('mentioned you in a comment on')
+    expect(posts[1].channel).toBe('Uowner')
+  })
+
+  test('W6: actor self-mention gets no DM; another recipient still does', async () => {
+    const { app, env, kv } = await seedCommentApp({ ownerEmail: 'owner@x.com', commenterEmail: 'c@x.com' })
+    await kv.put('slackuid:owner@x.com', 'Uowner')
+    await kv.put('slackuid:c@x.com', 'Ucommenter') // cached, to prove exclusion is by logic
+    const { fetchImpl, posts } = slackFetch()
+    const res = await postComment(app, bindings(env, { SLACK_BOT_TOKEN: 'xoxb', SLACK_FETCH: fetchImpl }), {
+      body: 'note to self',
+      filePath: 'index.html',
+      mentions: ['commenter'], // the actor mentions themselves
+    })
+    expect(res.status).toBe(201)
+    expect(posts.map((p) => p.channel)).not.toContain('Ucommenter')
+    expect(posts.map((p) => p.channel)).toContain('Uowner')
+  })
+
+  test('token unset → zero Slack HTTP even with recipients present', async () => {
+    const { app, env, kv } = await seedCommentApp({ ownerEmail: 'owner@x.com', commenterEmail: 'c@x.com' })
+    await kv.put('slackuid:owner@x.com', 'Uowner')
+    const { fetchImpl, posts, lookupCalls } = slackFetch()
+    const res = await postComment(app, bindings(env, { SLACK_FETCH: fetchImpl }), {
+      body: 'hi',
+      filePath: 'index.html',
+    })
+    expect(res.status).toBe(201)
+    expect(posts).toHaveLength(0)
+    expect(lookupCalls).toHaveLength(0)
+  })
+})
+
+describe('W/R — a Slack fault never touches the comment', () => {
+  test('W4: a mid-fan-out post throw → comment still 201, in-app rows kept, earlier posts survive', async () => {
+    const { app, env, db, kv, owner } = await seedCommentApp({ ownerEmail: 'owner@x.com', commenterEmail: 'c@x.com' })
+    const mentioned = await seedUser(db, { id: 'mtn', email: 'mtn@x.com' })
+    await kv.put('slackuid:owner@x.com', 'Uowner')
+    await kv.put('slackuid:mtn@x.com', 'Umtn')
+    const { fetchImpl, posts } = slackFetch({
+      onPost: (n) => {
+        if (n === 2) throw new Error('slack down')
+        return Response.json({ ok: true })
+      },
+    })
+    const res = await postComment(app, bindings(env, { SLACK_BOT_TOKEN: 'xoxb', SLACK_FETCH: fetchImpl }), {
+      body: 'ping',
+      filePath: 'index.html',
+      mentions: [mentioned],
+    })
+    expect(res.status).toBe(201) // request never rejects
+    expect(posts).toHaveLength(1) // first (mention) succeeded; second threw and was skipped
+    const inApp = await listNotifications(db, owner)
+    expect(inApp.items.length).toBeGreaterThanOrEqual(1) // in-app fan-out committed before Slack
+  })
+
+  test('R1: a 429 + Retry-After on the post → 201, no poisoned cache', async () => {
+    const { app, env, kv } = await seedCommentApp({ ownerEmail: 'owner@x.com', commenterEmail: 'c@x.com' })
+    await kv.put('slackuid:owner@x.com', 'Uowner')
+    const { fetchImpl, posts } = slackFetch({
+      onPost: () => new Response('', { status: 429, headers: { 'Retry-After': '30' } }),
+    })
+    const res = await postComment(app, bindings(env, { SLACK_BOT_TOKEN: 'xoxb', SLACK_FETCH: fetchImpl }), {
+      body: 'hi',
+      filePath: 'index.html',
+    })
+    expect(res.status).toBe(201)
+    expect(posts).toHaveLength(1) // the attempt happened
+    expect(kv.store.get('slackuid:owner@x.com')).toBe('Uowner') // 429 on POST never touches the lookup cache
+  })
+
+  test('R2: a KV cache-put failure after a live lookup still delivers the DM', async () => {
+    const { app, env, kv } = await seedCommentApp({ ownerEmail: 'owner@x.com', commenterEmail: 'c@x.com' })
+    const sessions = countingKv(kv) // wrap the route's KV (the F4 caller)
+    sessions.failNextPut(new Error('kv down')) // the next put is the slackuid cache write
+    const { fetchImpl, posts } = slackFetch({ lookups: { 'owner@x.com': 'Uowner' } }) // NOT pre-cached → live lookup
+    const res = await postComment(
+      app,
+      bindings(env, { SLACK_BOT_TOKEN: 'xoxb', SLACK_FETCH: fetchImpl, GLANCE_SESSIONS: sessions }),
+      { body: 'hi', filePath: 'index.html' },
+    )
+    expect(res.status).toBe(201)
+    expect(posts).toHaveLength(1)
+    expect(posts[0].channel).toBe('Uowner')
+  })
+})
+
+describe('W5 — email hydration chunks at the D1 IN limit', () => {
+  test('91 ids → 2 IN-chunk statements in one batch, exact id→email map', async () => {
+    const db = makeDb()
+    const ids: string[] = []
+    for (let i = 0; i < 91; i++) ids.push(await seedUser(db, { id: `u${i}`, email: `u${i}@x.com` }))
+    db.resetCounters()
+    const map = await usersEmailsByIds(db, ids)
+    expect(map.size).toBe(91)
+    expect(map.get('u0')).toBe('u0@x.com')
+    expect(map.get('u90')).toBe('u90@x.com')
+    expect(db.counters.batches).toBe(1)
+    expect(db.counters.batchStmts).toBe(2) // ceil(91 / 90) = 2 chunks
+  })
+})

--- a/packages/api/src/routes/comments.ts
+++ b/packages/api/src/routes/comments.ts
@@ -16,7 +16,13 @@ import {
   threadsWithUsersBySlugsStmt,
 } from '../db/comments'
 import { truncateSnippet } from '../db/comment-feed'
-import { createNotifications, type NotificationInput, resolveCommentAudience } from '../db/notifications'
+import {
+  createNotifications,
+  type NotificationInput,
+  resolveCommentAudience,
+  usersEmailsByIds,
+} from '../db/notifications'
+import { deliverSlack, type SlackReason, type SlackRecipient, slackDepsFromEnv, slackEnabled } from '../lib/slack'
 import type { Comment, CommentThread } from '../db/schema'
 import { listMentionableUsers } from '../db/repo'
 import { fireAndForget } from '../lib/events'
@@ -196,6 +202,14 @@ async function notifyForComment(
         })
         if (mentionRecipients.length === 0 && commentRecipients.length === 0) return
 
+        // ONE reason-tagged audience (mentions first) drives BOTH the in-app rows and the Slack
+        // fan-out — resolved once, never re-combined. SlackReason ⊇ CommentAudienceReason, so the
+        // comment recipients spread in unchanged.
+        const audience: Array<{ id: string; reason: SlackReason }> = [
+          ...mentionRecipients.map((id) => ({ id, reason: 'mention' as const })),
+          ...commentRecipients,
+        ]
+
         const snippet = truncateSnippet(opts.snippet)
         const toRow = (recipientId: string, type: NotificationInput['type']): NotificationInput => ({
           recipientId,
@@ -208,15 +222,48 @@ async function notifyForComment(
           filePath: opts.filePath,
           snippet,
         })
-        await createNotifications(db, [
-          ...mentionRecipients.map((id) => toRow(id, 'mention')),
-          ...commentRecipients.map((id) => toRow(id, 'comment')),
-        ])
+        // The D1 row type is only 'mention' | 'comment'; the finer owner/participant/share reason
+        // rides the Slack recipient list only (no migration).
+        await createNotifications(
+          db,
+          audience.map((a) => toRow(a.id, a.reason === 'mention' ? 'mention' : 'comment')),
+        )
+
+        await deliverSlackForComment(c, audience, {
+          siteLabel,
+          filePath: opts.filePath,
+          threadId: opts.threadId,
+          snippet,
+        })
       } catch {
         // Notifications are best-effort — never surface to the caller (mirrors recordEvent).
       }
     })(),
   )
+}
+
+/** Best-effort Slack DM fan-out for a just-notified comment, over the SAME reason-tagged audience
+ *  the in-app rows used (no re-resolve). Gated on the token kill-switch — when Slack is off it does
+ *  ZERO extra D1/HTTP (deliverSlack's line-one no-op is the backstop). Owns its try/catch so a Slack
+ *  fault stays isolated from the notification write that already committed; never throws. */
+async function deliverSlackForComment(
+  c: Context<AppEnv>,
+  audience: Array<{ id: string; reason: SlackReason }>,
+  event: { siteLabel: string; filePath: string; threadId: string; snippet: string },
+): Promise<void> {
+  if (!slackEnabled(c.env.SLACK_BOT_TOKEN)) return
+  try {
+    const db = c.get('db')
+    const actor = c.get('user')
+    // One uniform chunked hydration over every recipient id. listMentionableUsers already fetched
+    // emails for the mention subset, but a single lookup over the whole audience is simpler than
+    // merging two email sources — a deliberate simplicity trade for a handful of avoidable reads.
+    const emails = await usersEmailsByIds(db, [...new Set(audience.map((a) => a.id))])
+    const recipients: SlackRecipient[] = audience.map((a) => ({ ...a, email: emails.get(a.id) ?? null }))
+    await deliverSlack(slackDepsFromEnv(c.env), { actorName: actor.name, actorEmail: actor.email, ...event }, recipients)
+  } catch {
+    // Slack delivery is best-effort and isolated — a fault here never fails the comment.
+  }
 }
 
 function notifyThreadCreated(

--- a/packages/api/src/test/harness.ts
+++ b/packages/api/src/test/harness.ts
@@ -462,6 +462,41 @@ export function makeKv() {
   }
 }
 
+/** Wrap a KV mock (default a fresh `makeKv()`) to COUNT get/put/delete ops — `makeKv` exposes
+ *  store/ttls but no counters, and specs like "token absent → zero KV ops" or "cache hit → no
+ *  put" need the count. `failNextPut(err)` makes exactly the next put reject (the op is still
+ *  counted — it was issued, it just failed), proving a KV put failure doesn't abort delivery.
+ *  Re-exposes the inner `store`/`ttls` so ttl assertions keep working. */
+export function countingKv(inner = makeKv()) {
+  const ops = { get: 0, put: 0, delete: 0 }
+  let nextPutError: unknown = null
+  return {
+    get: (key: string) => {
+      ops.get++
+      return inner.get(key)
+    },
+    put: (key: string, value: string, options?: { expirationTtl?: number }) => {
+      ops.put++
+      if (nextPutError != null) {
+        const err = nextPutError
+        nextPutError = null
+        return Promise.reject(err)
+      }
+      return inner.put(key, value, options)
+    },
+    delete: (key: string) => {
+      ops.delete++
+      return inner.delete(key)
+    },
+    store: inner.store,
+    ttls: inner.ttls,
+    ops: () => ({ ...ops }),
+    failNextPut(err: unknown) {
+      nextPutError = err
+    },
+  }
+}
+
 /** R2's 3 range shapes (`{offset, length?}` / `{offset?, length}` / `{suffix}`), sliced on
  *  BYTES. `size` on the returned object is always the FULL object size — matching real R2
  *  (`R2Object.size` is unaffected by the requested range) — so callers must slice the body,

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -28,6 +28,10 @@ export interface Bindings {
   // Optional Slack bot token (xoxb-…). Unset = kill-switch: comment notifications never fan out to
   // Slack (deliverSlack no-ops on line one). Set via `wrangler secret put SLACK_BOT_TOKEN`.
   SLACK_BOT_TOKEN?: string
+  // DI seam for Slack HTTP (mirrors summarize's injected fetchImpl): route tests set a fake fetch on
+  // env to capture users.lookupByEmail / chat.postMessage without touching global fetch. Never set in
+  // prod — unset → deliverSlack falls back to globalThis.fetch.
+  SLACK_FETCH?: typeof fetch
   SESSION_SECRET: string
   CONTENT_TOKEN_SECRET: string
   // Optional: separate HMAC secret for the shared-backend data-plane tokens (glance.db SDK).

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -25,6 +25,9 @@ export interface Bindings {
   GOOGLE_CLIENT_SECRET?: string
   // Optional one-shot secret gating first-superadmin bootstrap. Unset → bootstrap inert (404).
   BOOTSTRAP_TOKEN?: string
+  // Optional Slack bot token (xoxb-…). Unset = kill-switch: comment notifications never fan out to
+  // Slack (deliverSlack no-ops on line one). Set via `wrangler secret put SLACK_BOT_TOKEN`.
+  SLACK_BOT_TOKEN?: string
   SESSION_SECRET: string
   CONTENT_TOKEN_SECRET: string
   // Optional: separate HMAC secret for the shared-backend data-plane tokens (glance.db SDK).


### PR DESCRIPTION
Mirror the shipped in-app comment notifications as Slack DMs. Slack is a **delivery channel over the existing seam** — every DM mirrors a D1 row `notifyForComment` already writes. No new recipient logic, no schema change, no cross-package import.

## What
- **`lib/slack.ts`** (pure, dependency-injected): `lookupSlackId` (KV-cached email→Slack-id; positive ~30d, `users_not_found` ~1h, transient/`invalid_auth`/429 → null with no cache), `formatSlackMessage` (verb by reason, escaped snippet, absolute deep link), `deliverSlack` (token no-op on line one, mention-first cap 15, sequential post with per-recipient isolation).
- **`lib/notification-link.ts`**: absolute deep-link, a mirror of web's `notificationHref` (packages don't cross-import).
- **`resolveCommentAudience` → `{id, reason}[]`** (owner > participant > share precedence) from the sets it already computes — no new query. D1 rows stay `type='comment'` (no migration); the reason rides the Slack list only.
- **Wiring** in `notifyForComment`: one reason-tagged audience drives both the in-app rows and the Slack fan-out; `usersEmailsByIds` hydrates emails in D1_MAX_IN chunks; `deliverSlackForComment` is token-gated and isolated in its own try/catch.

## Kill-switch
`SLACK_BOT_TOKEN` is the on/off. Unset/blank → `slackEnabled()` is false at both the route gate and `deliverSlack`'s no-op, so comment flows do zero extra D1/HTTP (the whole existing suite stays green without a token). Scopes: `chat:write · users:read · users:read.email`. See DEPLOY.md.

## Tests
New: `slack.test.ts`, `notification-link.test.ts`, route-level `comments-slack.test.ts` (W1–W6, R1–R2 via a `SLACK_FETCH` DI seam). Full suite green (api 762 / web 175, 0 fail). Every phase passed a simplify → verify → thermo gate.

## Follow-up
Live-workspace DM smoke confirms whether a first DM by user-id needs `im:write`/`conversations.open` before `chat.postMessage` (both consults said user-id-as-channel works directly; unconfirmed live).

🤖 Generated with [Claude Code](https://claude.com/claude-code)