### PR TITLE
Order Team activity feed by last content activity

### DIFF
--- a/packages/api/drizzle/0017_site_updated_at.sql
+++ b/packages/api/drizzle/0017_site_updated_at.sql
@@ -1,0 +1,7 @@
+-- "Last activity" timestamp for the Team activity feed: set on create + re-stamped on every content
+-- REPLACE (upload.ts) so a re-deployed site bubbles back to the top instead of staying frozen at its
+-- creation slot. Plain ADD COLUMN (nullable, no table rebuild), then backfill every existing row to
+-- its createdAt so the first sort is stable. New rows get it from the schema $defaultFn; the replace
+-- path stamps the current time. Content-only — renames/moves/visibility changes never touch it.
+ALTER TABLE `sites` ADD COLUMN `updatedAt` text;--> statement-breakpoint
+UPDATE `sites` SET `updatedAt` = `createdAt` WHERE `updatedAt` IS NULL;

--- a/packages/api/drizzle/meta/_journal.json
+++ b/packages/api/drizzle/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1784221237892,
       "tag": "0016_notifications_comment_index",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "6",
+      "when": 1784300000000,
+      "tag": "0017_site_updated_at",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/src/db/schema.ts
+++ b/packages/api/src/db/schema.ts
@@ -59,6 +59,10 @@ export const sites = sqliteTable(
     // source may only drop the link, never the content.
     forkedFrom: text('forkedFrom').references((): AnySQLiteColumn => sites.id, { onDelete: 'set null' }),
     createdAt: text('createdAt').notNull().$defaultFn(() => new Date().toISOString()),
+    // Last content-activity timestamp: set on create, re-stamped on every REPLACE (upload.ts), so a
+    // re-deployed site bubbles back to the top of the Team activity feed (createdAt alone froze a busy
+    // site at its creation slot). Renames/moves/visibility changes do NOT bump it — content only.
+    updatedAt: text('updatedAt').notNull().$defaultFn(() => new Date().toISOString()),
   },
   (t) => [unique('sites_space_slug_unq').on(t.spaceId, t.slug), index('sites_owner').on(t.ownerId)],
 )

--- a/packages/api/src/lib/site-feed.ts
+++ b/packages/api/src/lib/site-feed.ts
@@ -12,6 +12,7 @@ export function siteFeedColumns() {
     visibility: sites.visibility,
     status: sites.status,
     createdAt: sites.createdAt,
+    updatedAt: sites.updatedAt,
     audio: pureAudioSql(sites.id),
     hasSummary: hasSummarySql(sites.id),
   }
@@ -25,6 +26,7 @@ type FeedSourceRow = {
   visibility: Visibility
   status: 'active' | 'archived'
   createdAt: string
+  updatedAt: string
   audio: number
   hasSummary: number
 }
@@ -41,5 +43,6 @@ export function toFeedRow(row: FeedSourceRow, appUrl: string) {
     hasSummary: row.hasSummary === 1,
     url: `${appUrl}/${row.spaceSlug}/${row.slug}`,
     createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
   }
 }

--- a/packages/api/src/routes/sites-feeds.test.ts
+++ b/packages/api/src/routes/sites-feeds.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test'
 import type { Hono } from 'hono'
-import { siteSummaries } from '../db/schema'
+import { eq } from 'drizzle-orm'
+import { sites, siteSummaries } from '../db/schema'
 import { seedFile, seedMember, seedSite, seedSpace, seedUserShare } from '../test/harness'
 import { APP_URL, at, auth, makeRouteApp, mintUser, postAuthRequests, type RouteApp } from '../test/route-fixtures'
 import type { AppEnv } from '../types'
@@ -58,6 +59,7 @@ describe('C31 — site feed characterization before summary badge', () => {
         hasSummary: false,
         url: `${APP_URL}/acme/voice`,
         createdAt: at(7),
+        updatedAt: at(7),
       },
     ])
     expect(postAuthRequests(db)).toBe(1)
