### PR TITLE
Slack DM: bold author + hyperlinked site, italic comment

### DIFF
--- a/packages/api/src/lib/slack.test.ts
+++ b/packages/api/src/lib/slack.test.ts
@@ -100,39 +100,45 @@ describe('formatSlackMessage', () => {
     threadId: 't1',
   } as const
 
-  test('V1: reason=owner says "your site"; reason=share does not', () => {
+  test('V1: owner verb + bold hyperlinked site; share omits "your site"', () => {
     const owner = formatSlackMessage({ ...base, reason: 'owner', snippet: 'hi' }, appUrl)
-    expect(owner).toContain('commented on your site design/q3-dashboard')
+    expect(owner).toContain('commented on your site *<') // verb + bold link opener
+    expect(owner).toContain('|design/q3-dashboard>*') // site label is the bold hyperlink text
     const share = formatSlackMessage({ ...base, reason: 'share', snippet: 'hi' }, appUrl)
-    expect(share).toContain('commented on design/q3-dashboard')
+    expect(share).toContain('commented on *<')
     expect(share).not.toContain('your site')
   })
 
-  test('V2: participant verb + thread= in link; mention verb', () => {
+  test('V2: participant verb + thread= in the site link; mention verb', () => {
     const p = formatSlackMessage({ ...base, reason: 'participant', snippet: 'hi' }, appUrl)
     expect(p).toContain('replied in a thread you commented on')
-    expect(p).toContain('thread=t1')
+    expect(p).toContain('thread=t1') // rides the hyperlink URL
     const m = formatSlackMessage({ ...base, reason: 'mention', snippet: 'hi' }, appUrl)
     expect(m).toContain('mentioned you in a comment on')
   })
 
-  test('S7: null actorName → email fallback; snippet escapes &/</>; empty/null snippet stays non-empty', () => {
+  test('S7: null actorName → bold email fallback; snippet is italic + escaped; empty/null snippet stays non-empty', () => {
     const withEmail = formatSlackMessage({ ...base, actorName: null, reason: 'share', snippet: 'a & b < c > d' }, appUrl)
-    expect(withEmail).toContain('ravi@plivo.com')
-    expect(withEmail).toContain('a &amp; b &lt; c &gt; d')
+    expect(withEmail).toContain('*ravi@plivo.com*') // bold actor from the email fallback
+    expect(withEmail).toContain('> _a &amp; b &lt; c &gt; d_') // block-quoted, italic, escaped
 
     const empty = formatSlackMessage({ ...base, reason: 'share', snippet: '' }, appUrl)
     expect(empty.trim().length).toBeGreaterThan(0)
     expect(empty).toContain('commented on')
+    expect(empty).not.toContain('\n>') // no quote line when the snippet is blank
 
     const nullSnippet = formatSlackMessage({ ...base, reason: 'share', snippet: null }, appUrl)
     expect(nullSnippet.trim().length).toBeGreaterThan(0)
   })
 
-  test('actor name preferred over email; message carries the absolute deep link', () => {
+  test('actor is bold; the site label hyperlinks to the absolute deep link, with no trailing raw URL', () => {
     const msg = formatSlackMessage({ ...base, reason: 'mention', snippet: 'hey' }, appUrl)
-    expect(msg).toContain('Ravi Anand')
-    expect(msg).toContain('https://glance.example.com/design/q3-dashboard/q3.html?thread=t1&review=1')
+    expect(msg).toContain('*Ravi Anand*')
+    // the deep link rides the site label as a bold hyperlink (& entity-escaped per Slack)
+    expect(msg).toContain(
+      '*<https://glance.example.com/design/q3-dashboard/q3.html?thread=t1&amp;review=1|design/q3-dashboard>*',
+    )
+    expect(msg.split('\n')).toHaveLength(2) // verb line + quote; no separate URL line
   })
 })
 
@@ -180,9 +186,10 @@ describe('deliverSlack', () => {
     expect(posts[0].url).toContain('chat.postMessage')
     const body = postBody(posts[0].init)
     expect(body.channel).toBe('Uowner')
-    expect(body.text).toContain('commented on your site design/q3-dashboard')
-    expect(body.text).toContain('take a look')
-    expect(body.text).toContain('https://glance.example.com/design/q3-dashboard/q3.html?thread=t1&review=1')
+    expect(body.text).toContain('commented on your site *<')
+    expect(body.text).toContain('|design/q3-dashboard>*')
+    expect(body.text).toContain('> _take a look_')
+    expect(body.text).toContain('thread=t1&amp;review=1')
   })
 
   test('cap 15, mention-first regardless of array order (10 mention + 10 comment, comment-first)', async () => {

--- a/packages/api/src/lib/slack.ts
+++ b/packages/api/src/lib/slack.ts
@@ -101,21 +101,24 @@ const VERB: Record<SlackReason, (siteLabel: string) => string> = {
   share: (s) => `commented on ${s}`,
 }
 
-/** Build the Slack DM text: `{actor} {verb clause}`, an optional quoted snippet line, then the
- *  absolute deep link. Actor falls back name → email → "Someone"; the snippet is HTML-escaped and a
- *  null/blank snippet simply drops the quote line so the message is never empty (Slack rejects an
- *  empty `text` with no_text). */
+/** Build the Slack DM text: `*{actor}* {verb clause}` where the site label is a BOLD hyperlink
+ *  (`<url|label>`) to the review thread, then an optional italic block-quoted snippet. Actor falls
+ *  back name → email → "Someone"; snippet is HTML-escaped and a null/blank snippet drops the quote
+ *  line so the message is never empty (Slack rejects an empty `text` with no_text). The deep link
+ *  rides the site label — no trailing raw URL. */
 export function formatSlackMessage(input: SlackMessageInput, appUrl: string): string {
-  const actor = escapeSlack(input.actorName ?? input.actorEmail ?? 'Someone')
-  const link = notificationLink(appUrl, {
+  const actor = `*${escapeSlack(input.actorName ?? input.actorEmail ?? 'Someone')}*`
+  const url = notificationLink(appUrl, {
     siteLabel: input.siteLabel,
     filePath: input.filePath,
     threadId: input.threadId,
   })
-  const lines = [`${actor} ${VERB[input.reason](escapeSlack(input.siteLabel))}`]
+  // Site label as a bold Slack hyperlink. Slack link syntax is <url|text>; the & in the query string
+  // must be entity-escaped even inside the URL (Slack's mrkdwn escaping rule).
+  const site = `*<${url.replace(/&/g, '&amp;')}|${escapeSlack(input.siteLabel)}>*`
+  const lines = [`${actor} ${VERB[input.reason](site)}`]
   const snippet = input.snippet ? escapeSlack(input.snippet).trim() : ''
-  if (snippet) lines.push(`> ${snippet}`)
-  lines.push(link)
+  if (snippet) lines.push(`> _${snippet}_`) // block-quoted + italic
   return lines.join('\n')
 }
 

--- a/packages/api/src/routes/comments-slack.test.ts
+++ b/packages/api/src/routes/comments-slack.test.ts
@@ -79,10 +79,11 @@ describe('W — comment route fans out to Slack', () => {
     expect(lookupCalls).toHaveLength(0) // owner was cached
     expect(posts).toHaveLength(1)
     expect(posts[0].channel).toBe('Uowner')
-    expect(posts[0].text).toContain('commented on your site acme/doc')
-    expect(posts[0].text).toContain('hello world')
+    expect(posts[0].text).toContain('commented on your site *<') // bold hyperlinked site
+    expect(posts[0].text).toContain('|acme/doc>*')
+    expect(posts[0].text).toContain('> _hello world_') // italic quoted comment
     expect(posts[0].text).toContain(`${APP_URL}/acme/doc/index.html?thread=`)
-    expect(posts[0].text).toContain('review=1')
+    expect(posts[0].text).toContain('&amp;review=1')
   })
 
   test('W2: 1 mention + 1 comment recipient → 2 posts, mention body first', async () => {


### PR DESCRIPTION
Formatting polish on the comment DM (follow-up to #60), from live feedback:

- **Author name** bold — `*Plivo CX*`
- **Site label** is now a **bold hyperlink** to the review thread (`*<url|space/slug>*`) — replaces the trailing raw URL line
- **Comment** rendered as an italic block-quote — `> _…_`

Before:
```
Plivo CX commented on your site samuel-lawerence/slack-notifications-progress
| Checking comments functionality
https://glance.plivo.com/…/PROGRESS.html?thread=…&review=1
```
After:
```
*Plivo CX* commented on your site *<https://…?thread=…&amp;review=1|samuel-lawerence/slack-notifications-progress>*
> _Checking comments functionality_
```

The `&` in the link URL is entity-escaped (`&amp;`) per Slack's mrkdwn rule for `<url|text>`. Tests updated (format assertions in `slack.test.ts` + `comments-slack.test.ts`); full suite green (api 762 / web 175).

🤖 Generated with [Claude Code](https://claude.com/claude-code)