### PR TITLE
Slack link unfurls: link_shared → chat.unfurl, plus a derived site description

### DIFF
--- a/packages/api/drizzle/0018_site_description.sql
+++ b/packages/api/drizzle/0018_site_description.sql
@@ -1,0 +1,6 @@
+-- Short blurb for a site, derived at upload from the entry HTML's <meta name="description">
+-- (or og:description). Feeds the Slack link-unfurl card; unlike `title` it is CONTENT-derived, so
+-- every replace overwrites it (and clears it when the new entry has none) rather than filling only
+-- when null. Plain ADD COLUMN (nullable, no table rebuild); existing rows stay NULL until their
+-- next deploy re-derives one.
+ALTER TABLE `sites` ADD COLUMN `description` text;

--- a/packages/api/drizzle/meta/_journal.json
+++ b/packages/api/drizzle/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1784300000000,
       "tag": "0017_site_updated_at",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "6",
+      "when": 1784400000000,
+      "tag": "0018_site_description",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/src/db/repo.ts
+++ b/packages/api/src/db/repo.ts
@@ -32,6 +32,22 @@ export async function getUserById(
   return row[0] ?? null
 }
 
+/** The same identity read keyed by email. `users.email` is lowercase-canonical by construction (every
+ *  write path lowercases), and an external provider may hand us any casing — so the normalization is
+ *  the REPO layer's job here, not each caller's. Email is UNIQUE, so this is a single indexed read;
+ *  null when nobody with that address has a Glance account. */
+export async function getUserByEmail(
+  db: DrizzleD1Database,
+  email: string,
+): Promise<Pick<User, 'id' | 'email' | 'name' | 'role'> | null> {
+  const row = await db
+    .select({ id: users.id, email: users.email, name: users.name, role: users.role })
+    .from(users)
+    .where(eq(users.email, email.toLowerCase()))
+    .limit(1)
+  return row[0] ?? null
+}
+
 /** True iff at least one user row has role='superadmin'. Drives bootstrap availability. */
 export async function superadminExists(db: DrizzleD1Database): Promise<boolean> {
   const row = await db.select({ id: users.id }).from(users).where(eq(users.role, 'superadmin')).limit(1)

--- a/packages/api/src/db/schema.ts
+++ b/packages/api/src/db/schema.ts
@@ -42,6 +42,9 @@ export const sites = sqliteTable(
     spaceId: text('spaceId').notNull().references(() => spaces.id, { onDelete: 'cascade' }),
     slug: text('slug').notNull(),
     title: text('title'),
+    // Short blurb derived from the entry HTML's description meta at upload. CONTENT-derived, so a
+    // replace overwrites it (title is identity and stays fill-only-null). Feeds the Slack unfurl card.
+    description: text('description'),
     visibility: text('visibility', { enum: ['private', 'members', 'team'] })
       .notNull()
       .default('team'),

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -17,6 +17,7 @@ import { dataApi, dataToken } from './routes/data'
 import { notifications } from './routes/notifications'
 import { whatsNew } from './routes/whats-new'
 import { sites } from './routes/sites'
+import { slackEvents } from './routes/slack-events'
 import { spaces } from './routes/spaces'
 import { upload } from './routes/upload'
 import { users } from './routes/users'
@@ -108,5 +109,9 @@ app.route('/api/users', users)
 app.route('/api/notifications', notifications)
 app.route('/api/whats-new', whatsNew)
 app.route('/api/admin', admin)
+// Slack Events API (link_shared → chat.unfurl). Authenticated by Slack's HMAC signature, not a
+// session: requireSameOrigin above only guards COOKIE-authed unsafe methods, so this cookieless
+// POST passes through it untouched and the signature check inside the route is the real gate.
+app.route('/api/slack', slackEvents)
 
 export default app

--- a/packages/api/src/lib/extract.test.ts
+++ b/packages/api/src/lib/extract.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test'
-import { extractHtmlTitle, extractText, isSupportedEntry, pickEntry, resolveIndexPath, TEXT_CAP, type EntryFile } from './extract'
+import { extractHtmlMeta, extractText, isSupportedEntry, pickEntry, resolveIndexPath, TEXT_CAP, type EntryFile } from './extract'
 
 describe('pickEntry', () => {
   test('prefers the root index, returns a lone file, and rejects ambiguous sites', () => {
@@ -161,61 +161,104 @@ describe('extractText', () => {
   })
 })
 
-describe('extractHtmlTitle', () => {
+// The title half of the one-pass extractor — every title case below predates the description
+// field and reads better without the `.title` noise at each call site.
+const titleOf = async (entry: EntryFile, body: Blob | string) => (await extractHtmlMeta(entry, body)).title
+
+describe('extractHtmlMeta — title', () => {
   const entry = { path: 'index.html', mimeType: 'text/html' }
 
   test('returns the document title, whitespace-collapsed and trimmed', async () => {
     const body = '<html><head><title>  CX Team —\n  What They\'re Managing </title></head><body>x</body></html>'
-    expect(await extractHtmlTitle(entry, body)).toBe("CX Team — What They're Managing")
+    expect(await titleOf(entry, body)).toBe("CX Team — What They're Managing")
   })
 
   test('only the first <title> counts — a later inline svg title is ignored', async () => {
     const body = '<html><head><title>Real</title></head><body><svg><title>icon label</title></svg></body></html>'
-    expect(await extractHtmlTitle(entry, body)).toBe('Real')
+    expect(await titleOf(entry, body)).toBe('Real')
   })
 
   test('missing or empty title → null; non-HTML entry → null', async () => {
-    expect(await extractHtmlTitle(entry, '<html><body>no title</body></html>')).toBeNull()
-    expect(await extractHtmlTitle(entry, '<title>   </title>')).toBeNull()
-    expect(await extractHtmlTitle({ path: 'readme.md', mimeType: null }, '# Title')).toBeNull()
-    expect(await extractHtmlTitle({ path: 'clip.webm', mimeType: 'audio/webm' }, 'x')).toBeNull()
+    expect(await titleOf(entry, '<html><body>no title</body></html>')).toBeNull()
+    expect(await titleOf(entry, '<title>   </title>')).toBeNull()
+    expect(await titleOf({ path: 'readme.md', mimeType: null }, '# Title')).toBeNull()
+    expect(await titleOf({ path: 'clip.webm', mimeType: 'audio/webm' }, 'x')).toBeNull()
   })
 
   test('caps at 200 chars', async () => {
     const long = 'a'.repeat(300)
-    expect(await extractHtmlTitle(entry, `<title>${long}</title>`)).toBe('a'.repeat(200))
+    expect(await titleOf(entry, `<title>${long}</title>`)).toBe('a'.repeat(200))
   })
 })
 
-describe('extractHtmlTitle — svg exclusion, implied head, entities, streaming', () => {
+describe('extractHtmlMeta — description', () => {
+  const entry = { path: 'index.html', mimeType: 'text/html' }
+  const descOf = async (body: string) => (await extractHtmlMeta(entry, body)).description
+
+  test('reads <meta name="description">, whitespace-collapsed and entity-decoded', async () => {
+    expect(await descOf('<meta name="description" content="Q3  revenue &amp;\n churn">')).toBe('Q3 revenue & churn')
+  })
+
+  test('og:description wins over name=description, even when it comes second', async () => {
+    const body = '<meta name="description" content="seo blurb"><meta property="og:description" content="share blurb">'
+    expect(await descOf(body)).toBe('share blurb')
+  })
+
+  test('first of each kind wins; the name match is case-insensitive', async () => {
+    expect(await descOf('<meta name="Description" content="first"><meta name="description" content="second">')).toBe(
+      'first',
+    )
+  })
+
+  test('absent, empty, or non-HTML → null', async () => {
+    expect(await descOf('<html><head><title>t</title></head></html>')).toBeNull()
+    expect(await descOf('<meta name="description" content="   ">')).toBeNull()
+    expect(await descOf('<meta name="description">')).toBeNull()
+    expect((await extractHtmlMeta({ path: 'readme.md', mimeType: null }, '<meta name="description" content="x">')).description).toBeNull()
+  })
+
+  test('caps at 300 chars without leaving an unpaired surrogate', async () => {
+    expect(await descOf(`<meta name="description" content="${'a'.repeat(400)}">`)).toBe('a'.repeat(300))
+    const emoji = await descOf(`<meta name="description" content="${'a'.repeat(299)}😀">`)
+    expect(emoji).toBe('a'.repeat(299))
+    expect(emoji).not.toMatch(/[\uD800-\uDBFF]$/)
+  })
+
+  test('title and description come from ONE pass over the same body', async () => {
+    const body = '<title>Report</title><meta name="description" content="How the numbers moved">'
+    expect(await extractHtmlMeta(entry, body)).toEqual({ title: 'Report', description: 'How the numbers moved' })
+  })
+})
+
+describe('extractHtmlMeta — svg exclusion, implied head, entities, streaming', () => {
   const entry = { path: 'index.html', mimeType: 'text/html' }
 
   test('an svg title BEFORE the document title never wins; an svg-only doc yields null', async () => {
     const before = '<svg><title>icon label</title></svg><title>Real</title>'
-    expect(await extractHtmlTitle(entry, before)).toBe('Real')
+    expect(await titleOf(entry, before)).toBe('Real')
     const svgOnly = '<html><body><svg><title>Download icon</title></svg></body></html>'
-    expect(await extractHtmlTitle(entry, svgOnly)).toBeNull()
+    expect(await titleOf(entry, svgOnly)).toBeNull()
     const tpl = '<template><title>inert</title></template><title>Live</title>'
-    expect(await extractHtmlTitle(entry, tpl)).toBe('Live')
+    expect(await titleOf(entry, tpl)).toBe('Live')
   })
 
   test('implied-head fragments (no literal <head>) still resolve their title', async () => {
     const fragment = '<!doctype html><meta charset="utf-8"><title>Implied Head</title><style>x{}</style><h1>hi</h1>'
-    expect(await extractHtmlTitle(entry, fragment)).toBe('Implied Head')
+    expect(await titleOf(entry, fragment)).toBe('Implied Head')
   })
 
   test('decodes numeric and common named entities', async () => {
     const body = '<title>Mentions &amp; Notifications &#8212; A&nbsp;B &#x2192; C &unknown; &#1114112;</title>'
-    expect(await extractHtmlTitle(entry, body)).toBe('Mentions & Notifications — A B → C &unknown; &#1114112;')
+    expect(await titleOf(entry, body)).toBe('Mentions & Notifications — A B → C &unknown; &#1114112;')
   })
 
   test('cap never leaves an unpaired surrogate', async () => {
-    const title = await extractHtmlTitle(entry, `<title>${'a'.repeat(199)}😀</title>`)
+    const title = await titleOf(entry, `<title>${'a'.repeat(199)}😀</title>`)
     expect(title).toBe('a'.repeat(199))
     expect(title).not.toMatch(/[\uD800-\uDBFF]$/)
   })
 
   test('accepts a Blob body (the upload path streams the File, never buffering it)', async () => {
-    expect(await extractHtmlTitle(entry, new Blob(['<title>From Blob</title>']))).toBe('From Blob')
+    expect(await titleOf(entry, new Blob(['<title>From Blob</title>']))).toBe('From Blob')
   })
 })

--- a/packages/api/src/lib/extract.ts
+++ b/packages/api/src/lib/extract.ts
@@ -1,5 +1,8 @@
 export const TEXT_CAP = 40_000
 export const TITLE_CAP = 200
+// Unfurl cards (Slack, and OG consumers generally) truncate well before this; 300 keeps a full
+// two-sentence blurb without letting a pathological meta tag bloat the row.
+export const DESCRIPTION_CAP = 300
 
 export type EntryFile = { path: string; mimeType: string | null }
 export type Extracted = { ok: true; text: string; truncated: boolean } | { ok: false; reason: string }
@@ -73,15 +76,28 @@ function decodeEntities(text: string): string {
   })
 }
 
-// The entry document's <title>, for the site's display title when the uploader didn't name it.
-// HTML only — a markdown entry has no <title>. Takes the FIRST title in document order that is
-// not an <svg>/<template> accessibility/inert title. NOT `head > title`: a streaming rewriter
-// never sees an implied <head>, and headless fragments (a file starting at <style>/<h1>) are
-// common among agent-generated uploads — the bare selector plus exclusion covers both.
-// The body streams through the rewriter and only title chunks are retained, so a 20MB entry is
-// never buffered. Whitespace-collapsed, trimmed, entity-decoded, capped; empty/absent → null.
-export async function extractHtmlTitle(entry: EntryFile, body: Blob | string): Promise<string | null> {
-  if (!(/\.html?$/i.test(entry.path) || entry.mimeType === 'text/html')) return null
+const clean = (raw: string, limit: number): string | null => {
+  const text = decodeEntities(raw).replace(/\s+/g, ' ').trim()
+  return text ? cap(text, limit).text : null
+}
+
+export type HtmlMeta = { title: string | null; description: string | null }
+
+/** The "nothing derivable" result — also what an upload with no HTML entry at all should use. */
+export const NO_META: HtmlMeta = { title: null, description: null }
+
+// The entry document's <title> and description meta, for the site's display title (when the
+// uploader didn't name it) and the unfurl card's blurb. HTML only — a markdown entry has neither.
+// Title: the FIRST one in document order that is not an <svg>/<template> accessibility/inert title.
+// NOT `head > title`: a streaming rewriter never sees an implied <head>, and headless fragments (a
+// file starting at <style>/<h1>) are common among agent-generated uploads — the bare selector plus
+// exclusion covers both. Description: `og:description` wins over `name="description"` regardless of
+// document order (the author-curated share blurb beats the SEO one), first of each kind wins.
+// The body streams through ONE rewriter pass and only the matched strings are retained, so a 20MB
+// entry is never buffered. Each value is whitespace-collapsed, trimmed, entity-decoded, and capped;
+// empty/absent → null.
+export async function extractHtmlMeta(entry: EntryFile, body: Blob | string): Promise<HtmlMeta> {
+  if (!(/\.html?$/i.test(entry.path) || entry.mimeType === 'text/html')) return NO_META
   // Handlers on the same element fire in registration order, so the exclusion selectors run
   // before the bare 'title' handler and can flag the element it is about to see.
   let excluded = false
@@ -96,6 +112,9 @@ export async function extractHtmlTitle(entry: EntryFile, body: Blob | string): P
       },
     })
   }
+  // Attribute values arrive raw (entities undecoded), same as text chunks — `clean` handles both.
+  let ogDescription: string | null = null
+  let nameDescription: string | null = null
   const transformed = rewriter
     .on('title', {
       element() {
@@ -107,12 +126,22 @@ export async function extractHtmlTitle(entry: EntryFile, body: Blob | string): P
         if (taking) chunks.push(text.text)
       },
     })
+    .on('meta', {
+      element(element) {
+        const content = element.getAttribute('content')
+        if (!content) return
+        if (ogDescription === null && element.getAttribute('property') === 'og:description') {
+          ogDescription = clean(content, DESCRIPTION_CAP)
+        } else if (nameDescription === null && element.getAttribute('name')?.toLowerCase() === 'description') {
+          nameDescription = clean(content, DESCRIPTION_CAP)
+        }
+      },
+    })
     .transform(new Response(body))
   // Drain without collecting the rewritten output (Response.text() would rebuild the whole body).
   const reader = transformed.body?.getReader()
   if (reader) while (!(await reader.read()).done) {}
-  const title = decodeEntities(chunks.join('')).replace(/\s+/g, ' ').trim()
-  return title ? capTitle(title) : null
+  return { title: clean(chunks.join(''), TITLE_CAP), description: ogDescription ?? nameDescription }
 }
 
 export async function extractText(entry: EntryFile, body: string): Promise<Extracted> {

--- a/packages/api/src/lib/hmac.ts
+++ b/packages/api/src/lib/hmac.ts
@@ -30,6 +30,13 @@ export async function hmacSign(secret: string, message: string): Promise<string>
   return b64urlEncode(mac)
 }
 
+/** hex(HMAC-SHA256(secret, message)) — same primitive, the encoding third parties ask for (Slack's
+ *  request signatures are `v0=<hex>`). Compare the result with `secretEquals`, never `===`. */
+export async function hmacSignHex(secret: string, message: string): Promise<string> {
+  const mac = await crypto.subtle.sign('HMAC', await importKey(secret), enc.encode(message))
+  return Array.from(new Uint8Array(mac), (b) => b.toString(16).padStart(2, '0')).join('')
+}
+
 /** Constant-time verify of a base64url MAC against `message`. False on any decode error. */
 export async function hmacVerify(secret: string, message: string, macB64: string): Promise<boolean> {
   let mac: Uint8Array

--- a/packages/api/src/lib/site-access.ts
+++ b/packages/api/src/lib/site-access.ts
@@ -17,6 +17,7 @@ export type ResolvedSite = {
   spaceId: string
   slug: string
   title: string | null
+  description: string | null
   visibility: Visibility
   status: 'active' | 'archived'
   ownerId: string
@@ -29,6 +30,7 @@ const RESOLVED_SITE_COLUMNS = {
   spaceId: sitesTable.spaceId,
   slug: sitesTable.slug,
   title: sitesTable.title,
+  description: sitesTable.description,
   visibility: sitesTable.visibility,
   status: sitesTable.status,
   ownerId: sitesTable.ownerId,

--- a/packages/api/src/lib/slack-unfurl.test.ts
+++ b/packages/api/src/lib/slack-unfurl.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from 'bun:test'
+import { countingKv } from '../test/harness'
+import { buildUnfurlBlocks, parseSiteUrl, postUnfurl } from './slack-unfurl'
+import type { SlackHttpDeps } from './slack'
+
+const APP = 'https://glance.example.com'
+
+const depsWith = (fetchImpl: typeof fetch) =>
+  ({ kv: countingKv(), token: 'xoxb-test', fetchImpl }) as unknown as SlackHttpDeps
+
+describe('parseSiteUrl', () => {
+  test('returns the space and site slugs a URL points at, ignoring path tail, query, and fragment', () => {
+    const expected = { spaceSlug: 'acme', siteSlug: 'report' }
+    expect(parseSiteUrl(`${APP}/acme/report`, APP)).toEqual(expected)
+    expect(parseSiteUrl(`${APP}/acme/report/docs/page.html`, APP)).toEqual(expected)
+    expect(parseSiteUrl(`${APP}/acme/report?review=1#c1`, APP)).toEqual(expected)
+    expect(parseSiteUrl(`${APP}/acme/report/`, APP)).toEqual(expected)
+  })
+
+  test('rejects any other origin — a look-alike host must never resolve against our data', () => {
+    expect(parseSiteUrl('https://glance.evil.com/acme/report', APP)).toBeNull()
+    expect(parseSiteUrl('http://glance.example.com/acme/report', APP)).toBeNull() // scheme is part of origin
+    expect(parseSiteUrl('https://glance.example.com.evil.com/acme/report', APP)).toBeNull()
+  })
+
+  test('rejects non-site paths: too few segments and reserved first segments', () => {
+    expect(parseSiteUrl(`${APP}/`, APP)).toBeNull()
+    expect(parseSiteUrl(`${APP}/dashboard`, APP)).toBeNull()
+    expect(parseSiteUrl(`${APP}/api/sites/acme/report`, APP)).toBeNull()
+    expect(parseSiteUrl(`${APP}/assets/index-abc.js`, APP)).toBeNull()
+    expect(parseSiteUrl('not a url', APP)).toBeNull()
+  })
+})
+
+describe('buildUnfurlBlocks', () => {
+  const site = { title: 'Q3 Report', description: 'How the numbers moved', slug: 'report' }
+
+  test('links the title and includes the blurb plus a context line', () => {
+    const json = JSON.stringify(buildUnfurlBlocks(site, 'acme', `${APP}/acme/report`))
+    expect(json).toContain(`<${APP}/acme/report|Q3 Report>`)
+    expect(json).toContain('How the numbers moved')
+    expect(json).toContain('acme/report')
+  })
+
+  test('falls back to the slug when the site has no title, and drops the blurb when absent', () => {
+    const blocks = buildUnfurlBlocks({ ...site, title: null, description: null }, 'acme', `${APP}/acme/report`)
+    expect(JSON.stringify(blocks)).toContain('|report>')
+    expect(blocks).toHaveLength(2) // title section + context, no description section
+  })
+
+  test('escapes mrkdwn metacharacters in the author-controlled title and description', () => {
+    const json = JSON.stringify(
+      buildUnfurlBlocks({ ...site, title: '<script>&x', description: 'a > b & c < d' }, 'acme', `${APP}/acme/report`),
+    )
+    expect(json).toContain('&lt;script&gt;&amp;x')
+    expect(json).toContain('a &gt; b &amp; c &lt; d')
+    expect(json).not.toContain('<script>')
+  })
+})
+
+describe('postUnfurl', () => {
+  const unfurls = { [`${APP}/acme/report`]: { blocks: [{ type: 'section' }] } }
+
+  /** Capture the JSON body chat.unfurl was called with (null when it was never called). */
+  function capture() {
+    let body: Record<string, unknown> | null = null
+    const deps = depsWith(async (_url, init) => {
+      body = JSON.parse(String((init as RequestInit).body))
+      return Response.json({ ok: true })
+    })
+    return { deps, body: () => body }
+  }
+
+  test('addresses the message by unfurl_id + source when present, keyed by the pasted URL', async () => {
+    const { deps, body } = capture()
+    await postUnfurl(deps, { unfurl_id: 'C1.1', source: 'conversations_history', channel: 'C1', message_ts: '1.2' }, unfurls)
+    expect(body()).toMatchObject({ unfurl_id: 'C1.1', source: 'conversations_history' })
+    // Exclusive with the channel+ts form — Slack gets one addressing scheme, not both.
+    expect(body()?.channel).toBeUndefined()
+    expect(Object.keys(body()?.unfurls as object)).toEqual([`${APP}/acme/report`])
+  })
+
+  test('falls back to channel + ts when the event carries no unfurl_id', async () => {
+    const { deps, body } = capture()
+    await postUnfurl(deps, { channel: 'C123', message_ts: '1.2' }, unfurls)
+    expect(body()).toMatchObject({ channel: 'C123', ts: '1.2' })
+    expect(body()?.unfurl_id).toBeUndefined()
+  })
+
+  test('no cards → zero HTTP; a failing post never throws', async () => {
+    const { deps, body } = capture()
+    await postUnfurl(deps, { unfurl_id: 'C1.1' }, {})
+    expect(body()).toBeNull()
+    await postUnfurl(
+      depsWith(() => {
+        throw new Error('network')
+      }),
+      { unfurl_id: 'C1.1' },
+      unfurls,
+    )
+  })
+})

--- a/packages/api/src/lib/slack-unfurl.ts
+++ b/packages/api/src/lib/slack-unfurl.ts
@@ -1,0 +1,81 @@
+// Slack link-unfurl lib: parse a pasted Glance URL, build the card, post it back via chat.unfurl.
+// Transport, escaping, and identity lookups all come from lib/slack.ts — this file owns only what is
+// unfurl-specific (URL shape, card layout).
+//
+// Why app-controlled unfurling instead of public Open Graph tags: the unfurl travels over Slack's
+// authenticated API, so NO site metadata is ever exposed to an anonymous fetch of the URL. Sites
+// stay fully gated (lib/access.ts is untouched), and we can authorize the card against the person
+// who pasted the link. Docs: https://docs.slack.dev/messaging/unfurling-links-in-messages/
+
+import { escapeSlack, slackLink, slackPost, type SlackHttpDeps } from './slack'
+import { RESERVED_SLUGS } from './slug'
+
+const UNFURL_URL = 'https://slack.com/api/chat.unfurl'
+
+/** A Block Kit block. Slack's schema is open-ended (dozens of block/element types), so this pins the
+ *  one field every block has rather than pretending to model the union — still far tighter than the
+ *  `object` it replaces. */
+export type SlackBlock = { type: string } & Record<string, unknown>
+
+/** The site slugs a pasted URL points at. Deliberately NOT the in-site file path: the card links the
+ *  pasted URL verbatim, so nothing downstream needs the path split out. */
+export type ParsedSiteUrl = { spaceSlug: string; siteSlug: string }
+
+/** Parse a pasted URL into (space, site), or null when it isn't a site link on THIS instance.
+ *  Rejects: another origin (a look-alike host must never be resolved against our D1), fewer than two
+ *  path segments (`/dashboard`, `/:space`), and a reserved first segment (`/api/…`, `/assets/…` —
+ *  never a space, see lib/slug.ts, so this skips a pointless D1 read). Slugs are `[a-z0-9-]` by
+ *  `isValidSlug`, so no percent-decoding is needed to compare them. */
+export function parseSiteUrl(raw: string, appUrl: string): ParsedSiteUrl | null {
+  let url: URL
+  let base: URL
+  try {
+    url = new URL(raw)
+    base = new URL(appUrl)
+  } catch {
+    return null
+  }
+  if (url.origin !== base.origin) return null
+  const [spaceSlug, siteSlug] = url.pathname.split('/').filter(Boolean)
+  if (!spaceSlug || !siteSlug || RESERVED_SLUGS.has(spaceSlug)) return null
+  return { spaceSlug, siteSlug }
+}
+
+/** Block Kit blocks for one site card: bold linked title, the derived blurb, and a context line
+ *  naming the space/site. Slack renders `text` fields as mrkdwn, so the two author-controlled
+ *  strings (title, description) go through `escapeSlack`; the slugs are `[a-z0-9-]` and need none. */
+export function buildUnfurlBlocks(
+  site: { title: string | null; description: string | null; slug: string },
+  spaceSlug: string,
+  url: string,
+): SlackBlock[] {
+  return [
+    { type: 'section', text: { type: 'mrkdwn', text: `*${slackLink(url, site.title ?? site.slug)}*` } },
+    ...(site.description
+      ? [{ type: 'section', text: { type: 'mrkdwn', text: escapeSlack(site.description) } } as SlackBlock]
+      : []),
+    { type: 'context', elements: [{ type: 'mrkdwn', text: `Glance · ${spaceSlug}/${site.slug}` }] },
+  ]
+}
+
+/** The `link_shared` fields that say WHICH message to attach the unfurl to. `unfurl_id`+`source` is
+ *  the modern pair (it also covers composer-time previews); `channel`+`ts` is the fallback for an
+ *  event that carries no unfurl_id. */
+export type UnfurlTarget = { unfurl_id?: string; source?: string; channel?: string; message_ts?: string }
+
+/** POST the assembled cards to chat.unfurl. Keys of `unfurls` MUST be the URLs verbatim as they
+ *  appeared in the link_shared event; the nested-object form is what Slack's chat.unfurl JSON-body
+ *  docs show. No cards → no request at all. */
+export async function postUnfurl(
+  deps: SlackHttpDeps,
+  target: UnfurlTarget,
+  unfurls: Record<string, { blocks: SlackBlock[] }>,
+): Promise<void> {
+  if (Object.keys(unfurls).length === 0) return
+  await slackPost(deps, UNFURL_URL, {
+    ...(target.unfurl_id
+      ? { unfurl_id: target.unfurl_id, source: target.source }
+      : { channel: target.channel, ts: target.message_ts }),
+    unfurls,
+  })
+}

--- a/packages/api/src/lib/slack-verify.test.ts
+++ b/packages/api/src/lib/slack-verify.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from 'bun:test'
+import { MAX_SKEW_SECONDS, verifySlackSignature } from './slack-verify'
+
+const TEST_SIGNING_KEY = 'not-a-real-slack-signing-key'
+const NOW = 1_700_000_000
+
+/** Independently re-derive the signature Slack would send, so the test proves the algorithm
+ *  (v0:ts:body → HMAC-SHA256 hex) rather than replaying whatever the implementation produced. */
+async function sign(body: string, timestamp: number, secret = TEST_SIGNING_KEY): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  )
+  const mac = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(`v0:${timestamp}:${body}`))
+  const hex = Array.from(new Uint8Array(mac), (b) => b.toString(16).padStart(2, '0')).join('')
+  return `v0=${hex}`
+}
+
+const verify = (over: Partial<Parameters<typeof verifySlackSignature>[0]> & { signature?: string }) =>
+  verifySlackSignature({
+    signingSecret: TEST_SIGNING_KEY,
+    timestamp: String(NOW),
+    signature: '',
+    body: '{}',
+    nowSeconds: NOW,
+    ...over,
+  })
+
+describe('verifySlackSignature', () => {
+  const body = '{"type":"event_callback","event":{"type":"link_shared"}}'
+
+  test('accepts a correctly signed, fresh request', async () => {
+    expect(await verify({ body, signature: await sign(body, NOW) })).toBe(true)
+  })
+
+  test('rejects a tampered body under a valid signature', async () => {
+    const signature = await sign(body, NOW)
+    expect(await verify({ body: `${body} `, signature })).toBe(false)
+  })
+
+  test('rejects a signature made with a different signing secret', async () => {
+    expect(await verify({ body, signature: await sign(body, NOW, 'wrong-secret') })).toBe(false)
+  })
+
+  test('rejects a replay outside the skew window, in both directions', async () => {
+    const old = NOW - MAX_SKEW_SECONDS - 1
+    expect(await verify({ body, timestamp: String(old), signature: await sign(body, old) })).toBe(false)
+    const future = NOW + MAX_SKEW_SECONDS + 1
+    expect(await verify({ body, timestamp: String(future), signature: await sign(body, future) })).toBe(false)
+  })
+
+  test('accepts right at the edge of the skew window', async () => {
+    const edge = NOW - MAX_SKEW_SECONDS
+    expect(await verify({ body, timestamp: String(edge), signature: await sign(body, edge) })).toBe(true)
+  })
+
+  test('rejects a signature bound to a DIFFERENT timestamp than the header claims', async () => {
+    expect(await verify({ body, timestamp: String(NOW), signature: await sign(body, NOW - 10) })).toBe(false)
+  })
+
+  test('fails closed on missing headers, a non-numeric timestamp, or a blank secret', async () => {
+    expect(await verify({ body, signature: undefined })).toBe(false)
+    expect(await verify({ body, timestamp: undefined, signature: await sign(body, NOW) })).toBe(false)
+    expect(await verify({ body, timestamp: 'not-a-number', signature: await sign(body, NOW) })).toBe(false)
+    expect(await verify({ body, signingSecret: '', signature: await sign(body, NOW) })).toBe(false)
+  })
+
+  test('rejects a malformed signature (wrong prefix, truncated, empty)', async () => {
+    const good = await sign(body, NOW)
+    expect(await verify({ body, signature: good.replace('v0=', 'v1=') })).toBe(false)
+    expect(await verify({ body, signature: good.slice(0, -2) })).toBe(false)
+    expect(await verify({ body, signature: '' })).toBe(false)
+  })
+})

--- a/packages/api/src/lib/slack-verify.ts
+++ b/packages/api/src/lib/slack-verify.ts
@@ -1,0 +1,44 @@
+// Slack request-signature verification for the events endpoint. Pure + injectable so it unit-tests
+// directly. Slack signs every request to our Request URL; this is the ONLY thing standing between the
+// endpoint and an anonymous POST, since Slack sends no cookie and no Origin (requireSameOrigin
+// therefore passes it through untouched).
+// Algorithm per https://docs.slack.dev/authentication/verifying-requests-from-slack/:
+//   basestring = `v0:${timestamp}:${rawBody}` → HMAC-SHA256 with the signing secret → hex, `v0=`-prefixed.
+// The crypto itself is lib/hmac.ts + lib/bootstrap.ts's secretEquals — never re-implemented here.
+
+import { secretEquals } from './bootstrap'
+import { hmacSignHex } from './hmac'
+
+/** How far a request's timestamp may drift from now before we treat it as a replay. Slack's own
+ *  guidance is five minutes; the timestamp is signed, so this is what bounds a captured request's
+ *  usable lifetime. */
+export const MAX_SKEW_SECONDS = 300
+
+export type SlackSignatureInput = {
+  signingSecret: string
+  /** The `x-slack-request-timestamp` header, verbatim. */
+  timestamp: string | undefined
+  /** The `x-slack-signature` header, verbatim (`v0=<hex>`). */
+  signature: string | undefined
+  /** The RAW request body — the exact bytes Slack signed. Re-serializing parsed JSON breaks this. */
+  body: string
+  /** Current unix time in seconds (injected so the skew check is testable). */
+  nowSeconds: number
+}
+
+/** True iff the request carries a fresh, correctly-signed Slack signature. Fails closed on every
+ *  missing/malformed input — a blank secret can never verify, so an unconfigured deploy accepts
+ *  nothing (the route also gates on the secret being set before it gets here). Never throws. */
+export async function verifySlackSignature(input: SlackSignatureInput): Promise<boolean> {
+  const { signingSecret, timestamp, signature, body, nowSeconds } = input
+  if (!signingSecret.trim() || !timestamp || !signature) return false
+  // Reject a stale (or future-dated) timestamp before spending a HMAC on it.
+  const ts = Number(timestamp)
+  if (!Number.isFinite(ts) || Math.abs(nowSeconds - ts) > MAX_SKEW_SECONDS) return false
+
+  try {
+    return await secretEquals(`v0=${await hmacSignHex(signingSecret, `v0:${timestamp}:${body}`)}`, signature)
+  } catch {
+    return false
+  }
+}

--- a/packages/api/src/lib/slack.test.ts
+++ b/packages/api/src/lib/slack.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 import { countingKv } from '../test/harness'
-import { deliverSlack, formatSlackMessage, lookupSlackId } from './slack'
+import { deliverSlack, formatSlackMessage, lookupSlackEmail, lookupSlackId } from './slack'
 
 // Records every fetch call so specs can assert exact request count, URL, and headers.
 function recordingFetch(handler: (url: string, init?: RequestInit) => Response | Promise<Response>) {
@@ -253,5 +253,51 @@ describe('deliverSlack', () => {
       { id: 'u1', email: 'live@plivo.com', reason: 'owner' },
     ])
     expect(posts).toBe(1)
+  })
+})
+
+describe('lookupSlackEmail', () => {
+  const infoOk = (email: string) => Response.json({ ok: true, user: { profile: { email } } })
+
+  test('resolves the profile email, caches it 30d, and serves the second call from KV', async () => {
+    const kv = countingKv()
+    const { fetchImpl, calls } = recordingFetch(() => infoOk('sam@plivo.com'))
+    const deps = { kv, token: 'xoxb-tok', fetchImpl }
+
+    expect(await lookupSlackEmail(deps, 'U123')).toBe('sam@plivo.com')
+    expect(await lookupSlackEmail(deps, 'U123')).toBe('sam@plivo.com')
+    expect(calls).toHaveLength(1)
+    expect(calls[0].url).toContain('users.info')
+    expect(bearer(calls[0].init)).toBe('Bearer xoxb-tok')
+    expect(kv.store.get('slackemail:U123')).toBe('sam@plivo.com')
+    expect(kv.ttls.get('slackemail:U123')).toBe(2_592_000)
+  })
+
+  test('an ok response with no readable email is DEFINITIVE — negative-cached, so no re-fetch storm', async () => {
+    const kv = countingKv()
+    const { fetchImpl, calls } = recordingFetch(() => Response.json({ ok: true, user: { profile: {} } }))
+    const deps = { kv, token: 'tok', fetchImpl }
+
+    expect(await lookupSlackEmail(deps, 'Ubot')).toBeNull()
+    expect(await lookupSlackEmail(deps, 'Ubot')).toBeNull()
+    expect(calls).toHaveLength(1) // second call short-circuits on the cached marker
+    expect(kv.ttls.get('slackemail:Ubot')).toBe(3_600)
+  })
+
+  test('transient failures (5xx, ok:false, network throw) return null and cache NOTHING', async () => {
+    const kv = countingKv()
+    const server = recordingFetch(() => new Response('', { status: 503 }))
+    expect(await lookupSlackEmail({ kv, token: 't', fetchImpl: server.fetchImpl }, 'U1')).toBeNull()
+    const notOk = recordingFetch(() => Response.json({ ok: false, error: 'ratelimited' }))
+    expect(await lookupSlackEmail({ kv, token: 't', fetchImpl: notOk.fetchImpl }, 'U1')).toBeNull()
+    const threw = recordingFetch(() => {
+      throw new Error('network')
+    })
+    expect(await lookupSlackEmail({ kv, token: 't', fetchImpl: threw.fetchImpl }, 'U1')).toBeNull()
+    expect(kv.ops().put).toBe(0)
+
+    // ...and a later success still resolves, proving nothing was poisoned.
+    const ok = recordingFetch(() => infoOk('a@b.c'))
+    expect(await lookupSlackEmail({ kv, token: 't', fetchImpl: ok.fetchImpl }, 'U1')).toBe('a@b.c')
   })
 })

