### PR TITLE
Collapse the viewer top bar into a hamburger on mobile

### DIFF
--- a/packages/web/src/components/ShareDialog.tsx
+++ b/packages/web/src/components/ShareDialog.tsx
@@ -24,7 +24,6 @@ type Props = {
   spaceSlug: string
   siteSlug: string
   title?: string | null
-  compact?: boolean
   // Controlled mode: when `open` is provided the dialog renders no trigger and is driven by the
   // parent (e.g. a dropdown-menu item). Uncontrolled (default) keeps its own Share button.
   open?: boolean
@@ -50,7 +49,7 @@ function toggleUser(map: Map<string, ShareRole>, id: string): Map<string, ShareR
 // site's visibility tier. Data loads on open via a ref-callback on the dialog content (Radix
 // mounts it on every open — and a controlled/external open does NOT fire Radix onOpenChange,
 // so the load can't live there); Save replaces the whole set via PUT.
-export function ShareDialog({ spaceSlug, siteSlug, title, compact, open: openProp, onOpenChange }: Props) {
+export function ShareDialog({ spaceSlug, siteSlug, title, open: openProp, onOpenChange }: Props) {
   const navigate = useNavigate()
   const [internalOpen, setInternalOpen] = useState(false)
   const controlled = openProp !== undefined
@@ -114,22 +113,10 @@ export function ShareDialog({ spaceSlug, siteSlug, title, compact, open: openPro
     <Dialog open={open} onOpenChange={setOpen}>
       {!controlled && (
         <DialogTrigger asChild>
-          {compact ? (
-            <Button
-              variant="ghost"
-              size="icon"
-              className="size-8 rounded-full"
-              title="Share with people & groups"
-              aria-label="Share with people & groups"
-            >
-              <Share2 />
-            </Button>
-          ) : (
-            <Button variant="outline" size="sm">
-              <Share2 />
-              Share with people &amp; groups
-            </Button>
-          )}
+          <Button variant="outline" size="sm">
+            <Share2 />
+            Share with people &amp; groups
+          </Button>
         </DialogTrigger>
       )}
       <DialogContent className="sm:max-w-md">

--- a/packages/web/src/components/ViewerTopBar.tsx
+++ b/packages/web/src/components/ViewerTopBar.tsx
@@ -1,37 +1,28 @@
-import { Check, ChevronRight, Command, GitFork, History, MessageSquare, Sparkles } from 'lucide-react'
+import { Check, ChevronRight, Command, GitFork, History, Menu, MessageSquare, Share2, Sparkles } from 'lucide-react'
 import { useState } from 'react'
 import { Link } from 'react-router'
 import { useForkSite } from '@/hooks/useForkSite'
 import type { ViewerSite } from '@/lib/types'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
 import { ShareDialog } from '@/components/ShareDialog'
 import { SummarySheet } from '@/components/SummarySheet'
 import { Spinner } from '@/components/states'
-
-// Copy this site into a space of your own. Deliberately NOT gated on site.isOwner (unlike Share):
-// anyone who can read a site can fork it, so a plain viewer gets this button too.
-function ForkButton({ site }: { site: ViewerSite }) {
-  const { fork, forking } = useForkSite(site)
-  return (
-    <Button
-      size="sm"
-      variant="ghost"
-      className="gap-1.5"
-      disabled={forking}
-      onClick={() => void fork()}
-      title="Copy this site into your own space"
-    >
-      {forking ? <Spinner className="size-3.5" /> : <GitFork className="size-3.5" />}
-      Fork
-    </Button>
-  )
-}
 
 // The persistent top chrome for the viewer: brand (→ dashboard) + a breadcrumb, then one action
 // row that stays put across modes — Fork, TL;DR, Comments (with an open count, outside review),
 // Share, and Done while reviewing. The Read·Annotate toggle lives in the ReviewRail header, next
 // to the comments it drives. Replaces the old floating PreviewToolbar dock.
+//
+// Below `md` the row doesn't fit (7 controls overlapped the breadcrumb on a phone), so everything
+// except Comments and Done collapses into a hamburger menu. Fork/TL;DR/Share are driven from shared
+// state rather than duplicated components, so the desktop button and the menu item are one action.
 export function ViewerTopBar({
   site,
   sitePath,
@@ -52,21 +43,31 @@ export function ViewerTopBar({
   onSearch: () => void
 }) {
   const [summaryOpen, setSummaryOpen] = useState(false)
+  const [shareOpen, setShareOpen] = useState(false)
+  const { fork, forking } = useForkSite(site)
   return (
-    <header className="flex h-12 shrink-0 items-center gap-3 border-b bg-background px-3">
+    <header className="flex h-12 shrink-0 items-center gap-2 border-b bg-background px-3 md:gap-3">
       <Link to="/dashboard" className="flex shrink-0 items-center gap-2 font-mono font-semibold text-sm tracking-tight">
         <span className="size-2.5 rounded-[3px] bg-primary shadow-[0_0_12px_1px_var(--primary)]" />
         glance
       </Link>
 
-      <Button size="sm" variant="ghost" className="shrink-0 px-2" title="Recently opened" aria-label="Recently opened" onClick={onToggleSidebar}>
+      <Button
+        size="sm"
+        variant="ghost"
+        className="hidden shrink-0 px-2 md:inline-flex"
+        title="Recently opened"
+        aria-label="Recently opened"
+        onClick={onToggleSidebar}
+      >
         <History className="size-3.5" />
       </Button>
 
       <nav aria-label="Breadcrumb" className="flex min-w-0 items-center gap-1.5 text-muted-foreground text-sm">
         <ChevronRight className="size-3.5 shrink-0 opacity-40" />
-        <span className="shrink-0">{site.spaceSlug}</span>
-        <span className="opacity-40">/</span>
+        {/* The space slug is the first thing to go on a phone — the file being viewed matters more. */}
+        <span className="hidden shrink-0 md:inline">{site.spaceSlug}</span>
+        <span className="hidden opacity-40 md:inline">/</span>
         <span className={cn('truncate', !sitePath && 'text-foreground')}>{site.title ?? site.siteSlug}</span>
         {sitePath && (
           <>
@@ -80,7 +81,7 @@ export function ViewerTopBar({
         <Button
           variant="outline"
           size="sm"
-          className="gap-2 text-muted-foreground"
+          className="hidden gap-2 text-muted-foreground md:inline-flex"
           onClick={onSearch}
           title="Search sites or run a command"
         >
@@ -90,8 +91,26 @@ export function ViewerTopBar({
             ⌘K
           </kbd>
         </Button>
-        <ForkButton site={site} />
-        <Button size="sm" variant="ghost" className="gap-1.5" title="AI summary" onClick={() => setSummaryOpen(true)}>
+        {/* Fork is deliberately NOT gated on site.isOwner (unlike Share): anyone who can read a
+            site can fork it, so a plain viewer gets this too. */}
+        <Button
+          size="sm"
+          variant="ghost"
+          className="hidden gap-1.5 md:inline-flex"
+          disabled={forking}
+          onClick={() => void fork()}
+          title="Copy this site into your own space"
+        >
+          {forking ? <Spinner className="size-3.5" /> : <GitFork className="size-3.5" />}
+          Fork
+        </Button>
+        <Button
+          size="sm"
+          variant="ghost"
+          className="hidden gap-1.5 md:inline-flex"
+          title="AI summary"
+          onClick={() => setSummaryOpen(true)}
+        >
           <Sparkles className="size-3.5" />
           TL;DR
         </Button>
@@ -112,16 +131,69 @@ export function ViewerTopBar({
             )}
           </Button>
         )}
-        {site.isOwner && <ShareDialog spaceSlug={site.spaceSlug} siteSlug={site.siteSlug} title={site.title} compact />}
+        {site.isOwner && (
+          <Button
+            variant="ghost"
+            size="icon"
+            className="hidden size-8 rounded-full md:inline-flex"
+            title="Share with people & groups"
+            aria-label="Share with people & groups"
+            onClick={() => setShareOpen(true)}
+          >
+            <Share2 />
+          </Button>
+        )}
         {review && (
           <Button size="sm" variant="secondary" onClick={onExit}>
             <Check className="size-3.5" />
             Done
           </Button>
         )}
+
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="ghost" size="icon" className="size-8 md:hidden" aria-label="Menu">
+              <Menu />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="w-48">
+            <DropdownMenuItem onSelect={onToggleSidebar}>
+              <History />
+              Recently opened
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={onSearch}>
+              <Command />
+              Search
+            </DropdownMenuItem>
+            <DropdownMenuItem disabled={forking} onSelect={() => void fork()}>
+              <GitFork />
+              Fork
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => setSummaryOpen(true)}>
+              <Sparkles />
+              TL;DR
+            </DropdownMenuItem>
+            {site.isOwner && (
+              <DropdownMenuItem onSelect={() => setShareOpen(true)}>
+                <Share2 />
+                Share…
+              </DropdownMenuItem>
+            )}
+          </DropdownMenuContent>
+        </DropdownMenu>
       </div>
-      {/* Sheet renders through a portal, so it can live inside the header without affecting layout. */}
+      {/* Both render through a portal, so they can live inside the header without affecting layout.
+          Controlled (no inline trigger) — the desktop button and the menu item drive the same state. */}
       <SummarySheet spaceSlug={site.spaceSlug} siteSlug={site.siteSlug} open={summaryOpen} onOpenChange={setSummaryOpen} />
+      {site.isOwner && (
+        <ShareDialog
+          spaceSlug={site.spaceSlug}
+          siteSlug={site.siteSlug}
+          title={site.title}
+          open={shareOpen}
+          onOpenChange={setShareOpen}
+        />
+      )}
     </header>
   )
 }


### PR DESCRIPTION
The viewer header packed seven controls into one row, so on a phone the breadcrumb ran straight through the action buttons and the row overflowed the screen. (The dashboard header was already fine — this is viewer-only.)

Below `md` everything except **Comments** — and **Done**, while reviewing — now collapses into a hamburger: Recently opened, Search, Fork, TL;DR, Share. The space slug hides too, so the breadcrumb truncates on the file being viewed instead of pushing into the buttons.

Fork/TL;DR/Share are driven from shared state rather than duplicated components, so the desktop button and the menu item are one action. That makes `ShareDialog` controlled from `ViewerTopBar` (the existing `SitesTable` kebab pattern) and leaves its `compact` trigger with no callers, so that branch goes.

**Desktop (≥ `md`) is unchanged** — every collapsed control is `hidden md:inline-flex`, the hamburger is `md:hidden`, and the breadcrumb slug is `hidden md:inline`.

## Screenshots

| Mobile — menu open | Mobile — review mode | Mobile — long path | Desktop 1280×800 |
|---|---|---|---|
| <img src="https://github.com/plivo-labs/glance/releases/download/assets-pr-mobile-menu/mobile-menu.png" width="220"> | <img src="https://github.com/plivo-labs/glance/releases/download/assets-pr-mobile-menu/mobile-review.png" width="220"> | <img src="https://github.com/plivo-labs/glance/releases/download/assets-pr-mobile-menu/mobile-longpath.png" width="220"> | <img src="https://github.com/plivo-labs/glance/releases/download/assets-pr-mobile-menu/desktop.png" width="420"> |

## Verification

Driven in a real browser at 390×844 against the local stack (content origin blocked, hence the placeholder in the frame):

- every menu item opens its surface — command palette, recents sheet, TL;DR sheet, share dialog
- review mode fits with `Done` + hamburger
- a long nested path truncates cleanly, no overlap
- desktop at 1280×800 renders the original row, hamburger absent

`bun run typecheck` clean, biome clean on both files, `bun run test` 763 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mQeZk6r5SbRGKPcjHVwuN