### PR TITLE
Revert the glance-cli skill title line

### DIFF
--- a/glance-cli/SKILL.md
+++ b/glance-cli/SKILL.md
@@ -53,7 +53,6 @@ Device-code flow. If no browser opener is available (SSH/headless), open the pri
 - `--visibility` defaults to `team`.
 - If the site already exists and you own it, prompts `Replace? (y/N)`. If owned by someone else, it aborts.
 - Prints `✓ Deployed → <url>`.
-- Give every deployed HTML file a real `<title>` (and ideally a `<meta name="description">`): Glance derives the site's display/tab title from the entry HTML's `<title>` at deploy time — an untitled file falls back to the slug.
 
 ```bash
 glance deploy report.html                                  # → /<you>/report in your personal space

--- a/packages/cli/SKILL.md
+++ b/packages/cli/SKILL.md
@@ -53,7 +53,6 @@ Device-code flow. If no browser opener is available (SSH/headless), open the pri
 - `--visibility` defaults to `team`.
 - If the site already exists and you own it, prompts `Replace? (y/N)`. If owned by someone else, it aborts.
 - Prints `✓ Deployed → <url>`.
-- Give every deployed HTML file a real `<title>` (and ideally a `<meta name="description">`): Glance derives the site's display/tab title from the entry HTML's `<title>` at deploy time — an untitled file falls back to the slug.
 
 ```bash
 glance deploy report.html                                  # → /<you>/report in your personal space


### PR DESCRIPTION
Reverts the `<title>` guidance line that rode along in #66 (merged before the branch cleanup landed). Canonical `glance-cli/SKILL.md` + embedded `packages/cli/SKILL.md` both reverted; `TestSkillEmbedInSync` green. Favicon untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018WBiQsXDuXtbUREYXButBt