--- a/packages/api/src/lib/slack.ts
+++ b/packages/api/src/lib/slack.ts
@@ -22,8 +22,17 @@ export type SlackHttpDeps = {
  *  whitespace-only token is OFF everywhere, never doing wasted D1/HTTP work). */
 export const slackEnabled = (token?: string): boolean => !!token && token.trim() !== ''
 
+/** The unfurl surface needs BOTH secrets — the bot token to post the card and the signing secret to
+ *  authenticate Slack's inbound request — and both must mean "off" the same way, so a whitespace-only
+ *  secret goes dark rather than leaving the endpoint live behind a guessable key. Shape mirrors
+ *  `isGoogleEnabled`. */
+export const slackUnfurlEnabled = (env: Pick<Bindings, 'SLACK_BOT_TOKEN' | 'SLACK_SIGNING_SECRET'>): boolean =>
+  slackEnabled(env.SLACK_BOT_TOKEN) && slackEnabled(env.SLACK_SIGNING_SECRET)
+
 const LOOKUP_URL = 'https://slack.com/api/users.lookupByEmail'
+const INFO_URL = 'https://slack.com/api/users.info'
 const CACHE_PREFIX = 'slackuid:'
+const EMAIL_CACHE_PREFIX = 'slackemail:'
 // Positive results are stable, so cache ~30d; a definitive not-found only ~1h (the person may join
 // the workspace). TTLs are product-chosen (see tracker 3.1).
 const POSITIVE_TTL = 2_592_000 // 30d
