### PR TITLE
Derive site title from entry HTML <title>; per-site tab title in viewer

### DIFF
--- a/packages/api/src/lib/extract.test.ts
+++ b/packages/api/src/lib/extract.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test'
-import { extractText, isSupportedEntry, pickEntry, resolveIndexPath, TEXT_CAP, type EntryFile } from './extract'
+import { extractHtmlTitle, extractText, isSupportedEntry, pickEntry, resolveIndexPath, TEXT_CAP, type EntryFile } from './extract'
 
 describe('pickEntry', () => {
   test('prefers the root index, returns a lone file, and rejects ambiguous sites', () => {
@@ -158,5 +158,64 @@ describe('extractText', () => {
       '<html><head><script>x()</script></head><body>   </body></html>',
     )
     expect(result).toEqual({ ok: false, reason: 'empty' })
+  })
+})
+
+describe('extractHtmlTitle', () => {
+  const entry = { path: 'index.html', mimeType: 'text/html' }
+
+  test('returns the document title, whitespace-collapsed and trimmed', async () => {
+    const body = '<html><head><title>  CX Team —\n  What They\'re Managing </title></head><body>x</body></html>'
+    expect(await extractHtmlTitle(entry, body)).toBe("CX Team — What They're Managing")
+  })
+
+  test('only the first <title> counts — a later inline svg title is ignored', async () => {
+    const body = '<html><head><title>Real</title></head><body><svg><title>icon label</title></svg></body></html>'
+    expect(await extractHtmlTitle(entry, body)).toBe('Real')
+  })
+
+  test('missing or empty title → null; non-HTML entry → null', async () => {
+    expect(await extractHtmlTitle(entry, '<html><body>no title</body></html>')).toBeNull()
+    expect(await extractHtmlTitle(entry, '<title>   </title>')).toBeNull()
+    expect(await extractHtmlTitle({ path: 'readme.md', mimeType: null }, '# Title')).toBeNull()
+    expect(await extractHtmlTitle({ path: 'clip.webm', mimeType: 'audio/webm' }, 'x')).toBeNull()
+  })
+
+  test('caps at 200 chars', async () => {
+    const long = 'a'.repeat(300)
+    expect(await extractHtmlTitle(entry, `<title>${long}</title>`)).toBe('a'.repeat(200))
+  })
+})
+
+describe('extractHtmlTitle — svg exclusion, implied head, entities, streaming', () => {
+  const entry = { path: 'index.html', mimeType: 'text/html' }
+
+  test('an svg title BEFORE the document title never wins; an svg-only doc yields null', async () => {
+    const before = '<svg><title>icon label</title></svg><title>Real</title>'
+    expect(await extractHtmlTitle(entry, before)).toBe('Real')
+    const svgOnly = '<html><body><svg><title>Download icon</title></svg></body></html>'
+    expect(await extractHtmlTitle(entry, svgOnly)).toBeNull()
+    const tpl = '<template><title>inert</title></template><title>Live</title>'
+    expect(await extractHtmlTitle(entry, tpl)).toBe('Live')
+  })
+
+  test('implied-head fragments (no literal <head>) still resolve their title', async () => {
+    const fragment = '<!doctype html><meta charset="utf-8"><title>Implied Head</title><style>x{}</style><h1>hi</h1>'
+    expect(await extractHtmlTitle(entry, fragment)).toBe('Implied Head')
+  })
+
+  test('decodes numeric and common named entities', async () => {
+    const body = '<title>Mentions &amp; Notifications &#8212; A&nbsp;B &#x2192; C &unknown; &#1114112;</title>'
+    expect(await extractHtmlTitle(entry, body)).toBe('Mentions & Notifications — A B → C &unknown; &#1114112;')
+  })
+
+  test('cap never leaves an unpaired surrogate', async () => {
+    const title = await extractHtmlTitle(entry, `<title>${'a'.repeat(199)}😀</title>`)
+    expect(title).toBe('a'.repeat(199))
+    expect(title).not.toMatch(/[\uD800-\uDBFF]$/)
+  })
+
+  test('accepts a Blob body (the upload path streams the File, never buffering it)', async () => {
+    expect(await extractHtmlTitle(entry, new Blob(['<title>From Blob</title>']))).toBe('From Blob')
   })
 })

--- a/packages/api/src/lib/extract.ts
+++ b/packages/api/src/lib/extract.ts
@@ -1,13 +1,20 @@
 export const TEXT_CAP = 40_000
+export const TITLE_CAP = 200
 
 export type EntryFile = { path: string; mimeType: string | null }
 export type Extracted = { ok: true; text: string; truncated: boolean } | { ok: false; reason: string }
 
-function cap(text: string): { text: string; truncated: boolean } {
-  if (text.length <= TEXT_CAP) return { text, truncated: false }
-  let capped = text.slice(0, TEXT_CAP)
+function cap(text: string, limit = TEXT_CAP): { text: string; truncated: boolean } {
+  if (text.length <= limit) return { text, truncated: false }
+  let capped = text.slice(0, limit)
   if (/[\uD800-\uDBFF]$/.test(capped)) capped = capped.slice(0, -1)
   return { text: capped, truncated: true }
+}
+
+// Surrogate-safe truncation for site titles (form-supplied or derived) — a plain slice can end on
+// an unpaired high surrogate when the boundary lands inside an emoji.
+export function capTitle(text: string): string {
+  return cap(text, TITLE_CAP).text
 }
 
 function extracted(text: string): Extracted {
@@ -32,6 +39,80 @@ export function pickEntry<T extends EntryFile>(files: T[]): T | null {
 
 export function isSupportedEntry(entry: EntryFile): boolean {
   return /\.(md|markdown)$/i.test(entry.path) || /\.html?$/i.test(entry.path) || entry.mimeType === 'text/html'
+}
+
+// HTMLRewriter text chunks carry RAW source text — entities are NOT decoded ('&amp;' arrives as
+// '&amp;'). Derived titles render as plain text in the app, so decode numeric references plus the
+// named entities that actually occur in titles; anything unknown is left as-is rather than guessed.
+const NAMED_ENTITIES: Record<string, string> = {
+  amp: '&',
+  lt: '<',
+  gt: '>',
+  quot: '"',
+  apos: "'",
+  nbsp: ' ',
+  mdash: '—',
+  ndash: '–',
+  hellip: '…',
+  middot: '·',
+  bull: '•',
+  lsquo: '‘',
+  rsquo: '’',
+  ldquo: '“',
+  rdquo: '”',
+  times: '×',
+  rarr: '→',
+  larr: '←',
+}
+
+function decodeEntities(text: string): string {
+  return text.replace(/&(?:#(\d+)|#x([0-9a-fA-F]+)|([a-zA-Z]+));/g, (match, dec, hex, name) => {
+    if (name) return NAMED_ENTITIES[name] ?? match
+    const code = dec ? Number(dec) : Number.parseInt(hex, 16)
+    return code <= 0x10ffff ? String.fromCodePoint(code) : match
+  })
+}
+
+// The entry document's <title>, for the site's display title when the uploader didn't name it.
+// HTML only — a markdown entry has no <title>. Takes the FIRST title in document order that is
+// not an <svg>/<template> accessibility/inert title. NOT `head > title`: a streaming rewriter
+// never sees an implied <head>, and headless fragments (a file starting at <style>/<h1>) are
+// common among agent-generated uploads — the bare selector plus exclusion covers both.
+// The body streams through the rewriter and only title chunks are retained, so a 20MB entry is
+// never buffered. Whitespace-collapsed, trimmed, entity-decoded, capped; empty/absent → null.
+export async function extractHtmlTitle(entry: EntryFile, body: Blob | string): Promise<string | null> {
+  if (!(/\.html?$/i.test(entry.path) || entry.mimeType === 'text/html')) return null
+  // Handlers on the same element fire in registration order, so the exclusion selectors run
+  // before the bare 'title' handler and can flag the element it is about to see.
+  let excluded = false
+  let taking = false
+  let done = false
+  const chunks: string[] = []
+  const rewriter = new HTMLRewriter()
+  for (const selector of ['svg title', 'template title']) {
+    rewriter.on(selector, {
+      element() {
+        excluded = true
+      },
+    })
+  }
+  const transformed = rewriter
+    .on('title', {
+      element() {
+        taking = !done && !excluded
+        if (taking) done = true
+        excluded = false
+      },
+      text(text) {
+        if (taking) chunks.push(text.text)
+      },
+    })
+    .transform(new Response(body))
+  // Drain without collecting the rewritten output (Response.text() would rebuild the whole body).
+  const reader = transformed.body?.getReader()
+  if (reader) while (!(await reader.read()).done) {}
+  const title = decodeEntities(chunks.join('')).replace(/\s+/g, ' ').trim()
+  return title ? capTitle(title) : null
 }
 
 export async function extractText(entry: EntryFile, body: string): Promise<Extracted> {

--- a/packages/api/src/routes/upload-editor.test.ts
+++ b/packages/api/src/routes/upload-editor.test.ts
@@ -125,3 +125,19 @@ describe('upload — editor-share enforcement', () => {
     expect((await siteRow(db)).contentVersion).toBe(1) // owner replace bumps advisorily
   })
 })
+
+describe('upload — editor replace never derives a title', () => {
+  test('null-title site + titled HTML via editor replace: title stays null', async () => {
+    const { db, app, env } = await fx()
+    const fd = new FormData()
+    fd.append('files', new File(['<html><head><title>Hijack</title></head><body>x</body></html>'], 'index.html', { type: 'text/html' }))
+    fd.append('expectedVersion', '0')
+    const res = await app.request(
+      '/api/upload/acme/doc?replace=true',
+      { method: 'POST', headers: { Authorization: 'Bearer ed' }, body: fd },
+      env,
+    )
+    expect(res.status).toBe(200)
+    expect((await siteRow(db)).title).toBeNull()
+  })
+})

--- a/packages/api/src/routes/upload.test.ts
+++ b/packages/api/src/routes/upload.test.ts
@@ -214,3 +214,83 @@ describe('upload — optional title on CREATE (W3-4)', () => {
     expect(await titleOf('titled')).toBe('My Recording') // unchanged
   })
 })
+
+describe('upload — derived title from entry HTML', () => {
+  const titled = (t: string) => html(`<html><head><title>${t}</title></head><body>x</body></html>`, 'index.html')
+  async function siteTitle(db: Awaited<ReturnType<typeof setup>>['db'], slug: string) {
+    return (await db.select({ title: sites.title }).from(sites).where(eq(sites.slug, slug)))[0]?.title
+  }
+
+  test('create without a form title derives it from the entry <title>', async () => {
+    const { app, env, db } = await setup()
+    expect((await postUpload(app, env, 'derived', [titled('My Report')])).status).toBe(200)
+    expect(await siteTitle(db, 'derived')).toBe('My Report')
+  })
+
+  test('an explicit form title always wins over the entry <title>', async () => {
+    const { app, env, db } = await setup()
+    expect((await postUpload(app, env, 'explicit', [titled('From HTML')], { title: 'From Form' })).status).toBe(200)
+    expect(await siteTitle(db, 'explicit')).toBe('From Form')
+  })
+
+  test('replace fills a null title but never overwrites an existing one', async () => {
+    const { app, env, db } = await setup()
+    // Entry HTML has no <title> → site title stays null.
+    await postUpload(app, env, 'fillme', [html('<html><body>no title</body></html>', 'index.html')])
+    expect(await siteTitle(db, 'fillme')).toBeNull()
+    // Redeploy with a <title> → the null title is filled.
+    await postUpload(app, env, 'fillme', [titled('Now Titled')], { replace: true })
+    expect(await siteTitle(db, 'fillme')).toBe('Now Titled')
+    // Another redeploy with a different <title> → existing title kept (never silently renamed).
+    await postUpload(app, env, 'fillme', [titled('Renamed?')], { replace: true })
+    expect(await siteTitle(db, 'fillme')).toBe('Now Titled')
+  })
+
+  test('multi-file site with no root index derives nothing', async () => {
+    const { app, env, db } = await setup()
+    const parts = [html('<title>A</title>', 'a.html'), html('<title>B</title>', 'b.html')]
+    expect((await postUpload(app, env, 'noentry', parts)).status).toBe(200)
+    expect(await siteTitle(db, 'noentry')).toBeNull()
+  })
+})
+
+describe('upload — derived title: R2 integrity + COALESCE race', () => {
+  const titled = (t: string) => html(`<html><head><title>${t}</title></head><body>x</body></html>`, 'index.html')
+
+  test('deriving the title does not consume the entry: the R2 object still holds the full HTML', async () => {
+    const { app, env, db, r2 } = await setup()
+    expect((await postUpload(app, env, 'intact', [titled('Intact')])).status).toBe(200)
+    const key = (await db.select({ k: files.storageKey }).from(files))[0].k
+    const obj = await r2.get(key)
+    expect(obj && (await obj.text())).toContain('<title>Intact</title>')
+  })
+
+  test('a title set concurrently during the replace is never clobbered (COALESCE at the write)', async () => {
+    const { app, env, db, r2 } = await setup()
+    // Create with untitled HTML → sites.title is null.
+    await postUpload(app, env, 'raceme', [html('<html><body>v1</body></html>', 'index.html')])
+    // Gate R2 puts: the replace suspends AFTER reading existing.title (null) but BEFORE writing.
+    const origPut = r2.put
+    let releasePut: () => void = () => {}
+    const gate = new Promise<void>((res) => {
+      releasePut = res
+    })
+    let reachedPut: () => void = () => {}
+    const reached = new Promise<void>((res) => {
+      reachedPut = res
+    })
+    r2.put = async (...args: Parameters<typeof origPut>) => {
+      reachedPut()
+      await gate
+      return origPut(...args)
+    }
+    const replace = postUpload(app, env, 'raceme', [titled('Derived Late')], { replace: true })
+    await reached
+    // Owner names the site while the upload is in flight (the PATCH-title race).
+    await db.update(sites).set({ title: 'Manual Name' }).where(eq(sites.slug, 'raceme'))
+    releasePut()
+    expect((await replace).status).toBe(200)
+    const row = (await db.select({ title: sites.title }).from(sites).where(eq(sites.slug, 'raceme')))[0]
+    expect(row.title).toBe('Manual Name')
+  })
+})

--- a/packages/api/src/routes/upload.ts
+++ b/packages/api/src/routes/upload.ts
@@ -5,6 +5,7 @@ import type { NewFileRow } from '../db/schema'
 import { files, sites, spaces } from '../db/schema'
 import { canReplace } from '../lib/access'
 import { fireAndForget } from '../lib/events'
+import { capTitle, extractHtmlTitle, pickEntry } from '../lib/extract'
 import { isValidSlug } from '../lib/slug'
 import { deleteKeys, MAX_FILE_BYTES, sanitizePath } from '../lib/storage'
 import { isVisibility, normalizeVisibility } from '../lib/visibility'
@@ -47,10 +48,12 @@ upload.post('/:spaceSlug/:siteSlug', requireAuth, async (c) => {
   // tier), so the two cases must stay distinguishable — `|| 'team'` alone can't tell them apart.
   const hasVisibility = typeof rawVisibility === 'string' && rawVisibility !== ''
   const visibility = normalizeVisibility(rawVisibility || 'team')
-  // Optional display title, applied on CREATE only (REPLACE keeps whatever the site already has —
-  // a re-upload/record must never silently rename an existing site). Trimmed + capped; empty → null.
+  // Optional display title. CREATE: an explicit form title wins; absent one, the entry HTML's
+  // <title> is derived below. REPLACE never renames a titled site — a re-upload/record must not
+  // silently rename it — but a still-null title may be filled from the new content
+  // (owner/superadmin only). Trimmed + capped; empty → null.
   const rawTitle = form.get('title')
-  const title = typeof rawTitle === 'string' ? rawTitle.trim().slice(0, 200) || null : null
+  const title = typeof rawTitle === 'string' ? capTitle(rawTitle.trim()) || null : null
   // Optimistic-concurrency token for a REPLACE: the contentVersion the caller last pulled. REQUIRED
   // for an editor replace (CAS below), advisory/ignored for an owner. Parsed to a non-negative int or
   // null (absent/blank/non-numeric).
@@ -96,7 +99,13 @@ upload.post('/:spaceSlug/:siteSlug', requireAuth, async (c) => {
   // contentVersion + status too: the editor CAS + archived guard need them.
   const existing = (
     await db
-      .select({ id: sites.id, ownerId: sites.ownerId, contentVersion: sites.contentVersion, status: sites.status })
+      .select({
+        id: sites.id,
+        ownerId: sites.ownerId,
+        title: sites.title,
+        contentVersion: sites.contentVersion,
+        status: sites.status,
+      })
       .from(sites)
       .where(and(eq(sites.spaceId, space.id), eq(sites.slug, siteSlug)))
       .limit(1)
@@ -164,6 +173,18 @@ upload.post('/:spaceSlug/:siteSlug', requireAuth, async (c) => {
     }
   }
 
+  // Derive a display title from the entry HTML's <title> when nothing names the site yet: an
+  // explicit form title wins on CREATE, and editors never touch title (content-only role). The
+  // null-title check here is ONLY work-avoidance — the replace UPDATE enforces fill-only-null
+  // atomically via COALESCE, so a title set concurrently (PATCH, racing replace) between this
+  // read and that write is never clobbered. Runs after request validation, before any R2 write.
+  const wantsDerivedTitle = existing ? !actingAsEditor && existing.title === null : title === null
+  let derivedTitle: string | null = null
+  if (wantsDerivedTitle) {
+    const entry = pickEntry(items.map(({ path, file }) => ({ path, file, mimeType: file.type || null })))
+    if (entry) derivedTitle = await extractHtmlTitle(entry, entry.file)
+  }
+
   // Write the objects with bounded concurrency so latency doesn't scale linearly with file count.
   // Track every key we attempt: if ANY put throws mid-flight, delete the ones already written so
   // nothing orphans in R2 (there are no rows yet). Deleting a never-written key is a harmless no-op.
@@ -198,7 +219,7 @@ upload.post('/:spaceSlug/:siteSlug', requireAuth, async (c) => {
           id: siteId,
           spaceId: space.id,
           slug: siteSlug,
-          title,
+          title: title ?? derivedTitle,
           visibility: isVisibility(visibility) ? visibility : 'team',
           ownerId: user.id,
         }),
@@ -238,6 +259,7 @@ upload.post('/:spaceSlug/:siteSlug', requireAuth, async (c) => {
             lastReplacedBy: user.id,
             updatedAt: new Date().toISOString(),
             ...(hasVisibility && isVisibility(visibility) ? { visibility } : {}),
+            ...(derivedTitle !== null ? { title: sql`coalesce(${sites.title}, ${derivedTitle})` } : {}),
           })
           .where(eq(sites.id, siteId)),
       ])

--- a/packages/web/src/routes/viewer.tsx
+++ b/packages/web/src/routes/viewer.tsx
@@ -183,6 +183,17 @@ function Viewer() {
   // Actionable count for the toolbar badge: open threads (mirrors the rail's default "open" list).
   const openCount = useMemo(() => threads.filter((t) => t.status === 'open').length, [threads])
 
+  // Per-site tab title: without this the shell's static <title> ("Glance — …") shows for EVERY
+  // site. site.title is owner-set or deploy-derived from the entry HTML's <title>; fall back to
+  // the slug. Restored on unmount so back-navigation to the dashboard keeps the shell default.
+  useEffect(() => {
+    const prev = document.title
+    document.title = site.title ?? site.siteSlug
+    return () => {
+      document.title = prev
+    }
+  }, [site.title, site.siteSlug])
+
   // glance.db credential broker: the injected SDK in the iframe hands us a MessagePort; we
   // execute its data-plane requests with OUR token so no credential ever enters the untrusted
   // frame (P0-1). Bound to THIS site — the page cannot ask for another site's data.


### PR DESCRIPTION
## Problem
CLI deploys never send a title, so `sites.title` was null for effectively every site, and the viewer never set `document.title` — every tab showed the shell's static "Glance — Artifacts for every agent".

## Changes
- **Upload derives the site title from the entry HTML's `<title>`** (`lib/extract.ts` → `extractHtmlTitle`, wired in `routes/upload.ts`):
  - CREATE: explicit form title still wins; REPLACE fills only a null title — enforced atomically at the write via `COALESCE`, so a concurrently set title (PATCH, racing replace) is never clobbered. Editors (content-only role) never touch title.
  - Entry streams through HTMLRewriter (never buffered); first non-`svg`/`template` title in document order — implied-head fragments work, svg a11y labels can't become the site title; entities decoded; surrogate-safe 200-char cap (`capTitle`, shared with the form-title path).
- **Viewer sets `document.title`** to `site.title ?? siteSlug` while mounted, restoring the shell default on unmount (`web/src/routes/viewer.tsx`).

## Tests
Extraction (svg exclusion, implied head, entities, surrogate cap, Blob streaming), upload (derive/precedence/fill-null, R2-object integrity after derivation, deterministic COALESCE race with a gated R2 put), editor-replace title regression. 779 API + 175 web pass; web typecheck + `bun run lint` clean.

Reviewed via a codex (gpt-5.6-sol) + cursor (grok-4.5) consult; all blockers (TOCTOU race, svg mislabeling, buffering, unsafe truncation) addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018WBiQsXDuXtbUREYXButBt