@@ -76,6 +78,7 @@ describe('C31 — site feed characterization before summary badge', () => {
         role: 'editor',
         url: `${APP_URL}/acme/voice`,
         createdAt: at(7),
+        updatedAt: at(7),
       },
     ])
     expect(postAuthRequests(db)).toBeLessThanOrEqual(2)
@@ -93,6 +96,7 @@ describe('C31 — site feed characterization before summary badge', () => {
         hasSummary: false,
         url: `${APP_URL}/acme/voice`,
         createdAt: at(7),
+        updatedAt: at(7),
         uploaderName: null,
         uploaderEmail: 'owner@e.com',
       },
@@ -113,6 +117,7 @@ describe('C31 — site feed characterization before summary badge', () => {
         hasSummary: false,
         url: `${APP_URL}/acme/voice`,
         createdAt: at(7),
+        updatedAt: at(7),
       },
     ])
     expect(postAuthRequests(db)).toBe(1)
@@ -168,8 +173,8 @@ describe('feeds — audio badge pins (S5b T5.4)', () => {
 
     // Hand-coded: one row PER SITE (30 files must not explode the feed), newest first.
     expect(await getJson(app, env, '/api/sites/mine', 'owner')).toEqual([
-      { id: 'voice', spaceSlug: 'acme', siteSlug: 'voice', title: null, visibility: 'private', status: 'active', audio: true, hasSummary: true, url: `${APP_URL}/acme/voice`, createdAt: at(2) },
-      { id: 'doc', spaceSlug: 'acme', siteSlug: 'doc', title: null, visibility: 'team', status: 'active', audio: false, hasSummary: false, url: `${APP_URL}/acme/doc`, createdAt: at(1) },
+      { id: 'voice', spaceSlug: 'acme', siteSlug: 'voice', title: null, visibility: 'private', status: 'active', audio: true, hasSummary: true, url: `${APP_URL}/acme/voice`, createdAt: at(2), updatedAt: at(2) },
+      { id: 'doc', spaceSlug: 'acme', siteSlug: 'doc', title: null, visibility: 'team', status: 'active', audio: false, hasSummary: false, url: `${APP_URL}/acme/doc`, createdAt: at(1), updatedAt: at(1) },
     ])
   })
 
@@ -189,7 +194,7 @@ describe('feeds — audio badge pins (S5b T5.4)', () => {
     // The 30-file site is pure audio; the file-less rest are not. Full payload on the head row.
     expect(rows[0]).toEqual({
       id: 's51', spaceSlug: 'acme', siteSlug: 's51', title: null, visibility: 'team', status: 'active',
-      audio: true, hasSummary: false, url: `${APP_URL}/acme/s51`, createdAt: at(51), uploaderName: null, uploaderEmail: 'owner@e.com',
+      audio: true, hasSummary: false, url: `${APP_URL}/acme/s51`, createdAt: at(51), updatedAt: at(51), uploaderName: null, uploaderEmail: 'owner@e.com',
     })
     expect(rows.slice(1).every((r) => r.audio === false)).toBe(true)
     expect(rows.every((r) => r.hasSummary === false)).toBe(true)
@@ -213,6 +218,20 @@ describe('feeds — audio badge pins (S5b T5.4)', () => {
     ]
     expect(flags(await getJson(app, env, '/api/sites/mine', 'owner'))).toEqual(expected)
     expect(flags(await getJson(app, env, '/api/sites/team', 'owner'))).toEqual(expected)
+  })
+
+  test('pin: /team orders by last activity — a re-deployed older site resurfaces above a newer one', async () => {
+    const { app, env, db } = await setup()
+    // 'old' was created before 'new', so by creation order 'new' leads.
+    await seedSite(db, { id: 'old', spaceId: 'acme', ownerId: 'owner', slug: 'old', createdAt: at(1) })
+    await seedSite(db, { id: 'new', spaceId: 'acme', ownerId: 'owner', slug: 'new', createdAt: at(2) })
+
+    const ids = (rows: TeamRow[]) => rows.map((r) => r.id)
+    expect(ids(await getJson(app, env, '/api/sites/team', 'owner'))).toEqual(['new', 'old'])
+
+    // Re-deploy 'old' (a REPLACE stamps updatedAt) — it must jump to the head of the feed.
+    await db.update(sites).set({ updatedAt: at(3) }).where(eq(sites.id, 'old'))
+    expect(ids(await getJson(app, env, '/api/sites/team', 'owner'))).toEqual(['old', 'new'])
   })
 })
 

