### PR TITLE
fix(auth): prefix the session cookie with __Host- to block cookie tossing

### DIFF
--- a/packages/api/src/lib/session.ts
+++ b/packages/api/src/lib/session.ts
@@ -2,20 +2,24 @@ import type { Context } from 'hono'
 import { deleteCookie, getSignedCookie, setSignedCookie } from 'hono/cookie'
 import type { AppEnv, SessionUser } from '../types'
 
-const SESSION_COOKIE = 'glance_session'
+const SESSION_COOKIE = '__Host-glance_session'
 const SESSION_TTL = 60 * 60 * 24 // 24h
 const CLI_TTL = 60 * 60 * 24 * 30 // 30d
 
-// SameSite=Lax (not Strict): the post-OAuth redirect and shared inbound links are
+// `__Host-` prefix: the browser refuses the cookie unless it is Secure, Path=/, and carries NO
+// Domain — which also blocks a sibling subdomain (the content worker, same registrable domain as
+// the app) from planting a same-named cookie, i.e. session fixation via cookie tossing. `secure`
+// is therefore unconditional; localhost counts as a secure context so http://localhost dev still
+// accepts it. SameSite=Lax (not Strict): the post-OAuth redirect and shared inbound links are
 // top-level GET navigations; Strict would drop the cookie and force a re-login.