@@ -34,44 +43,86 @@ const NEGATIVE_MARKER = '-'
 
 const cacheKey = (email: string) => `${CACHE_PREFIX}${email.toLowerCase()}`
 
-type LookupResponse = { ok?: boolean; error?: string; user?: { id?: unknown } }
+type LookupResponse = { ok?: boolean; error?: string; user?: { id?: unknown; profile?: { email?: unknown } } }
 
-/** Resolve a Slack user-id (usable directly as a DM channel) for an email, KV-cached. Cache hit →
- *  return (a negative marker resolves to null, never leaks as a channel). Miss → Slack
- *  users.lookupByEmail: a hit caches ~30d, a definitive `users_not_found` caches the negative marker
- *  ~1h. Transient/auth failures (5xx, network throw, 429, invalid_auth, or a malformed ok body) →
- *  null WITHOUT caching, so a later call re-attempts and never poisons on a recoverable error.
- *  Never throws. */
-export async function lookupSlackId(deps: SlackHttpDeps, email: string): Promise<string | null> {
-  const key = cacheKey(email)
+/** Slack GET with the bot token. Returns the parsed body, or null when the call failed in a way the
+ *  caller must treat as RETRYABLE (429, 5xx, network throw, unparseable body) — never as an answer.
+ *  Every Slack read goes through here so the transient-failure policy is stated exactly once. */
+async function slackGet(deps: SlackHttpDeps, url: string): Promise<LookupResponse | null> {
+  const fetchImpl = deps.fetchImpl ?? globalThis.fetch
+  try {
+    const res = await fetchImpl(url, { headers: { Authorization: `Bearer ${deps.token ?? ''}` } })
+    if (res.status === 429 || res.status >= 500) return null
+    return (await res.json()) as LookupResponse
+  } catch {
+    return null
+  }
+}
+
+/** Slack POST with a JSON body. Best-effort by contract: every failure mode (non-2xx, `{ok:false}`,
+ *  network throw) means "this message didn't land", and there is nothing to retry or report — so it
+ *  returns nothing and never throws. */
+export async function slackPost(deps: SlackHttpDeps, url: string, body: unknown): Promise<void> {
+  const fetchImpl = deps.fetchImpl ?? globalThis.fetch
+  try {
+    await fetchImpl(url, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${deps.token ?? ''}`, 'Content-Type': 'application/json; charset=utf-8' },
+      body: JSON.stringify(body),
+    })
+  } catch {
+    // Swallowed on purpose — see the contract above.
+  }
+}
+
+/** What a lookup response means, as the caching policy sees it: a resolved value, a DEFINITIVE miss
+ *  (worth remembering briefly), or a transient failure (never cached). */
+type LookupOutcome = { value: string } | 'not-found' | 'transient'
+
+/** KV-cached Slack identity lookup, shared by both directions (email→id, id→email). Cache hit →
+ *  return (the negative marker resolves to null, never leaking as a channel id). Miss → one
+ *  `slackGet`, then: a value caches ~30d, a definitive miss caches the marker ~1h (so a bot or
+ *  email-less guest doesn't re-hit Slack on every event), and a transient failure caches NOTHING so
+ *  a later call re-attempts. Caching is best-effort — a KV put failure must never lose an already
+ *  resolved value. Never throws. */
+async function cachedLookup(
+  deps: SlackHttpDeps,
+  key: string,
+  url: string,
+  read: (data: LookupResponse) => LookupOutcome,
+): Promise<string | null> {
   const cached = await deps.kv.get(key)
   if (cached !== null) return cached === NEGATIVE_MARKER ? null : cached
 
-  const fetchImpl = deps.fetchImpl ?? globalThis.fetch
-  let data: LookupResponse
-  try {
-    const res = await fetchImpl(`${LOOKUP_URL}?email=${encodeURIComponent(email)}`, {
-      headers: { Authorization: `Bearer ${deps.token ?? ''}` },
-    })
-    // Transient HTTP (rate-limit / server) — retryable, so never cache a negative.
-    if (res.status === 429 || res.status >= 500) return null
-    data = (await res.json()) as LookupResponse
-  } catch {
-    return null // network throw / bad JSON — transient, no cache
-  }
-
-  // Caching is best-effort: a KV put failure must never lose an already-resolved id (nor turn a
-  // clean not-found into a thrown error) — the caller still gets to deliver this event.
-  if (data.ok && typeof data.user?.id === 'string') {
-    await deps.kv.put(key, data.user.id, { expirationTtl: POSITIVE_TTL }).catch(() => {})
-    return data.user.id
-  }
-  if (data.error === 'users_not_found') {
+  const data = await slackGet(deps, url)
+  const outcome = data === null ? 'transient' : read(data)
+  if (outcome === 'transient') return null
+  if (outcome === 'not-found') {
     await deps.kv.put(key, NEGATIVE_MARKER, { expirationTtl: NEGATIVE_TTL }).catch(() => {})
     return null
   }
-  // invalid_auth, other errors, or ok-but-no-id → transient/unknown; return null without caching.
-  return null
+  await deps.kv.put(key, outcome.value, { expirationTtl: POSITIVE_TTL }).catch(() => {})
+  return outcome.value
+}
+
+/** Resolve a Slack user-id (usable directly as a DM channel) for an email. */
+export function lookupSlackId(deps: SlackHttpDeps, email: string): Promise<string | null> {
+  return cachedLookup(deps, cacheKey(email), `${LOOKUP_URL}?email=${encodeURIComponent(email)}`, (data) => {
+    if (data.ok && typeof data.user?.id === 'string') return { value: data.user.id }
+    // `users_not_found` is definitive; invalid_auth / other errors / ok-but-no-id are not.
+    return data.error === 'users_not_found' ? 'not-found' : 'transient'
+  })
+}
+
+/** Resolve the profile email of a Slack user-id — the inverse binding, used to map whoever shared a
+ *  link back onto a Glance account. An `ok` response with no readable email is DEFINITIVE (a bot, a
+ *  guest, or a workspace that never granted `users:read.email`), not a transient failure. */
+export function lookupSlackEmail(deps: SlackHttpDeps, userId: string): Promise<string | null> {
+  return cachedLookup(deps, `${EMAIL_CACHE_PREFIX}${userId}`, `${INFO_URL}?user=${encodeURIComponent(userId)}`, (data) => {
+    if (!data.ok) return 'transient'
+    const email = data.user?.profile?.email
+    return typeof email === 'string' && email !== '' ? { value: email } : 'not-found'
+  })
 }
 
 /** The per-event context shared by every DM: the actor and the link/snippet fields. */
@@ -89,8 +140,14 @@ export type SlackEvent = {
  *  fields feed notificationLink; `snippet` is the already-truncated comment body (may be null/empty). */
 export type SlackMessageInput = SlackEvent & { reason: SlackReason }
 
-// Slack mrkdwn only reserves &, <, > in message text (order matters — & first).
-const escapeSlack = (s: string): string => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+// Slack mrkdwn only reserves &, <, > in message text (order matters — & first). Exported because
+// EVERY Slack-wire string (DM text, unfurl card blocks) must pass through this one copy.
+export const escapeSlack = (s: string): string => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+
+/** Slack's hyperlink idiom, `<url|label>`. The `&` in a query string must be entity-escaped even
+ *  inside the URL (mrkdwn's rule), and the label is escaped like any other text. */
+export const slackLink = (url: string, label: string): string =>
+  `<${url.replace(/&/g, '&amp;')}|${escapeSlack(label)}>`
 
 // The verb clause per reason (owner > participant > share precedence is decided upstream). The
 // wording is Slack-only — the in-app bell keeps its terse "commented" (no schema change).
@@ -113,9 +170,7 @@ export function formatSlackMessage(input: SlackMessageInput, appUrl: string): st
     filePath: input.filePath,
     threadId: input.threadId,
   })
-  // Site label as a bold Slack hyperlink. Slack link syntax is <url|text>; the & in the query string
-  // must be entity-escaped even inside the URL (Slack's mrkdwn escaping rule).
-  const site = `*<${url.replace(/&/g, '&amp;')}|${escapeSlack(input.siteLabel)}>*`
+  const site = `*${slackLink(url, input.siteLabel)}*` // bold hyperlink
   const lines = [`${actor} ${VERB[input.reason](site)}`]
   const snippet = input.snippet ? escapeSlack(input.snippet).trim() : ''
   if (snippet) lines.push(`> _${snippet}_`) // block-quoted + italic
@@ -172,21 +227,14 @@ function capMentionFirst(recipients: SlackRecipient[]): SlackRecipient[] {
  *  or surfaces to the caller. Never throws. */
 export async function deliverSlack(deps: SlackDeps, event: SlackEvent, recipients: SlackRecipient[]): Promise<void> {
   if (!slackEnabled(deps.token)) return
-  const fetchImpl = deps.fetchImpl ?? globalThis.fetch
   for (const r of capMentionFirst(recipients)) {
     try {
       if (!r.email) continue
       const channel = await lookupSlackId(deps, r.email)
       if (!channel) continue
-      const text = formatSlackMessage({ ...event, reason: r.reason }, deps.appUrl)
-      // Best-effort post: every non-success outcome (429/5xx or an ok:false body) means "this DM
-      // didn't land" — there's nothing to retry and nothing to do differently, so we just move on.
-      // A network throw lands in the catch below. Neither ever aborts the remaining recipients.
-      await fetchImpl(POST_URL, {
-        method: 'POST',
-        headers: { Authorization: `Bearer ${deps.token}`, 'Content-Type': 'application/json; charset=utf-8' },
-        body: JSON.stringify({ channel, text }),
-      })
+      // slackPost is best-effort by contract (see its docstring); the try/catch here is the
+      // per-recipient isolation for the lookup, so one bad DM never aborts the remaining fan-out.
+      await slackPost(deps, POST_URL, { channel, text: formatSlackMessage({ ...event, reason: r.reason }, deps.appUrl) })
     } catch {
       // Per-recipient isolation — swallow so one bad DM never fails the comment that already committed.
     }

--- a/packages/api/src/routes/sites.ts
+++ b/packages/api/src/routes/sites.ts
@@ -618,6 +618,9 @@ sites.post('/:spaceSlug/:siteSlug/fork', requireAuth, async (c) => {
         spaceId: dest.id,
         slug,
         title,
+        // A fork COPIES the bytes, so it inherits the blurb derived from them; the next replace
+        // re-derives it from whatever the fork's own content becomes.
+        description: site.description,
         // Inherit the source's tier: a fork of a private site is private, not silently widened.
         visibility: site.visibility,
         ownerId: user.id,

--- a/packages/api/src/routes/slack-events.test.ts
+++ b/packages/api/src/routes/slack-events.test.ts
@@ -1,0 +1,249 @@
+import { describe, expect, test } from 'bun:test'
+import { APP_URL, makeRouteApp, signSlack } from '../test/route-fixtures'
+import { seedSite, seedSpace, seedUser } from '../test/harness'
+import type { AppEnv } from '../types'
+
+// Route-level Slack unfurl: a signed link_shared event → chat.unfurl, exercised through
+// app.request with an injected SLACK_FETCH (the same env DI seam comments-slack.test.ts uses).
+// In app.request there is no executionCtx, so fireAndForget awaits inline — the unfurl is already
+// posted by the time the 200 resolves.
+
+const TEST_SIGNING_KEY = 'not-a-real-slack-signing-key'
+const NOW = () => Math.floor(Date.now() / 1000)
+
+/** Recording SLACK_FETCH: users.info answers from `emails` (Slack id → email), chat.unfurl records
+ *  the posted body. Any other Slack URL is a test bug and throws. */
+function slackFetch(emails: Record<string, string> = {}) {
+  const unfurls: Record<string, unknown>[] = []
+  let infoCalls = 0
+  const fetchImpl = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input.toString()
+    if (url.includes('users.info')) {
+      infoCalls++
+      const id = new URL(url).searchParams.get('user') ?? ''
+      const email = emails[id]
+      return email
+        ? Response.json({ ok: true, user: { profile: { email } } })
+        : Response.json({ ok: false, error: 'user_not_found' })
+    }
+    if (url.includes('chat.unfurl')) {
+      unfurls.push(JSON.parse(String(init?.body)))
+      return Response.json({ ok: true })
+    }
+    throw new Error(`unexpected slack url: ${url}`)
+  }) as unknown as typeof fetch
+  return { fetchImpl, unfurls, infoCalls: () => infoCalls }
+}
+
+/** The production-shaped fixture env plus the two Slack secrets; `extra` overrides either (or
+ *  injects the recording SLACK_FETCH). */
+const envWith = (env: AppEnv['Bindings'], extra: Record<string, unknown>) =>
+  ({ ...env, SLACK_BOT_TOKEN: 'xoxb-test', SLACK_SIGNING_SECRET: TEST_SIGNING_KEY, ...extra }) as unknown as AppEnv['Bindings']
+
+async function post(
+  app: ReturnType<typeof makeRouteApp>['app'],
+  env: AppEnv['Bindings'],
+  payload: unknown,
+  opts: { signature?: string; timestamp?: number } = {},
+) {
+  const body = JSON.stringify(payload)
+  const timestamp = opts.timestamp ?? NOW()
+  const signature = opts.signature ?? (await signSlack(TEST_SIGNING_KEY, body, timestamp))
+  return app.request(
+    '/api/slack/events',
+    {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-slack-request-timestamp': String(timestamp),
+        'x-slack-signature': signature,
+      },
+      body,
+    },
+    env,
+  )
+}
+
+const linkShared = (urls: string[], user = 'Usharer') => ({
+  type: 'event_callback',
+  event: {
+    type: 'link_shared',
+    user,
+    channel: 'C123',
+    message_ts: '1700000000.1',
+    unfurl_id: 'C123.1700000000.1.1',
+    source: 'conversations_history',
+    links: urls.map((url) => ({ url, domain: 'glance.example.com' })),
+  },
+})
+
+/** Owner + space + one site; `sharer` is a separate user whose Slack profile email maps to them. */
+async function seedWorld(opts: { visibility?: 'private' | 'members' | 'team'; status?: 'active' | 'archived' } = {}) {
+  const world = makeRouteApp()
+  const owner = await seedUser(world.db, { id: 'owner', email: 'owner@x.com' })
+  await seedUser(world.db, { id: 'sharer', email: 'sharer@x.com' })
+  const spaceId = await seedSpace(world.db, { createdBy: owner, slug: 'acme' })
+  await seedSite(world.db, {
+    id: 'site-1',
+    spaceId,
+    ownerId: owner,
+    slug: 'report',
+    title: 'Q3 Report',
+    description: 'How the numbers moved',
+    visibility: opts.visibility ?? 'team',
+    status: opts.status ?? 'active',
+  })
+  return world
+}
+
+describe('POST /api/slack/events — gating', () => {
+  test('inert (404) when either secret is unset', async () => {
+    const { app, env } = makeRouteApp()
+    const noToken = await post(app, envWith(env, { SLACK_BOT_TOKEN: undefined }), { type: 'url_verification' })
+    expect(noToken.status).toBe(404)
+    const noSecret = await post(app, envWith(env, { SLACK_SIGNING_SECRET: undefined }), { type: 'url_verification' })
+    expect(noSecret.status).toBe(404)
+  })
+
+  test('answers the url_verification challenge on a signed request', async () => {
+    const { app, env } = makeRouteApp()
+    const res = await post(app, envWith(env, {}), { type: 'url_verification', challenge: 'abc123' })
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ challenge: 'abc123' })
+  })
+
+  test('401 on a bad signature — and no Slack HTTP happens', async () => {
+    const world = await seedWorld()
+    const { fetchImpl, infoCalls } = slackFetch({ Usharer: 'sharer@x.com' })
+    const res = await post(
+      world.app,
+      envWith(world.env, { SLACK_FETCH: fetchImpl }),
+      linkShared([`${APP_URL}/acme/report`]),
+      { signature: 'v0=deadbeef' },
+    )
+    expect(res.status).toBe(401)
+    expect(infoCalls()).toBe(0)
+  })
+
+  test('a cookieless Slack POST is not blocked by the same-origin CSRF guard', async () => {
+    const { app, env } = makeRouteApp()
+    const res = await post(app, envWith(env, {}), { type: 'url_verification', challenge: 'x' })
+    expect(res.status).not.toBe(403)
+  })
+})
+
+describe('POST /api/slack/events — link_shared', () => {
+  test('a site the sharer can read → one card with its title, blurb, and link', async () => {
+    const world = await seedWorld({ visibility: 'team' })
+    const { fetchImpl, unfurls } = slackFetch({ Usharer: 'sharer@x.com' })
+    const url = `${APP_URL}/acme/report`
+    const res = await post(world.app, envWith(world.env, { SLACK_FETCH: fetchImpl }), linkShared([url]))
+
+    expect(res.status).toBe(200)
+    expect(unfurls).toHaveLength(1)
+    expect(unfurls[0]).toMatchObject({ unfurl_id: 'C123.1700000000.1.1', source: 'conversations_history' })
+    const card = JSON.stringify((unfurls[0].unfurls as Record<string, unknown>)[url])
+    expect(card).toContain('Q3 Report')
+    expect(card).toContain('How the numbers moved')
+    expect(card).toContain(url)
+  })
+
+  test('a PRIVATE site the sharer cannot read → no card at all (no title, no existence signal)', async () => {
+    const world = await seedWorld({ visibility: 'private' })
+    const { fetchImpl, unfurls } = slackFetch({ Usharer: 'sharer@x.com' })
+    const res = await post(
+      world.app,
+      envWith(world.env, { SLACK_FETCH: fetchImpl }),
+      linkShared([`${APP_URL}/acme/report`]),
+    )
+    expect(res.status).toBe(200)
+    expect(unfurls).toHaveLength(0)
+  })
+
+  test('the site OWNER pasting their own private link does get a card', async () => {
+    const world = await seedWorld({ visibility: 'private' })
+    const { fetchImpl, unfurls } = slackFetch({ Uowner: 'owner@x.com' })
+    await post(
+      world.app,
+      envWith(world.env, { SLACK_FETCH: fetchImpl }),
+      linkShared([`${APP_URL}/acme/report`], 'Uowner'),
+    )
+    expect(unfurls).toHaveLength(1)
+  })
+
+  test('an archived site is not unfurled (checkAccess 410 applies here too)', async () => {
+    const world = await seedWorld({ status: 'archived' })
+    const { fetchImpl, unfurls } = slackFetch({ Usharer: 'sharer@x.com' })
+    await post(world.app, envWith(world.env, { SLACK_FETCH: fetchImpl }), linkShared([`${APP_URL}/acme/report`]))
+    expect(unfurls).toHaveLength(0)
+  })
+
+  test('an unknown Slack user, or one with no Glance account, yields no card', async () => {
+    const world = await seedWorld()
+    const noEmail = slackFetch({})
+    await post(
+      world.app,
+      envWith(world.env, { SLACK_FETCH: noEmail.fetchImpl }),
+      linkShared([`${APP_URL}/acme/report`]),
+    )
+    expect(noEmail.unfurls).toHaveLength(0)
+
+    const stranger = slackFetch({ Ustranger: 'nobody@x.com' })
+    await post(
+      world.app,
+      envWith(world.env, { SLACK_FETCH: stranger.fetchImpl }),
+      linkShared([`${APP_URL}/acme/report`], 'Ustranger'),
+    )
+    expect(stranger.unfurls).toHaveLength(0)
+  })
+
+  test('non-site links (foreign origin, missing site, reserved path) are skipped, valid ones still unfurl', async () => {
+    const world = await seedWorld()
+    const { fetchImpl, unfurls } = slackFetch({ Usharer: 'sharer@x.com' })
+    const good = `${APP_URL}/acme/report`
+    await post(
+      world.app,
+      envWith(world.env, { SLACK_FETCH: fetchImpl }),
+      linkShared(['https://evil.example/acme/report', `${APP_URL}/api/sites`, `${APP_URL}/acme/missing`, good]),
+    )
+    expect(unfurls).toHaveLength(1)
+    expect(Object.keys(unfurls[0].unfurls as object)).toEqual([good])
+  })
+
+  test('nothing unfurlable → zero chat.unfurl calls', async () => {
+    const world = await seedWorld()
+    const { fetchImpl, unfurls } = slackFetch({ Usharer: 'sharer@x.com' })
+    await post(world.app, envWith(world.env, { SLACK_FETCH: fetchImpl }), linkShared([`${APP_URL}/acme/missing`]))
+    expect(unfurls).toHaveLength(0)
+  })
+
+  test("a mixed-case Slack profile email still matches the (lowercase-canonical) Glance account", async () => {
+    const world = await seedWorld()
+    const { fetchImpl, unfurls } = slackFetch({ Usharer: 'Sharer@X.Com' })
+    await post(world.app, envWith(world.env, { SLACK_FETCH: fetchImpl }), linkShared([`${APP_URL}/acme/report`]))
+    expect(unfurls).toHaveLength(1)
+  })
+
+  test('two links into the SAME site resolve it once and produce a card per URL', async () => {
+    const world = await seedWorld()
+    const { fetchImpl, unfurls } = slackFetch({ Usharer: 'sharer@x.com' })
+    const root = `${APP_URL}/acme/report`
+    const deep = `${APP_URL}/acme/report/docs/page.html`
+    await post(world.app, envWith(world.env, { SLACK_FETCH: fetchImpl }), linkShared([root, deep, root]))
+    expect(unfurls).toHaveLength(1)
+    // Slack keys unfurls by URL, so both pasted URLs get a card — from one access resolution.
+    expect(Object.keys(unfurls[0].unfurls as object).sort()).toEqual([root, deep].sort())
+  })
+
+  test('a non-link_shared event is acked and ignored', async () => {
+    const world = await seedWorld()
+    const { fetchImpl, unfurls, infoCalls } = slackFetch({ Usharer: 'sharer@x.com' })
+    const res = await post(world.app, envWith(world.env, { SLACK_FETCH: fetchImpl }), {
+      type: 'event_callback',
+      event: { type: 'message', user: 'Usharer' },
+    })
+    expect(res.status).toBe(200)
+    expect(unfurls).toHaveLength(0)
+    expect(infoCalls()).toBe(0)
+  })
+})

--- a/packages/api/src/routes/slack-events.ts
+++ b/packages/api/src/routes/slack-events.ts
@@ -1,0 +1,120 @@
+import { type Context, Hono } from 'hono'
+import { getUserByEmail, toSessionUser } from '../db/repo'
+import { fireAndForget } from '../lib/events'
+import { fetchAccessFacts, siteAccessFromFacts } from '../lib/site-access'
+import { lookupSlackEmail, slackDepsFromEnv, slackUnfurlEnabled } from '../lib/slack'
+import {
+  buildUnfurlBlocks,
+  parseSiteUrl,
+  type ParsedSiteUrl,
+  postUnfurl,
+  type SlackBlock,
+  type UnfurlTarget,
+} from '../lib/slack-unfurl'
+import { verifySlackSignature } from '../lib/slack-verify'
+import type { AppEnv } from '../types'
+
+// Slack Events API endpoint (mounted at /api/slack), handling `link_shared` → chat.unfurl.
+//
+// Auth: Slack sends no cookie and no Origin, so requireSameOrigin passes it through (it only guards
+// COOKIE-authed unsafe methods) — the HMAC signature is the whole gate, and an unsigned request
+// never reaches any D1 read. Both Slack secrets must be set or the route is inert (404), matching
+// how Google OAuth and the data plane go dark when unconfigured.
+
+export const slackEvents = new Hono<AppEnv>()
+
+// Bound the work one event can trigger, counted in SITES actually resolved (not raw links, which are
+// filtered first) — five cards is already more than a channel wants to read.
+const MAX_SITES_PER_EVENT = 5
+
+type LinkSharedEvent = UnfurlTarget & { type?: string; user?: string; links?: { url?: unknown }[] }
+type SlackEnvelope = { type?: string; challenge?: string; event?: LinkSharedEvent }
+
+slackEvents.post('/events', async (c) => {
+  if (!slackUnfurlEnabled(c.env)) return c.notFound()
+
+  // The RAW body is what Slack signed — read it as text and parse only after verifying. Re-encoding
+  // a parsed object would change the bytes and break every signature.
+  const body = await c.req.text()
+  const verified = await verifySlackSignature({
+    signingSecret: c.env.SLACK_SIGNING_SECRET ?? '',
+    timestamp: c.req.header('x-slack-request-timestamp'),
+    signature: c.req.header('x-slack-signature'),
+    body,
+    nowSeconds: Math.floor(Date.now() / 1000),
+  })
+  if (!verified) return c.json({ error: 'bad signature' }, 401)
+
+  let envelope: SlackEnvelope
+  try {
+    envelope = JSON.parse(body) as SlackEnvelope
+  } catch {
+    return c.json({ error: 'bad request' }, 400)
+  }
+
+  // One-time handshake when you paste the Request URL into the Slack app config.
+  if (envelope.type === 'url_verification') return c.json({ challenge: envelope.challenge ?? '' })
+
+  const event = envelope.event
+  if (envelope.type !== 'event_callback' || event?.type !== 'link_shared') return c.body(null, 200)
+
+  // Slack wants a 200 immediately; the resolve + post rides waitUntil (awaited inline under the test
+  // harness, which has no executionCtx). A throw in there can never fail the ack.
+  await fireAndForget(c, unfurlLinks(c, event))
+  return c.body(null, 200)
+})
+
+/** The distinct sites a message linked to, each with the URLs that pointed at it. Two deep links into
+ *  one site (`/space/site` + `/space/site/report.html` — the common paste) resolve that site ONCE and
+ *  fan the result back onto both URLs, since Slack keys unfurls by URL. */
+function siteTargets(event: LinkSharedEvent, appUrl: string): { parsed: ParsedSiteUrl; urls: string[] }[] {
+  const bySite = new Map<string, { parsed: ParsedSiteUrl; urls: string[] }>()
+  for (const link of event.links ?? []) {
+    if (typeof link.url !== 'string') continue
+    const parsed = parseSiteUrl(link.url, appUrl)
+    if (!parsed) continue
+    const key = `${parsed.spaceSlug}/${parsed.siteSlug}`
+    const target = bySite.get(key) ?? { parsed, urls: [] }
+    if (!target.urls.includes(link.url)) target.urls.push(link.url)
+    bySite.set(key, target)
+  }
+  return [...bySite.values()].slice(0, MAX_SITES_PER_EVENT)
+}
+
+/** Resolve every linked site the SHARER is allowed to see and post the cards.
+ *
+ *  The access check is deliberately on the person who pasted the link, not each channel member:
+ *  chat.unfurl renders one card for the whole channel, so there is no per-viewer rendering to
+ *  authorize. This means pasting a link you cannot open produces NO card at all (no title, no
+ *  existence signal), while a link you can open shows its title to that channel — the same thing
+ *  that would happen if you typed the title out yourself. */
+async function unfurlLinks(c: Context<AppEnv>, event: LinkSharedEvent): Promise<void> {
+  // Parse first: URL parsing is free, while resolving the sharer costs a KV read, a Slack subrequest,
+  // and a D1 round trip. A message whose links aren't Glance sites must cost none of that.
+  const targets = siteTargets(event, c.env.APP_URL)
+  if (targets.length === 0 || !event.user) return
+
+  const deps = slackDepsFromEnv(c.env)
+  // No email → no way to map the sharer onto a Glance identity → fail closed (no card).
+  const email = await lookupSlackEmail(deps, event.user)
+  if (!email) return
+  const db = c.get('db')
+  const row = await getUserByEmail(db, email)
+  if (!row) return
+  const user = toSessionUser(row)
+
+  // One batched access read per site, all in flight together — the sites are independent, and D1's
+  // primary is far enough away that serializing these would dominate the whole handler.
+  const cards = await Promise.all(
+    targets.map(async ({ parsed, urls }) => {
+      // checkAccess is the single source of truth (lib/access.ts) — archived sites and every
+      // visibility tier resolve exactly as they do in the app and the content worker.
+      const { facts } = await fetchAccessFacts(db, parsed.spaceSlug, parsed.siteSlug, user.id)
+      const { site, access } = siteAccessFromFacts(facts, user)
+      if (!site || !access.ok) return []
+      return urls.map((url) => [url, { blocks: buildUnfurlBlocks(site, parsed.spaceSlug, url) }] as const)
+    }),
+  )
+
+  await postUnfurl(deps, event, Object.fromEntries(cards.flat()) as Record<string, { blocks: SlackBlock[] }>)
+}

--- a/packages/api/src/routes/upload.test.ts
+++ b/packages/api/src/routes/upload.test.ts
@@ -254,6 +254,43 @@ describe('upload — derived title from entry HTML', () => {
   })
 })
 
+describe('upload — derived description from entry HTML', () => {
+  const described = (d: string) =>
+    html(`<html><head><title>T</title><meta name="description" content="${d}"></head><body>x</body></html>`, 'index.html')
+  async function siteDescription(db: Awaited<ReturnType<typeof setup>>['db'], slug: string) {
+    return (await db.select({ description: sites.description }).from(sites).where(eq(sites.slug, slug)))[0]?.description
+  }
+
+  test('create derives the description from the entry description meta', async () => {
+    const { app, env, db } = await setup()
+    expect((await postUpload(app, env, 'blurb', [described('Quarterly numbers')])).status).toBe(200)
+    expect(await siteDescription(db, 'blurb')).toBe('Quarterly numbers')
+  })
+
+  test('replace OVERWRITES the description — unlike the title, it tracks the current content', async () => {
+    const { app, env, db } = await setup()
+    await postUpload(app, env, 'moving', [described('First blurb')])
+    await postUpload(app, env, 'moving', [described('Second blurb')], { replace: true })
+    expect(await siteDescription(db, 'moving')).toBe('Second blurb')
+  })
+
+  test('a redeploy whose entry dropped its description CLEARS the stale one', async () => {
+    const { app, env, db } = await setup()
+    await postUpload(app, env, 'cleared', [described('Was here')])
+    await postUpload(app, env, 'cleared', [html('<html><head><title>T</title></head><body>x</body></html>', 'index.html')], {
+      replace: true,
+    })
+    expect(await siteDescription(db, 'cleared')).toBeNull()
+  })
+
+  test('no HTML entry → null, and the site still uploads', async () => {
+    const { app, env, db } = await setup()
+    const md = new File(['# hi'], 'notes.md', { type: 'text/markdown' })
+    expect((await postUpload(app, env, 'nohtml', [md])).status).toBe(200)
+    expect(await siteDescription(db, 'nohtml')).toBeNull()
+  })
+})
+
 describe('upload — derived title: R2 integrity + COALESCE race', () => {
   const titled = (t: string) => html(`<html><head><title>${t}</title></head><body>x</body></html>`, 'index.html')
 

--- a/packages/api/src/routes/upload.ts
+++ b/packages/api/src/routes/upload.ts
@@ -5,7 +5,7 @@ import type { NewFileRow } from '../db/schema'
 import { files, sites, spaces } from '../db/schema'
 import { canReplace } from '../lib/access'
 import { fireAndForget } from '../lib/events'
-import { capTitle, extractHtmlTitle, pickEntry } from '../lib/extract'
+import { capTitle, extractHtmlMeta, NO_META, pickEntry } from '../lib/extract'
 import { isValidSlug } from '../lib/slug'
 import { deleteKeys, MAX_FILE_BYTES, sanitizePath } from '../lib/storage'
 import { isVisibility, normalizeVisibility } from '../lib/visibility'
@@ -102,7 +102,6 @@ upload.post('/:spaceSlug/:siteSlug', requireAuth, async (c) => {
       .select({
         id: sites.id,
         ownerId: sites.ownerId,
-        title: sites.title,
         contentVersion: sites.contentVersion,
         status: sites.status,
       })
@@ -178,12 +177,13 @@ upload.post('/:spaceSlug/:siteSlug', requireAuth, async (c) => {
   // null-title check here is ONLY work-avoidance — the replace UPDATE enforces fill-only-null
   // atomically via COALESCE, so a title set concurrently (PATCH, racing replace) between this
   // read and that write is never clobbered. Runs after request validation, before any R2 write.
-  const wantsDerivedTitle = existing ? !actingAsEditor && existing.title === null : title === null
-  let derivedTitle: string | null = null
-  if (wantsDerivedTitle) {
-    const entry = pickEntry(items.map(({ path, file }) => ({ path, file, mimeType: file.type || null })))
-    if (entry) derivedTitle = await extractHtmlTitle(entry, entry.file)
-  }
+  // Derive title + description from the entry HTML in ONE streamed pass. Started here but awaited
+  // AFTER the R2 puts, so the parse overlaps the uploads instead of delaying them — nothing needs the
+  // result until the D1 write. The description is derived unconditionally: unlike the title (identity
+  // — a re-upload must never rename a site) it describes the CURRENT bytes, so every write below sets
+  // it outright, clearing it to null when the new entry carries no description meta.
+  const entry = pickEntry(items.map(({ path, file }) => ({ path, file, mimeType: file.type || null })))
+  const metaPromise = entry ? extractHtmlMeta(entry, entry.file) : Promise.resolve(NO_META)
 
   // Write the objects with bounded concurrency so latency doesn't scale linearly with file count.
   // Track every key we attempt: if ANY put throws mid-flight, delete the ones already written so
@@ -204,6 +204,13 @@ upload.post('/:spaceSlug/:siteSlug', requireAuth, async (c) => {
     throw err
   }
 
+  // Both writes below enforce the real rules themselves — the insert via `title ?? derivedTitle`, the
+  // owner replace via SQL COALESCE (atomic against a concurrent PATCH rename) — so the only thing to
+  // decide here is that an EDITOR never touches the title at all (content-only role).
+  const meta = await metaPromise
+  const derivedTitle = actingAsEditor ? null : meta.title
+  const { description } = meta
+
   const newRows = plan.map((p) => p.row)
   const insertRows = newRows.map((r) => db.insert(files).values(r))
   const newKeys = newRows.map((r) => r.storageKey)
@@ -220,6 +227,7 @@ upload.post('/:spaceSlug/:siteSlug', requireAuth, async (c) => {
           spaceId: space.id,
           slug: siteSlug,
           title: title ?? derivedTitle,
+          description,
           visibility: isVisibility(visibility) ? visibility : 'team',
           ownerId: user.id,
         }),
@@ -236,14 +244,25 @@ upload.post('/:spaceSlug/:siteSlug', requireAuth, async (c) => {
       // price of leaving files untouched on a stale 409, which a single atomic batch cannot express.)
       const claimed = await db
         .update(sites)
-        .set({ contentVersion: sql`${sites.contentVersion} + 1`, lastReplacedBy: user.id, updatedAt: new Date().toISOString() })
+        .set({
+          contentVersion: sql`${sites.contentVersion} + 1`,
+          lastReplacedBy: user.id,
+          updatedAt: new Date().toISOString(),
+        })
         .where(and(eq(sites.id, siteId), eq(sites.contentVersion, expectedVersion as number)))
         .returning({ id: sites.id })
       if (claimed.length === 0) {
         await deleteKeys(c.env.GLANCE_FILES, newKeys)
         return c.json({ error: 'version conflict', conflict: true }, 409)
       }
-      await db.batch([db.delete(files).where(eq(files.siteId, siteId)), ...insertRows])
+      // The blurb ships in the SWAP batch, not the claim above: it describes the bytes, so it must
+      // commit with them — a claim-time write would advertise the new description while the site
+      // still served the old content if the swap then threw. (Editors never touch the title.)
+      await db.batch([
+        db.delete(files).where(eq(files.siteId, siteId)),
+        ...insertRows,
+        db.update(sites).set({ description }).where(eq(sites.id, siteId)),
+      ])
     } else {
       // OWNER / SUPERADMIN REPLACE: atomically swap file rows, bump the version advisorily + record
       // lastReplacedBy, and apply visibility only when the caller explicitly sent one (absent → keep
@@ -260,6 +279,9 @@ upload.post('/:spaceSlug/:siteSlug', requireAuth, async (c) => {
             updatedAt: new Date().toISOString(),
             ...(hasVisibility && isVisibility(visibility) ? { visibility } : {}),
             ...(derivedTitle !== null ? { title: sql`coalesce(${sites.title}, ${derivedTitle})` } : {}),
+            // Unconditional (not COALESCE'd): a redeploy whose entry dropped its description meta
+            // must clear the stale blurb rather than keep unfurling the previous content's.
+            description,
           })
           .where(eq(sites.id, siteId)),
       ])

--- a/packages/api/src/test/harness.ts
+++ b/packages/api/src/test/harness.ts
@@ -48,6 +48,7 @@ const MIGRATIONS = [
   'drizzle/0015_notifications_comment_id.sql',
   'drizzle/0016_notifications_comment_index.sql',
   'drizzle/0017_site_updated_at.sql',
+  'drizzle/0018_site_description.sql',
 ]
 
 // --- S0 recorder: one shared, ordered timeline across D1/R2/cache mocks so perf specs can
@@ -311,6 +312,7 @@ export async function seedSite(
     ownerId: o.ownerId,
     slug: o.slug ?? id,
     title: o.title ?? null,
+    description: o.description ?? null,
     visibility: o.visibility ?? 'team',
     status: o.status ?? 'active',
     // Omitted → schema $defaultFn (now). Passable so ordering specs can pin exact timelines.

--- a/packages/api/src/test/route-fixtures.ts
+++ b/packages/api/src/test/route-fixtures.ts
@@ -8,6 +8,7 @@ import { commentFeed } from '../routes/comment-feed'
 import { comments } from '../routes/comments'
 import { summary } from '../routes/summary'
 import { sites } from '../routes/sites'
+import { slackEvents } from '../routes/slack-events'
 import { spaces } from '../routes/spaces'
 import type { AppEnv } from '../types'
 import { makeDb, makeKv, makeR2, seedUser } from './harness'
@@ -39,7 +40,23 @@ export function makeRouteApp() {
   app.route('/api/sites', comments)
   app.route('/api/sites', summary)
   app.route('/api/comments', commentFeed)
+  app.route('/api/slack', slackEvents)
   return { app, env, db, kv, r2 }
+}
+
+/** Slack's request signature for a raw body — `v0:{ts}:{body}` HMAC'd with the signing secret, hex,
+ *  `v0=`-prefixed. Derived independently of lib/slack-verify so route tests exercise the real
+ *  algorithm rather than replaying the implementation. */
+export async function signSlack(secret: string, body: string, timestamp: number): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  )
+  const mac = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(`v0:${timestamp}:${body}`))
+  return `v0=${Array.from(new Uint8Array(mac), (b) => b.toString(16).padStart(2, '0')).join('')}`
 }
 
 export type RouteApp = ReturnType<typeof makeRouteApp>

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -28,6 +28,9 @@ export interface Bindings {
   // Optional Slack bot token (xoxb-…). Unset = kill-switch: comment notifications never fan out to
   // Slack (deliverSlack no-ops on line one). Set via `wrangler secret put SLACK_BOT_TOKEN`.
   SLACK_BOT_TOKEN?: string
+  // Optional Slack app signing secret. Verifies inbound Events API requests (link_shared → unfurl);
+  // unset → /api/slack/events is inert (404). Set via `wrangler secret put SLACK_SIGNING_SECRET`.
+  SLACK_SIGNING_SECRET?: string
   // DI seam for Slack HTTP (mirrors summarize's injected fetchImpl): route tests set a fake fetch on
   // env to capture users.lookupByEmail / chat.postMessage without touching global fetch. Never set in
   // prod — unset → deliverSlack falls back to globalThis.fetch.


### PR DESCRIPTION
Pasting a Glance link in Slack shows the same generic card for every site — `Glance — Artifacts for every agent`. Slackbot sends no cookie and runs no JS, so it gets the static SPA shell and never sees the viewer's client-side `document.title`.

## Why app-controlled unfurling, not Open Graph tags

The obvious fix is per-site `og:*` tags in the served shell. That would publish site titles and descriptions to **anyone holding or guessing a `/space/site` URL**, on a product where every tier requires an authenticated user (`lib/access.ts` — there is no anonymous tier). Personal space slugs are derived from email local-parts, so they're guessable from a directory.

Slack's app-controlled unfurling avoids that entirely: the metadata travels over Slack's authenticated API, nothing is exposed to an unauthenticated fetch, and the card can be authorized. **Paste a link you can't open and there is no card at all** — no title, no existence signal. The owner pasting the same link gets one. Archived sites don't unfurl.

Two constraints also ruled the OG route out, both verified against prod rather than assumed:
- `_headers` never applies to worker-generated responses ([Cloudflare docs](https://developers.cloudflare.com/workers/static-assets/headers/)), and the Hono `secureHeaders` CSP is stricter than `public/_headers` — it lacks the inline theme-script hash and the Google Fonts hosts. Routing the viewer path through the worker breaks fonts and the theme script for every browser unless that CSP is re-set by hand.
- `glance.plivo.com` sits behind CloudFront → Cloudflare, and CloudFront honors `no-store` only when the cache policy's Min TTL is 0.

Trade-off: this is Slack-only. Notion/Teams/iMessage keep the generic card.

## What's here

**`POST /api/slack/events`** — verifies Slack's HMAC signature over the RAW body (`v0:{ts}:{body}`, 5-minute skew window, `secretEquals`) **before any D1 read**, answers the `url_verification` handshake, acks 200, resolves in `waitUntil`. Inert (404) unless both `SLACK_BOT_TOKEN` and `SLACK_SIGNING_SECRET` are set. `requireSameOrigin` only guards cookie-authed unsafe methods, so the cookieless POST passes through it untouched and the signature is the real gate.

Links are parsed *before* the sharer is resolved (a message with no Glance links costs zero KV/Slack/D1), deduped per **site** so two deep links into one site cost one lookup, capped at 5, and each site's access is a single `fetchAccessFacts` batch with all sites in flight together.

**`sites.description`** (migration `0018`) — derived from the entry HTML's `og:description` / `<meta name="description">` in the same streamed `HTMLRewriter` pass as the title. Unlike the title (identity — a re-upload must never rename a site) it's content-derived, so every replace overwrites it and clears it when the new entry has none. It commits in the **swap batch**, never the editor's CAS claim, so it can't advertise bytes that failed to land.

**Shared plumbing factored out rather than copied:** `slackGet`/`slackPost` own the bearer header and the transient-failure policy; one `cachedLookup` serves both identity directions with negative caching (an email-less bot no longer re-hits `users.info` forever); `escapeSlack`/`slackLink` are exported and used by both callers; the signature uses `lib/hmac.ts` (new `hmacSignHex`) + `secretEquals` instead of inlined crypto. `getUserByEmail` lowercases in the repo layer — `users.email` is lowercase-canonical and Slack returns the IdP string verbatim, so a capitalized profile address would otherwise silently resolve to "no account".

## Testing

`823 pass, 0 fail`; typecheck and lint clean. New coverage: signature valid/tampered/wrong-key/stale/edge-of-window/malformed, URL parsing incl. look-alike origins and reserved paths, mrkdwn escaping of author-controlled title/description, negative caching, private/archived/no-account → no card, owner → card, mixed-case email, and same-site dedupe.

## Deploying this

The route is dark until configured, so this is safe to merge and deploy first. Then:

1. `wrangler secret put SLACK_SIGNING_SECRET` (Slack app → Basic Information → Signing Secret)
2. Add bot scopes `links:read` + `links:write`
3. Event Subscriptions → Request URL `https://glance.plivo.com/api/slack/events` (Slack verifies it live, so it must already be deployed)
4. Same page → **App unfurl domains** → `glance.plivo.com`
5. **Reinstall the app** — required after any scope or unfurl-domain change, or nothing fires

Note the card is visible to everyone in the channel, so the access check is on whoever pasted the link, not each viewer — `chat.unfurl` has no per-viewer rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C4YTn4rgi1t4dfWAAL6Sgq