--- a/packages/api/src/routes/sites.ts
+++ b/packages/api/src/routes/sites.ts
@@ -253,9 +253,10 @@ sites.get('/shared', requireAuth, async (c) => {
   )
 })
 
-// GET /api/sites/team — team-wide upload feed: every team site across all spaces,
-// newest first, with who uploaded it. Visible to any signed-in member (the team tier is
-// already visible team-wide). Capped — this is an at-a-glance activity feed, not a full log.
+// GET /api/sites/team — team-wide upload feed: every team site across all spaces, ordered by last
+// content activity (updatedAt = create or most-recent replace) so a re-deployed site resurfaces and
+// the feed stays live. Visible to any signed-in member (the team tier is already visible team-wide).
+// Capped — this is an at-a-glance activity feed, not a full log.
 sites.get('/team', requireAuth, async (c) => {
   const db = c.get('db')
   const rows = await db
@@ -268,7 +269,7 @@ sites.get('/team', requireAuth, async (c) => {
     .innerJoin(spaces, eq(sitesTable.spaceId, spaces.id))
     .innerJoin(users, eq(sitesTable.ownerId, users.id))
     .where(and(eq(sitesTable.status, 'active'), eq(sitesTable.visibility, 'team')))
-    .orderBy(desc(sitesTable.createdAt))
+    .orderBy(desc(sitesTable.updatedAt))
     .limit(50)
   return c.json(
     rows.map((r) => ({

--- a/packages/api/src/routes/upload.ts
+++ b/packages/api/src/routes/upload.ts
@@ -215,7 +215,7 @@ upload.post('/:spaceSlug/:siteSlug', requireAuth, async (c) => {
       // price of leaving files untouched on a stale 409, which a single atomic batch cannot express.)
       const claimed = await db
         .update(sites)
-        .set({ contentVersion: sql`${sites.contentVersion} + 1`, lastReplacedBy: user.id })
+        .set({ contentVersion: sql`${sites.contentVersion} + 1`, lastReplacedBy: user.id, updatedAt: new Date().toISOString() })
         .where(and(eq(sites.id, siteId), eq(sites.contentVersion, expectedVersion as number)))
         .returning({ id: sites.id })
       if (claimed.length === 0) {
@@ -236,6 +236,7 @@ upload.post('/:spaceSlug/:siteSlug', requireAuth, async (c) => {
           .set({
             contentVersion: sql`${sites.contentVersion} + 1`,
             lastReplacedBy: user.id,
+            updatedAt: new Date().toISOString(),
             ...(hasVisibility && isVisibility(visibility) ? { visibility } : {}),
           })
           .where(eq(sites.id, siteId)),

--- a/packages/api/src/test/harness.ts
+++ b/packages/api/src/test/harness.ts
@@ -47,6 +47,7 @@ const MIGRATIONS = [
   'drizzle/0014_site_summaries.sql',
   'drizzle/0015_notifications_comment_id.sql',
   'drizzle/0016_notifications_comment_index.sql',
+  'drizzle/0017_site_updated_at.sql',
 ]
 
 // --- S0 recorder: one shared, ordered timeline across D1/R2/cache mocks so perf specs can
@@ -314,6 +315,9 @@ export async function seedSite(
     status: o.status ?? 'active',
     // Omitted → schema $defaultFn (now). Passable so ordering specs can pin exact timelines.
     ...(o.createdAt !== undefined && { createdAt: o.createdAt }),
+    // A fresh site's updatedAt == createdAt (no replace yet); default it so createdAt-pinned ordering
+    // specs stay deterministic under the updatedAt sort. Override explicitly to simulate a replace.
+    ...(o.updatedAt !== undefined ? { updatedAt: o.updatedAt } : o.createdAt !== undefined ? { updatedAt: o.createdAt } : {}),
   })
   return id
 }

--- a/packages/web/src/components/siteColumns.tsx
+++ b/packages/web/src/components/siteColumns.tsx
@@ -99,3 +99,23 @@ export function createdColumn<T extends SiteSummary>(key = 'created', label = 'C
     ),
   }
 }
+
+// Like createdColumn but on updatedAt (last content activity) — used by the Team activity feed so a
+// re-deployed site sorts to the top. Falls back to createdAt for any legacy row without an updatedAt.
+export function updatedColumn<T extends SiteSummary>(key = 'updated', label = 'Updated'): Column<T> {
+  return {
+    key,
+    label,
+    defaultDir: 'desc',
+    compare: (a, b) => (a.updatedAt ?? a.createdAt).localeCompare(b.updatedAt ?? b.createdAt),
+    cellClassName: 'text-sm text-muted-foreground',
+    render: (s) => {
+      const when = s.updatedAt ?? s.createdAt
+      return (
+        <time dateTime={when} title={new Date(when).toLocaleString()}>
+          {timeAgo(when)}
+        </time>
+      )
+    },
+  }
+}

--- a/packages/web/src/lib/types.ts
+++ b/packages/web/src/lib/types.ts
@@ -44,6 +44,7 @@ export interface SiteSummary {
   role?: ShareRole
   url: string
   createdAt: string
+  updatedAt: string // last content activity (create or most-recent replace); drives Team activity order
 }
 
 export interface TeamUpload extends SiteSummary {

--- a/packages/web/src/routes/dashboard.tsx
+++ b/packages/web/src/routes/dashboard.tsx
@@ -20,6 +20,7 @@ import {
   createdColumn,
   nameColumn,
   OpenLinkButton,
+  updatedColumn,
   urlColumn,
   visibilityBadgeColumn,
 } from '@/components/siteColumns'
@@ -354,7 +355,8 @@ function TabCount({ n }: { n: number }) {
 
 // ─── Team activity ───────────────────────────────────────────────────────────
 
-// Same table shell, with who-shipped + when columns. Defaults to newest-first (a feed).
+// Same table shell, with who-shipped + updated columns. Orders by last content activity (updatedAt)
+// so a re-deployed site resurfaces to the top and the feed stays live.
 const who = (u: TeamUpload) => u.uploaderName ?? u.uploaderEmail
 
 const TEAM_COLUMNS: Column<TeamUpload>[] = [
@@ -368,7 +370,7 @@ const TEAM_COLUMNS: Column<TeamUpload>[] = [
     cellClassName: 'max-w-[12rem]',
     render: (u) => <span className="block truncate text-sm">{who(u)}</span>,
   },
-  createdColumn('when', 'When'),
+  updatedColumn('when', 'Updated'),
   actionsColumn((u) => <OpenLinkButton url={u.url} />),
 ]
 


### PR DESCRIPTION
## What

The **Team activity** tab sorted by `createdAt`, and `sites` had no `updatedAt` timestamp (only a `contentVersion` counter — no time). So re-deploying an existing site never moved it in the feed: a busy site stayed frozen at its creation slot and the feed went stale.

This orders the Team feed by **last content activity** so a re-deployed site resurfaces at the top and the feed stays live.

## Changes
- **`schema.ts` + migration `0017_site_updated_at.sql`** — new `sites.updatedAt` (defaults to now on create; migration backfills existing rows to their `createdAt`). Journal + test-harness `MIGRATIONS` array updated.
- **`routes/upload.ts`** — stamps `updatedAt = now` on every content REPLACE (editor-CAS + owner paths). Renames/moves/visibility changes deliberately do **not** bump it — content activity only.
- **`lib/site-feed.ts`** — exposes `updatedAt` on all feed rows.
- **`routes/sites.ts`** — `/api/sites/team` now orders by `updatedAt DESC` (only the Team feed changed).
- **web** — `SiteSummary.updatedAt`, new `updatedColumn` helper, Team table sorts/renders on it ("Updated" column).

## Testing
- `bun run test` — 763 pass, 0 fail (added a pin proving a re-deployed older site jumps above a newer one in `/team`).
- `bun run typecheck` clean; migration applies cleanly to local D1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)