-function cookieOpts(c: Context<AppEnv>) {
-  return { httpOnly: true, secure: c.env.APP_URL.startsWith('https://'), sameSite: 'Lax' as const, path: '/' }
+function cookieOpts() {
+  return { httpOnly: true, secure: true, sameSite: 'Lax' as const, path: '/' }
 }
 
 export async function createSession(c: Context<AppEnv>, user: SessionUser): Promise<void> {
   const token = crypto.randomUUID()
   await c.env.GLANCE_SESSIONS.put(`session:${token}`, JSON.stringify(user), { expirationTtl: SESSION_TTL })
-  await setSignedCookie(c, SESSION_COOKIE, token, c.env.SESSION_SECRET, { ...cookieOpts(c), maxAge: SESSION_TTL })
+  await setSignedCookie(c, SESSION_COOKIE, token, c.env.SESSION_SECRET, { ...cookieOpts(), maxAge: SESSION_TTL })
 }
 
 export async function readSession(c: Context<AppEnv>): Promise<SessionUser | null> {
@@ -33,7 +37,7 @@ export async function readSession(c: Context<AppEnv>): Promise<SessionUser | nul
 export async function destroySession(c: Context<AppEnv>): Promise<void> {
   const token = await getSignedCookie(c, c.env.SESSION_SECRET, SESSION_COOKIE)
   if (typeof token === 'string') await c.env.GLANCE_SESSIONS.delete(`session:${token}`)
-  deleteCookie(c, SESSION_COOKIE, { path: '/' })
+  deleteCookie(c, SESSION_COOKIE, { path: '/', secure: true })
 }
 
 // --- CLI tokens (opaque, long-lived, stored in KV; sent as Bearer by the CLI) ---

--- a/packages/api/src/middleware/analytics.test.ts
+++ b/packages/api/src/middleware/analytics.test.ts
@@ -107,7 +107,7 @@ describe('trackCliUsage', () => {
     // rule requireAuth uses). The route still 200s via the Bearer fallback, but nothing is recorded.
     const res = await app.request(
       '/api/sites/acme/demo',
-      { headers: { Authorization: `Bearer ${tok}`, Cookie: 'glance_session=irrelevant' } },
+      { headers: { Authorization: `Bearer ${tok}`, Cookie: '__Host-glance_session=irrelevant' } },
       env,
     )
     expect(res.status).toBe(200)

--- a/packages/api/src/middleware/analytics.ts
+++ b/packages/api/src/middleware/analytics.ts
@@ -5,7 +5,7 @@ import { fireAndForget, parseCliVersion, recordEvent } from '../lib/events'
 import { readSessionOrBearer } from '../lib/session'
 import type { AppEnv } from '../types'
 
-const SESSION_COOKIE = 'glance_session'
+const SESSION_COOKIE = '__Host-glance_session'
 
 // A request is a CLI call when it carries a Bearer token and NO session cookie — the exact rule
 // requireAuth uses to tag `authKind` (cookie wins, mirroring readSessionOrBearer). We DERIVE it

--- a/packages/api/src/middleware/auth.ts
+++ b/packages/api/src/middleware/auth.ts
@@ -4,7 +4,7 @@ import { getUserById } from '../db/repo'
 import { readSessionOrBearer } from '../lib/session'
 import type { AppEnv } from '../types'
 
-const SESSION_COOKIE = 'glance_session'
+const SESSION_COOKIE = '__Host-glance_session'
 const UNSAFE_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE'])
 
 /**

--- a/packages/api/src/middleware/csrf.test.ts
+++ b/packages/api/src/middleware/csrf.test.ts
@@ -11,7 +11,7 @@ app.use('/api/*', requireSameOrigin)
 app.post('/api/thing', (c) => c.json({ ok: true }))
 app.get('/api/thing', (c) => c.json({ ok: true }))
 
-const cookie = 'glance_session=signed-token'
+const cookie = '__Host-glance_session=signed-token'
 
 describe('requireSameOrigin', () => {
   test('cookie POST with foreign Origin → 403', async () => {

--- a/packages/api/src/routes/auth-bootstrap.test.ts
+++ b/packages/api/src/routes/auth-bootstrap.test.ts
@@ -48,7 +48,7 @@ describe('POST /api/auth/bootstrap', () => {
     const { app, env, db } = setup()
     const res = await post(app, env, { token: TOKEN })
     expect(res.status).toBe(200)
-    expect(res.headers.get('set-cookie') ?? '').toContain('glance_session=')
+    expect(res.headers.get('set-cookie') ?? '').toContain('__Host-glance_session=')
 
     const rows = await db.select().from(users).where(eq(users.email, 'owner@example.com'))
     expect(rows[0]?.role).toBe('superadmin')

--- a/packages/api/src/routes/comments.test.ts
+++ b/packages/api/src/routes/comments.test.ts
@@ -94,7 +94,7 @@ describe('comments routes — auth / access / authz', () => {
     await seedSiteWithFile(db, r2, owner)
     const res = await app.request(
       url(),
-      { method: 'POST', headers: { cookie: 'glance_session=x', Origin: 'https://evil.com', 'Content-Type': 'application/json' }, body: '{}' },
+      { method: 'POST', headers: { cookie: '__Host-glance_session=x', Origin: 'https://evil.com', 'Content-Type': 'application/json' }, body: '{}' },
       env,
     )
     expect(res.status).toBe(403)

--- a/packages/api/src/routes/summary.test.ts
+++ b/packages/api/src/routes/summary.test.ts
@@ -581,7 +581,7 @@ describe('site summary routes', () => {
       {
         method: 'POST',
         headers: {
-          cookie: 'glance_session=x',
+          cookie: '__Host-glance_session=x',
           Origin: 'https://evil.example.com',
           'Content-Type': 'application/json',
         },


### PR DESCRIPTION
## What & why

The app (`glance.plivo.com`) and the content worker that serves untrusted uploaded HTML (`glance-content.plivo.com`) are **sibling subdomains of the same registrable domain** — same-*site*, not cross-site (`plivo.com` isn't a public suffix, unlike the `*.workers.dev` default the isolation model in `content.ts` was written for).

The viewer iframe runs uploaded JS with `allow-same-origin`, so a hosted site executes on the content origin and can call `document.cookie` with `Domain=plivo.com`. Because `glance_session` had **no `__Host-` prefix**, nothing stopped that sibling from planting a same-named cookie scoped to the parent domain. `HttpOnly` blocks *reading* a victim's cookie but not *planting* a competing one; by cookie path-length ordering (RFC 6265) + Hono's first-occurrence-wins parser, a planted `Path=/api` cookie deterministically wins on every `/api/*` request.

**Impact:** any authenticated user (default upload visibility is `team`) could publish a site that plants their own valid session, silently logging a victim in **as the attacker** — session fixation / confused deputy. The victim's subsequent uploads and comments land in, and are readable from, the attacker's account.

Found during a full-repo security audit; this was the one High-severity finding. (Two Low findings — a 404-vs-403 existence oracle and an over-broad directory listing on the content worker — are tracked separately.)

## The fix

Rename the cookie to `__Host-glance_session`. Browsers **refuse any `__Host-`-prefixed cookie that carries a `Domain` attribute**, killing the toss regardless of what domain the content worker runs on (domain-agnostic, unlike moving the content origin, which breaks the moment app + content share a parent again).

- `secure` is now **unconditional** (the prefix requires it; `localhost` is a secure context, so `http://localhost` dev still accepts it).
- `deleteCookie` carries `Secure` so logout can clear a `__Host-` cookie.
- Both duplicated `SESSION_COOKIE` constants in the middleware are updated (CSRF-presence + CLI-vs-web detection read the cookie), plus the tests that send a session cookie.

## Deploy note ⚠️

Existing browser sessions won't match the new cookie name, so **every active web user re-logs-in once** (CLI Bearer tokens unaffected). Recommend deploying in a low-traffic window.

## Not included

The short-lived OAuth state cookie (`glance_oauth`) is tossable by the same mechanism (lower risk — 600s TTL, login-CSRF variant). Can fold the same one-line `__Host-` fix in here or as a follow-up — say the word.

## Verification

- `bun run typecheck` — clean
- `bun run test` — **779 pass / 0 fail**
- biome clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)