### PR TITLE
Slack unfurl v2: freshness + signed brand-thumbnail PNG

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -17,6 +17,7 @@
         "drizzle-orm": "^0.45.2",
         "hono": "^4.12.0",
         "marked": "^18.0.5",
+        "workers-og": "^0.0.27",
       },
       "devDependencies": {
         "drizzle-kit": "^0.31.10",
@@ -368,6 +369,8 @@
 
     "@radix-ui/rect": ["@radix-ui/rect@1.1.2", "", {}, "sha512-xnXE7wG13PI+cxieVssYXlQJuYVRhH9NBoxt3KNwzghDIA69GMm7d4wXRouHIYjE+KvS6U/MsMO73NdS2MH9ZA=="],
 
+    "@resvg/resvg-wasm": ["@resvg/resvg-wasm@2.4.0", "", {}, "sha512-C7c51Nn4yTxXFKvgh2txJFNweaVcfUPQxwEUFw4aWsCmfiBDJsTSwviIF8EcwjQ6k8bPyMWCl1vw4BdxE569Cg=="],
+
     "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.1.3", "", { "os": "android", "cpu": "arm64" }, "sha512-DT6Z3PhvioeHMvxo+xHc3KtqggrI7CCTXCmC2h/5zUlp5jVitv7XEy+9q5/7v8IolhlioawpMo8Kg0EEBy7J0g=="],
 
     "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.1.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-0NwgwsjM7LrsuVnXMK3koTpagBNOhloc/BNjKqZjv4V5zI5r13qx69uVhRx+o5Z0yy4Hzq+lpy7TAgUG/ocvrw=="],
@@ -399,6 +402,8 @@
     "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.1.3", "", { "os": "win32", "cpu": "x64" }, "sha512-OL4OMk7UPXOeVGGd3qo5zJyPIljf4AFgk5QAkPPS+OoLuOOozhuaQGC18MxVTnw/06q93gShAJzlwnSCY9YtqA=="],
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.1", "", {}, "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw=="],
+
+    "@shuding/opentype.js": ["@shuding/opentype.js@1.4.0-beta.0", "", { "dependencies": { "fflate": "^0.7.3", "string.prototype.codepointat": "^0.2.1" }, "bin": { "ot": "bin/ot" } }, "sha512-3NgmNyH3l/Hv6EvsWJbsvpcpUba6R8IREQ83nH83cyakCw7uM1arZKNfHwv1Wz6jgqrF/j4x5ELvR6PnK9nTcA=="],
 
     "@sindresorhus/is": ["@sindresorhus/is@7.2.0", "", {}, "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw=="],
 
@@ -452,11 +457,15 @@
 
     "aria-hidden": ["aria-hidden@1.2.6", "", { "dependencies": { "tslib": "^2.0.0" } }, "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA=="],
 
+    "base64-js": ["base64-js@0.0.8", "", {}, "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw=="],
+
     "blake3-wasm": ["blake3-wasm@2.1.5", "", {}, "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g=="],
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 
     "buffer-image-size": ["buffer-image-size@0.6.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ=="],
+
+    "camelize": ["camelize@1.0.1", "", {}, "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ=="],
 
     "class-variance-authority": ["class-variance-authority@0.7.1", "", { "dependencies": { "clsx": "^2.1.1" } }, "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg=="],
 
@@ -464,9 +473,21 @@
 
     "cmdk": ["cmdk@1.1.1", "", { "dependencies": { "@radix-ui/react-compose-refs": "^1.1.1", "@radix-ui/react-dialog": "^1.1.6", "@radix-ui/react-id": "^1.1.0", "@radix-ui/react-primitive": "^2.0.2" }, "peerDependencies": { "react": "^18 || ^19 || ^19.0.0-rc", "react-dom": "^18 || ^19 || ^19.0.0-rc" } }, "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg=="],
 
+    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
     "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
     "cookie-es": ["cookie-es@3.1.1", "", {}, "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg=="],
+
+    "css-background-parser": ["css-background-parser@0.1.0", "", {}, "sha512-2EZLisiZQ+7m4wwur/qiYJRniHX4K5Tc9w93MT3AS0WS1u5kaZ4FKXlOTBhOjc+CgEgPiGY+fX1yWD8UwpEqUA=="],
+
+    "css-box-shadow": ["css-box-shadow@1.0.0-3", "", {}, "sha512-9jaqR6e7Ohds+aWwmhe6wILJ99xYQbfmK9QQB9CcMjDbTxPZjwEmUQpU91OG05Xgm8BahT5fW+svbsQGjS/zPg=="],
+
+    "css-color-keywords": ["css-color-keywords@1.0.0", "", {}, "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg=="],
+
+    "css-gradient-parser": ["css-gradient-parser@0.0.16", "", {}, "sha512-3O5QdqgFRUbXvK1x5INf1YkBz1UKSWqrd63vWsum8MNHDBYD5urm3QtxZbKU259OrEXNM26lP/MPY3d1IGkBgA=="],
+
+    "css-to-react-native": ["css-to-react-native@3.2.0", "", { "dependencies": { "camelize": "^1.0.0", "css-color-keywords": "^1.0.0", "postcss-value-parser": "^4.0.2" } }, "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ=="],
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
@@ -478,6 +499,8 @@
 
     "drizzle-orm": ["drizzle-orm@0.45.2", "", { "peerDependencies": { "@aws-sdk/client-rds-data": ">=3", "@cloudflare/workers-types": ">=4", "@electric-sql/pglite": ">=0.2.0", "@libsql/client": ">=0.10.0", "@libsql/client-wasm": ">=0.10.0", "@neondatabase/serverless": ">=0.10.0", "@op-engineering/op-sqlite": ">=2", "@opentelemetry/api": "^1.4.1", "@planetscale/database": ">=1.13", "@prisma/client": "*", "@tidbcloud/serverless": "*", "@types/better-sqlite3": "*", "@types/pg": "*", "@types/sql.js": "*", "@upstash/redis": ">=1.34.7", "@vercel/postgres": ">=0.8.0", "@xata.io/client": "*", "better-sqlite3": ">=7", "bun-types": "*", "expo-sqlite": ">=14.0.0", "gel": ">=2", "knex": "*", "kysely": "*", "mysql2": ">=2", "pg": ">=8", "postgres": ">=3", "sql.js": ">=1", "sqlite3": ">=5" }, "optionalPeers": ["@aws-sdk/client-rds-data", "@cloudflare/workers-types", "@electric-sql/pglite", "@libsql/client", "@libsql/client-wasm", "@neondatabase/serverless", "@op-engineering/op-sqlite", "@opentelemetry/api", "@planetscale/database", "@prisma/client", "@tidbcloud/serverless", "@types/better-sqlite3", "@types/pg", "@types/sql.js", "@upstash/redis", "@vercel/postgres", "@xata.io/client", "better-sqlite3", "bun-types", "expo-sqlite", "gel", "knex", "kysely", "mysql2", "pg", "postgres", "sql.js", "sqlite3"] }, "sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q=="],
 
+    "emoji-regex-xs": ["emoji-regex-xs@2.0.1", "", {}, "sha512-1QFuh8l7LqUcKe24LsPUNzjrzJQ7pgRwp1QMcZ5MX6mFplk2zQ08NVCM84++1cveaUUYtcCYHmeFEuNg16sU4g=="],
+
     "enhanced-resolve": ["enhanced-resolve@5.21.6", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ=="],
 
     "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
@@ -486,7 +509,11 @@
 
     "esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
 
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
+
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "fflate": ["fflate@0.7.5", "", {}, "sha512-QieYf//cis6ywHNi5qW1+PXPQ4bC+XVJAtS4AXIML8P76GroEiOxm/oQtn1f02UkJY1+KsXMJcC+R2v/Eg4G3g=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
@@ -498,9 +525,13 @@
 
     "happy-dom": ["happy-dom@20.10.6", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "buffer-image-size": "^0.6.4", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.21.0" } }, "sha512-6QD0ilzDDt93tX44y8tbmZdAcdTRYDhUP+Asgi6pC8Pp5IA3cvaZGyoVN/EGtlq9ziT65iPuBBn3ASLr6hCgVw=="],
 
+    "hex-rgb": ["hex-rgb@4.3.0", "", {}, "sha512-Ox1pJVrDCyGHMG9CFg1tmrRUMRPRsAWYc/PinY0XzJU4K7y7vjNoLKIQ7BR5UJMCxNN8EM1MNDmHWA/B3aZUuw=="],
+
     "hono": ["hono@4.12.25", "", {}, "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ=="],
 
     "jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
+
+    "just-camel-case": ["just-camel-case@6.2.0", "", {}, "sha512-ICenRLXwkQYLk3UyvLQZ+uKuwFVJ3JHFYFn7F2782G2Mv2hW8WPePqgdhpnjGaqkYtSVWnyCESZhGXUmY3/bEg=="],
 
     "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
 
@@ -528,6 +559,8 @@
 
     "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
 
+    "linebreak": ["linebreak@1.1.0", "", { "dependencies": { "base64-js": "0.0.8", "unicode-trie": "^2.0.0" } }, "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ=="],
+
     "lucide-react": ["lucide-react@1.18.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-LZDb7H/0YfM+RJncD0hDQRCAu+vSGODqpe35TuVI8EuXaRjkczbsx7p8dY4J87F/MUSj6bpYqeI8nw8qXaAdmA=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
@@ -540,6 +573,10 @@
 
     "next-themes": ["next-themes@0.4.6", "", { "peerDependencies": { "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc", "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc" } }, "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA=="],
 
+    "pako": ["pako@0.2.9", "", {}, "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA=="],
+
+    "parse-css-color": ["parse-css-color@0.2.1", "", { "dependencies": { "color-name": "^1.1.4", "hex-rgb": "^4.1.0" } }, "sha512-bwS/GGIFV3b6KS4uwpzCFj4w297Yl3uqnSgIPsoQkx7GMLROXfMnWvxfNkL0oh8HVhZA4hvJoEoEIqonfJ3BWg=="],
+
     "path-to-regexp": ["path-to-regexp@6.3.0", "", {}, "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="],
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
@@ -549,6 +586,8 @@
     "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
     "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
+
+    "postcss-value-parser": ["postcss-value-parser@4.2.0", "", {}, "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="],
 
     "radix-ui": ["radix-ui@1.5.0", "", { "dependencies": { "@radix-ui/primitive": "1.1.4", "@radix-ui/react-accessible-icon": "1.1.9", "@radix-ui/react-accordion": "1.2.13", "@radix-ui/react-alert-dialog": "1.1.16", "@radix-ui/react-arrow": "1.1.9", "@radix-ui/react-aspect-ratio": "1.1.9", "@radix-ui/react-avatar": "1.1.12", "@radix-ui/react-checkbox": "1.3.4", "@radix-ui/react-collapsible": "1.1.13", "@radix-ui/react-collection": "1.1.9", "@radix-ui/react-compose-refs": "1.1.3", "@radix-ui/react-context": "1.1.4", "@radix-ui/react-context-menu": "2.3.0", "@radix-ui/react-dialog": "1.1.16", "@radix-ui/react-direction": "1.1.2", "@radix-ui/react-dismissable-layer": "1.1.12", "@radix-ui/react-dropdown-menu": "2.1.17", "@radix-ui/react-focus-guards": "1.1.4", "@radix-ui/react-focus-scope": "1.1.9", "@radix-ui/react-form": "0.1.9", "@radix-ui/react-hover-card": "1.1.16", "@radix-ui/react-label": "2.1.9", "@radix-ui/react-menu": "2.1.17", "@radix-ui/react-menubar": "1.1.17", "@radix-ui/react-navigation-menu": "1.2.15", "@radix-ui/react-one-time-password-field": "0.1.9", "@radix-ui/react-password-toggle-field": "0.1.4", "@radix-ui/react-popover": "1.1.16", "@radix-ui/react-popper": "1.3.0", "@radix-ui/react-portal": "1.1.11", "@radix-ui/react-presence": "1.1.6", "@radix-ui/react-primitive": "2.1.5", "@radix-ui/react-progress": "1.1.9", "@radix-ui/react-radio-group": "1.4.0", "@radix-ui/react-roving-focus": "1.1.12", "@radix-ui/react-scroll-area": "1.2.11", "@radix-ui/react-select": "2.3.0", "@radix-ui/react-separator": "1.1.9", "@radix-ui/react-slider": "1.4.0", "@radix-ui/react-slot": "1.2.5", "@radix-ui/react-switch": "1.3.0", "@radix-ui/react-tabs": "1.1.14", "@radix-ui/react-toast": "1.2.16", "@radix-ui/react-toggle": "1.1.11", "@radix-ui/react-toggle-group": "1.1.12", "@radix-ui/react-toolbar": "1.1.12", "@radix-ui/react-tooltip": "1.2.9", "@radix-ui/react-use-callback-ref": "1.1.2", "@radix-ui/react-use-controllable-state": "1.2.3", "@radix-ui/react-use-effect-event": "0.0.3", "@radix-ui/react-use-escape-keydown": "1.1.2", "@radix-ui/react-use-is-hydrated": "0.1.1", "@radix-ui/react-use-layout-effect": "1.1.2", "@radix-ui/react-use-size": "1.1.2", "@radix-ui/react-visually-hidden": "1.2.5" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-Nzh2HNpClgB31FBHRqt2xG8XNUfVfQRpf34hACC5PNrXTd5JdXdqOXwLs3BL+D8CNYiNQiJiT8QGr5Q4vq+00w=="],
 
@@ -568,6 +607,8 @@
 
     "rolldown": ["rolldown@1.1.3", "", { "dependencies": { "@oxc-project/types": "=0.137.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.1.3", "@rolldown/binding-darwin-arm64": "1.1.3", "@rolldown/binding-darwin-x64": "1.1.3", "@rolldown/binding-freebsd-x64": "1.1.3", "@rolldown/binding-linux-arm-gnueabihf": "1.1.3", "@rolldown/binding-linux-arm64-gnu": "1.1.3", "@rolldown/binding-linux-arm64-musl": "1.1.3", "@rolldown/binding-linux-ppc64-gnu": "1.1.3", "@rolldown/binding-linux-s390x-gnu": "1.1.3", "@rolldown/binding-linux-x64-gnu": "1.1.3", "@rolldown/binding-linux-x64-musl": "1.1.3", "@rolldown/binding-openharmony-arm64": "1.1.3", "@rolldown/binding-wasm32-wasi": "1.1.3", "@rolldown/binding-win32-arm64-msvc": "1.1.3", "@rolldown/binding-win32-x64-msvc": "1.1.3" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-1F1eEtUBtFvcGm1HQ9TiUIUHPQG7mSAODrhIzjxoUEFuo8OcbrGLiVLkevNgj84TE4lnHvnumwFjhJO5Eu135g=="],
 
+    "satori": ["satori@0.15.2", "", { "dependencies": { "@shuding/opentype.js": "1.4.0-beta.0", "css-background-parser": "^0.1.0", "css-box-shadow": "1.0.0-3", "css-gradient-parser": "^0.0.16", "css-to-react-native": "^3.0.0", "emoji-regex-xs": "^2.0.1", "escape-html": "^1.0.3", "linebreak": "^1.1.0", "parse-css-color": "^0.2.1", "postcss-value-parser": "^4.2.0", "yoga-wasm-web": "^0.3.3" } }, "sha512-vu/49vdc8MzV5jUchs3TIRDCOkOvMc1iJ11MrZvhg9tE4ziKIEIBjBZvies6a9sfM2vQ2gc3dXeu6rCK7AztHA=="],
+
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "semver": ["semver@7.8.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA=="],
@@ -582,6 +623,8 @@
 
     "source-map-support": ["source-map-support@0.5.21", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w=="],
 
+    "string.prototype.codepointat": ["string.prototype.codepointat@0.2.1", "", {}, "sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg=="],
+
     "supports-color": ["supports-color@10.2.2", "", {}, "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g=="],
 
     "tailwind-merge": ["tailwind-merge@3.6.0", "", {}, "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w=="],
@@ -589,6 +632,8 @@
     "tailwindcss": ["tailwindcss@4.3.1", "", {}, "sha512-hk+TB1m+K8CYNrP6rjQaq/Y+4Zylwpa87mLYBKCunwnnQ9p+fHb7kmSfGqyEJoxF/O6CDyABWVFEafNSYKll+Q=="],
 
     "tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
+
+    "tiny-inflate": ["tiny-inflate@1.0.3", "", {}, "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw=="],
 
     "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
 
@@ -606,6 +651,8 @@
 
     "unenv": ["unenv@2.0.0-rc.24", "", { "dependencies": { "pathe": "^2.0.3" } }, "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw=="],
 
+    "unicode-trie": ["unicode-trie@2.0.0", "", { "dependencies": { "pako": "^0.2.5", "tiny-inflate": "^1.0.0" } }, "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ=="],
+
     "use-callback-ref": ["use-callback-ref@1.3.3", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg=="],
 
     "use-sidecar": ["use-sidecar@1.1.3", "", { "dependencies": { "detect-node-es": "^1.1.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ=="],
@@ -616,9 +663,13 @@
 
     "workerd": ["workerd@1.20260611.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260611.1", "@cloudflare/workerd-darwin-arm64": "1.20260611.1", "@cloudflare/workerd-linux-64": "1.20260611.1", "@cloudflare/workerd-linux-arm64": "1.20260611.1", "@cloudflare/workerd-windows-64": "1.20260611.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-CS/640T7pIJ2HYX6x2DwKFGbcSckAWN3tgcdq+ptB6SaqjWUhlzIgA/YhPuwIU+/NnMnGpqOFX/hC18Oyge63w=="],
 
+    "workers-og": ["workers-og@0.0.27", "", { "dependencies": { "@resvg/resvg-wasm": "2.4.0", "just-camel-case": "^6.2.0", "satori": "^0.15.2", "yoga-wasm-web": "0.3.3" } }, "sha512-QvwptQ0twmouQHiITUi3kYxEPCLdueC/U4msQ2xMz2iktd+iseSs7zlREw3T1dAsPxPw73FQlw8cXFsfANZPlw=="],
+
     "wrangler": ["wrangler@4.100.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.5.0", "@cloudflare/unenv-preset": "2.16.1", "blake3-wasm": "2.1.5", "esbuild": "0.27.3", "miniflare": "4.20260611.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260611.1" }, "optionalDependencies": { "fsevents": "2.3.3" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20260611.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "cf-wrangler": "bin/cf-wrangler.js", "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-dSQO7DO+mD6XDzkVWIWBoGLO3yw+lacWSc/KhFvd7pgfpth+kX98qb5SGRHZN8ACCDhhfwzDLXwB6qHsIHhfBg=="],
 
     "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
+
+    "yoga-wasm-web": ["yoga-wasm-web@0.3.3", "", {}, "sha512-N+d4UJSJbt/R3wqY7Coqs5pcV0aUj2j9IaQ3rNj9bVCLld8tTGKRa2USARjnvZJWVx1NDmQev8EknoczaOQDOA=="],
 
     "youch": ["youch@4.1.0-beta.10", "", { "dependencies": { "@poppinss/colors": "^4.1.5", "@poppinss/dumper": "^0.6.4", "@speed-highlight/core": "^1.2.7", "cookie": "^1.0.2", "youch-core": "^0.3.3" } }, "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ=="],
 

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -16,7 +16,8 @@
     "arctic": "^3.7.0",
     "drizzle-orm": "^0.45.2",
     "hono": "^4.12.0",
-    "marked": "^18.0.5"
+    "marked": "^18.0.5",
+    "workers-og": "^0.0.27"
   },
   "devDependencies": {
     "drizzle-kit": "^0.31.10",

--- a/packages/api/src/content-og.test.ts
+++ b/packages/api/src/content-og.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from 'bun:test'
+import { type OgCard, signOgSig } from './lib/og-image'
+import { type Setup, setup } from './test/content-fixtures'
+import { seedSite, seedSpace, seedUser } from './test/harness'
+
+// The signed unfurl-image route on the CONTENT worker. The fixture env's CONTENT_TOKEN_SECRET is
+// 'test-secret' (the same secret the main worker signs with); the real renderer is never
+// exercised here — OG_RENDER is the env DI seam (like SLACK_FETCH), so these tests prove the
+// signature gate and the site resolution, not satori.
+
+const SECRET = 'test-secret'
+
+/** Recording OG_RENDER: captures the card each render was asked for. */
+function fakeRender() {
+  const cards: OgCard[] = []
+  const render = async (card: OgCard) => {
+    cards.push(card)
+    return new Response('png-bytes', { headers: { 'content-type': 'image/png' } })
+  }
+  return { render, cards }
+}
+
+async function seedReport(s: Setup, o: { title?: string | null; status?: 'active' | 'archived' } = {}) {
+  const owner = await seedUser(s.db)
+  const spaceId = await seedSpace(s.db, { createdBy: owner, slug: 'acme' })
+  await seedSite(s.db, {
+    spaceId,
+    ownerId: owner,
+    slug: 'report',
+    title: o.title === undefined ? 'Q3 Report' : o.title,
+    status: o.status ?? 'active',
+  })
+}
+
+const get = (s: Setup, path: string, render: (card: OgCard) => Promise<Response>) =>
+  s.app.request(path, {}, { ...(s.env as object), OG_RENDER: render } as Parameters<typeof s.app.request>[2])
+
+describe('GET /_glance/og/:space/:site.png', () => {
+  test('a correctly signed URL renders the card for that site', async () => {
+    const s = setup()
+    await seedReport(s)
+    const { render, cards } = fakeRender()
+    const sig = await signOgSig(SECRET, 'acme', 'report')
+    const res = await get(s, `/_glance/og/acme/report.png?sig=${sig}`, render)
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toBe('image/png')
+    expect(res.headers.get('cache-control')).toContain('public')
+    expect(cards).toEqual([{ title: 'Q3 Report', spaceSlug: 'acme', siteSlug: 'report' }])
+  })
+
+  test('a missing or malformed signature is an opaque 404 — no render, no existence signal', async () => {
+    const s = setup()
+    await seedReport(s)
+    const { render, cards } = fakeRender()
+    expect((await get(s, '/_glance/og/acme/report.png', render)).status).toBe(404)
+    expect((await get(s, '/_glance/og/acme/report.png?sig=deadbeef', render)).status).toBe(404)
+    expect(cards).toHaveLength(0)
+  })
+
+  test("a TAMPERED signature (another site's valid sig) never verifies", async () => {
+    const s = setup()
+    await seedReport(s)
+    const { render, cards } = fakeRender()
+    // Valid for acme/other-site — replayed against acme/report it must fail.
+    const stolen = await signOgSig(SECRET, 'acme', 'other-site')
+    expect((await get(s, `/_glance/og/acme/report.png?sig=${stolen}`, render)).status).toBe(404)
+    expect(cards).toHaveLength(0)
+  })
+
+  test('a signed URL for a site that no longer exists (or was archived) stops serving', async () => {
+    const missing = setup()
+    await seedReport(missing)
+    const { render, cards } = fakeRender()
+    const gone = await signOgSig(SECRET, 'acme', 'deleted-site')
+    expect((await get(missing, `/_glance/og/acme/deleted-site.png?sig=${gone}`, render)).status).toBe(404)
+
+    const archived = setup()
+    await seedReport(archived, { status: 'archived' })
+    const sig = await signOgSig(SECRET, 'acme', 'report')
+    expect((await get(archived, `/_glance/og/acme/report.png?sig=${sig}`, render)).status).toBe(404)
+    expect(cards).toHaveLength(0)
+  })
+
+  test('a titleless site falls back to its slug on the card', async () => {
+    const s = setup()
+    await seedReport(s, { title: null })
+    const { render, cards } = fakeRender()
+    const sig = await signOgSig(SECRET, 'acme', 'report')
+    await get(s, `/_glance/og/acme/report.png?sig=${sig}`, render)
+    expect(cards[0]?.title).toBe('report')
+  })
+})

--- a/packages/api/src/content.ts
+++ b/packages/api/src/content.ts
@@ -9,8 +9,10 @@ import { checkAccess } from './lib/access'
 import { escapeHtml, markdown } from './lib/markdown'
 import { contentType } from './lib/mime'
 import { type CacheLike, IMMUTABLE, readFullObject } from './lib/object-read'
+import { verifyOgSig } from './lib/og-image'
+import { renderOgPng } from './lib/og-render'
 import { decideRange } from './lib/range'
-import { fetchAccessFacts, isSharedFromFacts } from './lib/site-access'
+import { fetchAccessFacts, isSharedFromFacts, resolveSite } from './lib/site-access'
 import { verifyToken } from './lib/token'
 import type { Bindings } from './types'
 
@@ -72,6 +74,30 @@ app.get('/_glance/annotate.css', (c) =>
 app.get('/_glance/db.js', (c) =>
   c.body(GLANCE_DB_JS, 200, { 'content-type': 'text/javascript; charset=utf-8', 'cache-control': IMMUTABLE }),
 )
+
+// The Slack unfurl card's PNG (lib/og-image.ts). Slack fetches image_url server-side,
+// unauthenticated, and caches it — a PUBLIC GET whose only gate is the HMAC minted alongside
+// the card (signed on the MAIN worker with the shared CONTENT_TOKEN_SECRET, the same direction
+// as content tokens). It lives on THIS worker so the satori/resvg wasm (lib/og-render.ts) never
+// bloats the main worker bundle. The signature check runs BEFORE any D1 read, and every failure
+// is the same opaque 404 (no existence signal — the enumeration posture of the unfurl itself).
+app.get('/_glance/og/:space/:site{[a-z0-9-]+\\.png}', async (c) => {
+  const spaceSlug = c.req.param('space')
+  const siteSlug = c.req.param('site').replace(/\.png$/, '')
+  const verified = await verifyOgSig(c.env.CONTENT_TOKEN_SECRET, spaceSlug, siteSlug, c.req.query('sig') ?? '')
+  if (!verified) return notFound(c)
+
+  const site = await resolveSite(getDb(c), spaceSlug, siteSlug)
+  // A signed URL outlives the site it was minted for — deleted or archived sites stop serving.
+  if (site?.status !== 'active') return notFound(c)
+
+  const render = c.env.OG_RENDER ?? renderOgPng
+  const image = await render({ title: site.title ?? site.slug, spaceSlug, siteSlug })
+  // A day keeps Slack's and the edge's caches warm without pinning a renamed title forever.
+  return new Response(image.body, {
+    headers: { 'content-type': 'image/png', 'cache-control': 'public, max-age=86400' },
+  })
+})
 
 // Gated access: token is bound to the viewer's userId AND scoped to "<space>/<site>".
 // Path: /_t/<token>/<space>/<site>/<rest>. We verify the signature (recovering the bound

--- a/packages/api/src/lib/og-image.test.ts
+++ b/packages/api/src/lib/og-image.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test'
-import { ogCardHtml, ogImageUrl, signOgSig, verifyOgSig } from './og-image'
+import { ogCardHtml, signedOgImageUrl, signOgSig, verifyOgSig } from './og-image'
 
 const TEST_SIGNING_KEY = 'not-a-real-og-secret'
 
@@ -19,16 +19,15 @@ describe('og signature', () => {
     expect(await verifyOgSig(TEST_SIGNING_KEY, 'acme', 'report', '')).toBe(false)
   })
 
-  test('the slug separator cannot be gamed: (a/b, c) never verifies as (a, b/c)', async () => {
+  test("the raw MAC message is separator-AMBIGUOUS — (a/b, c) and (a, b/c) sign identically — which is safe only because slugs are [a-z0-9-] (parseSiteUrl/isValidSlug) and can never contain '/'", async () => {
     const sig = await signOgSig(TEST_SIGNING_KEY, 'acme/report', 'x')
-    expect(await verifyOgSig(TEST_SIGNING_KEY, 'acme', 'report/x', sig)).toBe(true) // same message…
-    // …but slugs are [a-z0-9-] (parseSiteUrl/isValidSlug), so a slash never reaches signing in
-    // practice; this test just documents the raw-primitive behavior.
+    expect(await verifyOgSig(TEST_SIGNING_KEY, 'acme', 'report/x', sig)).toBe(true)
   })
 
-  test('ogImageUrl carries the sig as a query param on the CONTENT origin', () => {
-    expect(ogImageUrl('https://content.example.com', 'acme', 'report', 'abc123')).toBe(
-      'https://content.example.com/_glance/og/acme/report.png?sig=abc123',
+  test('signedOgImageUrl mints the sig as a query param on the CONTENT origin', async () => {
+    const sig = await signOgSig(TEST_SIGNING_KEY, 'acme', 'report')
+    expect(await signedOgImageUrl(TEST_SIGNING_KEY, 'https://content.example.com', 'acme', 'report')).toBe(
+      `https://content.example.com/_glance/og/acme/report.png?sig=${sig}`,
     )
   })
 })

--- a/packages/api/src/lib/og-image.test.ts
+++ b/packages/api/src/lib/og-image.test.ts
@@ -41,4 +41,10 @@ describe('ogCardHtml', () => {
     expect(html).toContain('acme/report')
     expect(html).toContain('data:image/svg+xml;base64,') // the brand mark rides inline
   })
+
+  test('the title span carries satori line-clamp so overlong titles ellipsize at three lines', () => {
+    const html = ogCardHtml({ title: 'Q3 Report', spaceSlug: 'acme', siteSlug: 'report' })
+    // Needs display:block on the same span — satori only clamps block text containers.
+    expect(html).toMatch(/display:block;line-clamp:3;[^"]*">Q3 Report</)
+  })
 })

--- a/packages/api/src/lib/og-image.test.ts
+++ b/packages/api/src/lib/og-image.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from 'bun:test'
+import { ogCardHtml, ogImageUrl, signOgSig, verifyOgSig } from './og-image'
+
+const TEST_SIGNING_KEY = 'not-a-real-og-secret'
+
+describe('og signature', () => {
+  test('sign → verify roundtrips; hex output is URL-safe as-is', async () => {
+    const sig = await signOgSig(TEST_SIGNING_KEY, 'acme', 'report')
+    expect(sig).toMatch(/^[0-9a-f]{64}$/)
+    expect(await verifyOgSig(TEST_SIGNING_KEY, 'acme', 'report', sig)).toBe(true)
+  })
+
+  test('any moved part breaks verification: sig, slugs, secret', async () => {
+    const sig = await signOgSig(TEST_SIGNING_KEY, 'acme', 'report')
+    expect(await verifyOgSig(TEST_SIGNING_KEY, 'acme', 'report', sig.replace(/^./, 'f'))).toBe(false)
+    expect(await verifyOgSig(TEST_SIGNING_KEY, 'acme', 'other', sig)).toBe(false)
+    expect(await verifyOgSig(TEST_SIGNING_KEY, 'other', 'report', sig)).toBe(false)
+    expect(await verifyOgSig('another-secret', 'acme', 'report', sig)).toBe(false)
+    expect(await verifyOgSig(TEST_SIGNING_KEY, 'acme', 'report', '')).toBe(false)
+  })
+
+  test('the slug separator cannot be gamed: (a/b, c) never verifies as (a, b/c)', async () => {
+    const sig = await signOgSig(TEST_SIGNING_KEY, 'acme/report', 'x')
+    expect(await verifyOgSig(TEST_SIGNING_KEY, 'acme', 'report/x', sig)).toBe(true) // same message…
+    // …but slugs are [a-z0-9-] (parseSiteUrl/isValidSlug), so a slash never reaches signing in
+    // practice; this test just documents the raw-primitive behavior.
+  })
+
+  test('ogImageUrl carries the sig as a query param on the CONTENT origin', () => {
+    expect(ogImageUrl('https://content.example.com', 'acme', 'report', 'abc123')).toBe(
+      'https://content.example.com/_glance/og/acme/report.png?sig=abc123',
+    )
+  })
+})
+
+describe('ogCardHtml', () => {
+  test('escapes the author-controlled title and shows the space/site pair', () => {
+    const html = ogCardHtml({ title: '<b>&"Q3"', spaceSlug: 'acme', siteSlug: 'report' })
+    expect(html).toContain('&lt;b&gt;&amp;&quot;Q3&quot;')
+    expect(html).not.toContain('<b>')
+    expect(html).toContain('acme/report')
+    expect(html).toContain('data:image/svg+xml;base64,') // the brand mark rides inline
+  })
+})

--- a/packages/api/src/lib/og-image.ts
+++ b/packages/api/src/lib/og-image.ts
@@ -27,10 +27,15 @@ export async function verifyOgSig(secret: string, spaceSlug: string, siteSlug: s
   return secretEquals(await signOgSig(secret, spaceSlug, siteSlug), sig)
 }
 
-/** The absolute image_url the unfurl card carries — on the CONTENT origin, under the reserved
- *  `_glance` prefix (never a space slug, see content.ts's asset routes). */
-export function ogImageUrl(contentUrl: string, spaceSlug: string, siteSlug: string, sig: string): string {
-  return `${contentUrl}/_glance/og/${spaceSlug}/${siteSlug}.png?sig=${sig}`
+/** The absolute, signed image_url the unfurl card carries — on the CONTENT origin, under the
+ *  reserved `_glance` prefix (never a space slug, see content.ts's asset routes). */
+export async function signedOgImageUrl(
+  secret: string,
+  contentUrl: string,
+  spaceSlug: string,
+  siteSlug: string,
+): Promise<string> {
+  return `${contentUrl}/_glance/og/${spaceSlug}/${siteSlug}.png?sig=${await signOgSig(secret, spaceSlug, siteSlug)}`
 }
 
 /** What the card renders. Kept to what the picture needs — the route resolves it, the renderer
@@ -43,6 +48,8 @@ const BRAND_MARK_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512
 
 const BRAND_MARK_DATA_URI = `data:image/svg+xml;base64,${btoa(BRAND_MARK_SVG)}`
 
+// Not lib/markdown's escapeHtml: that module imports Marked at top level, which the main worker
+// (importing this file to mint URLs) must not bundle.
 const esc = (s: string) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;')
 
 /** The card markup (satori's HTML subset: everything display:flex, inline styles only). Brand

--- a/packages/api/src/lib/og-image.ts
+++ b/packages/api/src/lib/og-image.ts
@@ -46,7 +46,9 @@ const BRAND_MARK_DATA_URI = `data:image/svg+xml;base64,${btoa(BRAND_MARK_SVG)}`
 const esc = (s: string) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;')
 
 /** The card markup (satori's HTML subset: everything display:flex, inline styles only). Brand
- *  palette from the mark: dark #15181e, cream #faf6ec, amber #e0a13a. */
+ *  palette from the mark: dark #15181e, cream #faf6ec, amber #e0a13a. The title uses satori's
+ *  native line-clamp (needs display:block): a long title ends in a visible ellipsis at exactly
+ *  three wrapped lines instead of clipping mid-sentence. */
 export function ogCardHtml(card: OgCard): string {
   return `<div style="display:flex;flex-direction:column;justify-content:space-between;width:100vw;height:100vh;background:#15181e;padding:72px;font-family:'IBM Plex Sans'">
   <div style="display:flex;align-items:center">
@@ -54,7 +56,7 @@ export function ogCardHtml(card: OgCard): string {
     <span style="margin-left:28px;font-size:44px;font-weight:600;color:#faf6ec">Glance</span>
   </div>
   <div style="display:flex;flex-direction:column">
-    <span style="font-size:64px;font-weight:600;color:#faf6ec;line-height:1.2;max-height:230px;overflow:hidden">${esc(card.title)}</span>
+    <span style="display:block;line-clamp:3;font-size:64px;font-weight:600;color:#faf6ec;line-height:1.2">${esc(card.title)}</span>
     <span style="margin-top:24px;font-size:32px;color:#e0a13a">${esc(card.spaceSlug)}/${esc(card.siteSlug)}</span>
   </div>
 </div>`

--- a/packages/api/src/lib/og-image.ts
+++ b/packages/api/src/lib/og-image.ts
@@ -1,0 +1,61 @@
+// Signed brand-card image URL for the Slack unfurl (the "og image"): HMAC over
+// `og:<space>/<site>` (lib/hmac.ts primitives — never re-implemented), minted into the card's
+// image_url by the unfurl builder and verified by the CONTENT worker's /_glance/og route. Slack
+// fetches image_url SERVER-SIDE and UNAUTHENTICATED, so the route must be public — the signature
+// is what keeps a public image path from becoming the site-enumeration oracle the unfurl endpoint
+// deliberately avoids (Glance has no anonymous tier). Deliberately STABLE (no expiry): Slack
+// re-fetches after its cache lapses, and a dead URL breaks the card forever; unguessable-but-
+// stable is the right trade here.
+//
+// Signed with CONTENT_TOKEN_SECRET — the one secret both workers share, in its existing
+// direction (minted on main, verified on content, like lib/token.ts). The image lives on the
+// CONTENT worker so the ~700 KiB gz satori/resvg wasm (lib/og-render.ts) never enters the main
+// worker bundle. This file must stay renderer-free for the same reason in reverse: the main
+// worker imports it for minting.
+
+import { secretEquals } from './bootstrap'
+import { hmacSignHex } from './hmac'
+
+/** hex(HMAC(secret, `og:<space>/<site>`)) — the `og:` scope prefix domain-separates this use of
+ *  CONTENT_TOKEN_SECRET from the content tokens minted with it. */
+export function signOgSig(secret: string, spaceSlug: string, siteSlug: string): Promise<string> {
+  return hmacSignHex(secret, `og:${spaceSlug}/${siteSlug}`)
+}
+
+/** Constant-time verify (a MAC compared with `===` leaks timing). */
+export async function verifyOgSig(secret: string, spaceSlug: string, siteSlug: string, sig: string): Promise<boolean> {
+  return secretEquals(await signOgSig(secret, spaceSlug, siteSlug), sig)
+}
+
+/** The absolute image_url the unfurl card carries — on the CONTENT origin, under the reserved
+ *  `_glance` prefix (never a space slug, see content.ts's asset routes). */
+export function ogImageUrl(contentUrl: string, spaceSlug: string, siteSlug: string, sig: string): string {
+  return `${contentUrl}/_glance/og/${spaceSlug}/${siteSlug}.png?sig=${sig}`
+}
+
+/** What the card renders. Kept to what the picture needs — the route resolves it, the renderer
+ *  (real or the OG_RENDER test seam) consumes it. */
+export type OgCard = { title: string; spaceSlug: string; siteSlug: string }
+
+// The brand mark: packages/web/public/favicon.svg with the theme-adaptive <style> flattened to
+// the light-theme rim (satori/resvg render static SVG; a media query would be ignored anyway).
+const BRAND_MARK_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><defs><linearGradient id="tile" x1="40" y1="24" x2="472" y2="488" gradientUnits="userSpaceOnUse"><stop offset="0" stop-color="#e8ab44"/><stop offset="0.55" stop-color="#e0a13a"/><stop offset="1" stop-color="#c26248"/></linearGradient></defs><rect x="8" y="8" width="496" height="496" rx="112" fill="url(#tile)"/><rect x="14" y="14" width="484" height="484" rx="106" fill="none" stroke="rgba(18,21,26,0.16)" stroke-width="12"/><path d="M256 132C356 132 442 196 476 256C442 316 356 380 256 380C156 380 70 316 36 256C70 196 156 132 256 132Z" fill="#faf6ec"/><rect x="184" y="184" width="144" height="144" rx="34" fill="#15181e"/><rect x="208" y="222" width="92" height="20" rx="10" fill="#e0a13a"/><circle cx="300" cy="296" r="18" fill="#c26248"/></svg>`
+
+const BRAND_MARK_DATA_URI = `data:image/svg+xml;base64,${btoa(BRAND_MARK_SVG)}`
+
+const esc = (s: string) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;')
+
+/** The card markup (satori's HTML subset: everything display:flex, inline styles only). Brand
+ *  palette from the mark: dark #15181e, cream #faf6ec, amber #e0a13a. */
+export function ogCardHtml(card: OgCard): string {
+  return `<div style="display:flex;flex-direction:column;justify-content:space-between;width:100vw;height:100vh;background:#15181e;padding:72px;font-family:'IBM Plex Sans'">
+  <div style="display:flex;align-items:center">
+    <img src="${BRAND_MARK_DATA_URI}" width="96" height="96" />
+    <span style="margin-left:28px;font-size:44px;font-weight:600;color:#faf6ec">Glance</span>
+  </div>
+  <div style="display:flex;flex-direction:column">
+    <span style="font-size:64px;font-weight:600;color:#faf6ec;line-height:1.2;max-height:230px;overflow:hidden">${esc(card.title)}</span>
+    <span style="margin-top:24px;font-size:32px;color:#e0a13a">${esc(card.spaceSlug)}/${esc(card.siteSlug)}</span>
+  </div>
+</div>`
+}

--- a/packages/api/src/lib/og-render.ts
+++ b/packages/api/src/lib/og-render.ts
@@ -1,0 +1,20 @@
+// The unfurl card's real PNG renderer, split from lib/og-image.ts on purpose: workers-og drags
+// ~700 KiB gz of satori/resvg wasm into whichever bundle imports it, so ONLY the content worker
+// (which serves the image) may import this file — the main worker mints URLs via og-image.ts and
+// must never grow the wasm. The import inside stays DYNAMIC so bun tests that import content.ts
+// never load the wasm either (routes inject the OG_RENDER env seam instead, like SLACK_FETCH).
+
+import { type OgCard, ogCardHtml } from './og-image'
+
+/** workers-og (satori→SVG, resvg→PNG) at Slack's 1200×630. The font loads at render time via
+ *  the Workers cache (loadGoogleFont) — bundling a typeface would cost more than the rest of
+ *  the worker combined, and Slack's own image cache makes renders rare. */
+export async function renderOgPng(card: OgCard): Promise<Response> {
+  const { ImageResponse, loadGoogleFont } = await import('workers-og')
+  const font = await loadGoogleFont({ family: 'IBM Plex Sans', weight: 600 })
+  return new ImageResponse(ogCardHtml(card), {
+    width: 1200,
+    height: 630,
+    fonts: [{ name: 'IBM Plex Sans', data: font, weight: 600, style: 'normal' }],
+  })
+}

--- a/packages/api/src/lib/site-access.ts
+++ b/packages/api/src/lib/site-access.ts
@@ -23,6 +23,7 @@ export type ResolvedSite = {
   ownerId: string
   contentVersion: number
   createdAt: string
+  updatedAt: string
 }
 
 const RESOLVED_SITE_COLUMNS = {
@@ -36,6 +37,7 @@ const RESOLVED_SITE_COLUMNS = {
   ownerId: sitesTable.ownerId,
   contentVersion: sitesTable.contentVersion,
   createdAt: sitesTable.createdAt,
+  updatedAt: sitesTable.updatedAt,
 }
 
 /** Resolve a site by (spaceSlug, siteSlug), joined to its space. Null if missing. */

--- a/packages/api/src/lib/slack-unfurl.test.ts
+++ b/packages/api/src/lib/slack-unfurl.test.ts
@@ -57,11 +57,12 @@ describe('buildUnfurlBlocks', () => {
   const NOW = Date.parse('2026-07-27T12:00:00Z')
   const card: UnfurlCard = {
     title: 'Q3 Report',
-    slug: 'report',
+    spaceSlug: 'acme',
+    siteSlug: 'report',
     description: 'How the numbers moved',
     updatedAt: '2026-07-24T12:00:00Z',
   }
-  const build = (over: Partial<UnfurlCard>) => buildUnfurlBlocks({ ...card, ...over }, 'acme', `${APP}/acme/report`, NOW)
+  const build = (over: Partial<UnfurlCard>) => buildUnfurlBlocks({ ...card, ...over }, `${APP}/acme/report`, NOW)
 
   test('links the title and includes the blurb plus a context line with freshness', () => {
     const json = JSON.stringify(build({}))

--- a/packages/api/src/lib/slack-unfurl.test.ts
+++ b/packages/api/src/lib/slack-unfurl.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 import { countingKv } from '../test/harness'
-import { buildUnfurlBlocks, parseSiteUrl, postUnfurl } from './slack-unfurl'
+import { buildUnfurlBlocks, parseSiteUrl, postUnfurl, relativeTime, type UnfurlCard } from './slack-unfurl'
 import type { SlackHttpDeps } from './slack'
 
 const APP = 'https://glance.example.com'
@@ -32,26 +32,65 @@ describe('parseSiteUrl', () => {
   })
 })
 
-describe('buildUnfurlBlocks', () => {
-  const site = { title: 'Q3 Report', description: 'How the numbers moved', slug: 'report' }
+describe('relativeTime', () => {
+  const NOW = Date.parse('2026-07-27T12:00:00Z')
+  const at = (iso: string) => relativeTime(iso, NOW)
 
-  test('links the title and includes the blurb plus a context line', () => {
-    const json = JSON.stringify(buildUnfurlBlocks(site, 'acme', `${APP}/acme/report`))
+  test('picks the coarsest unit that fits', () => {
+    expect(at('2026-07-27T11:59:30Z')).toBe('just now')
+    expect(at('2026-07-27T11:55:00Z')).toBe('5 minutes ago')
+    expect(at('2026-07-27T09:00:00Z')).toBe('3 hours ago')
+    expect(at('2026-07-24T12:00:00Z')).toBe('3 days ago')
+    expect(at('2026-05-20T12:00:00Z')).toBe('2 months ago')
+    expect(at('2024-07-01T12:00:00Z')).toBe('2 years ago')
+  })
+
+  test('singular units, future skew clamps to "just now", garbage yields null', () => {
+    expect(at('2026-07-27T10:59:00Z')).toBe('1 hour ago')
+    expect(at('2026-07-26T11:00:00Z')).toBe('1 day ago')
+    expect(at('2026-07-28T12:00:00Z')).toBe('just now') // clock skew, never "in 1 day"
+    expect(at('not-a-date')).toBeNull()
+  })
+})
+
+describe('buildUnfurlBlocks', () => {
+  const NOW = Date.parse('2026-07-27T12:00:00Z')
+  const card: UnfurlCard = {
+    title: 'Q3 Report',
+    slug: 'report',
+    description: 'How the numbers moved',
+    updatedAt: '2026-07-24T12:00:00Z',
+  }
+  const build = (over: Partial<UnfurlCard>) => buildUnfurlBlocks({ ...card, ...over }, 'acme', `${APP}/acme/report`, NOW)
+
+  test('links the title and includes the blurb plus a context line with freshness', () => {
+    const json = JSON.stringify(build({}))
     expect(json).toContain(`<${APP}/acme/report|Q3 Report>`)
     expect(json).toContain('How the numbers moved')
-    expect(json).toContain('acme/report')
+    expect(json).toContain('Glance · acme/report · Updated 3 days ago')
   })
 
   test('falls back to the slug when the site has no title, and drops the blurb when absent', () => {
-    const blocks = buildUnfurlBlocks({ ...site, title: null, description: null }, 'acme', `${APP}/acme/report`)
+    const blocks = build({ title: null, description: null })
     expect(JSON.stringify(blocks)).toContain('|report>')
     expect(blocks).toHaveLength(2) // title section + context, no description section
   })
 
+  test('an unparseable updatedAt drops the freshness clause, not the card', () => {
+    const json = JSON.stringify(build({ updatedAt: 'garbage' }))
+    expect(json).toContain('Glance · acme/report')
+    expect(json).not.toContain('Updated')
+  })
+
+  test('an imageUrl renders as an image block with the title as alt text', () => {
+    const blocks = build({ imageUrl: `${APP}/api/og/acme/report.png?sig=abc` })
+    const image = blocks.find((b) => b.type === 'image')
+    expect(image).toMatchObject({ image_url: `${APP}/api/og/acme/report.png?sig=abc`, alt_text: 'Q3 Report' })
+    expect(JSON.stringify(build({}))).not.toContain('"image"')
+  })
+
   test('escapes mrkdwn metacharacters in the author-controlled title and description', () => {
-    const json = JSON.stringify(
-      buildUnfurlBlocks({ ...site, title: '<script>&x', description: 'a > b & c < d' }, 'acme', `${APP}/acme/report`),
-    )
+    const json = JSON.stringify(build({ title: '<script>&x', description: 'a > b & c < d' }))
     expect(json).toContain('&lt;script&gt;&amp;x')
     expect(json).toContain('a &gt; b &amp; c &lt; d')
     expect(json).not.toContain('<script>')

--- a/packages/api/src/lib/slack-unfurl.ts
+++ b/packages/api/src/lib/slack-unfurl.ts
@@ -41,20 +41,51 @@ export function parseSiteUrl(raw: string, appUrl: string): ParsedSiteUrl | null 
   return { spaceSlug, siteSlug }
 }
 
-/** Block Kit blocks for one site card: bold linked title, the derived blurb, and a context line
- *  naming the space/site. Slack renders `text` fields as mrkdwn, so the two author-controlled
- *  strings (title, description) go through `escapeSlack`; the slugs are `[a-z0-9-]` and need none. */
-export function buildUnfurlBlocks(
-  site: { title: string | null; description: string | null; slug: string },
-  spaceSlug: string,
-  url: string,
-): SlackBlock[] {
+/** Coarse "Updated …" clause for the card's context line. Sub-minute (and any clock skew that
+ *  makes the timestamp look future) collapses to "just now"; an unparseable timestamp yields
+ *  null so the caller drops the clause rather than rendering "NaN days ago". */
+export function relativeTime(iso: string, nowMs: number): string | null {
+  const diff = nowMs - Date.parse(iso)
+  if (Number.isNaN(diff)) return null
+  const ago = (v: number, unit: string) => `${v} ${unit}${v === 1 ? '' : 's'} ago`
+  const minutes = Math.floor(diff / 60_000)
+  if (minutes < 1) return 'just now'
+  if (minutes < 60) return ago(minutes, 'minute')
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return ago(hours, 'hour')
+  const days = Math.floor(hours / 24)
+  if (days < 31) return ago(days, 'day')
+  const months = Math.floor(days / 30)
+  if (months < 12) return ago(months, 'month')
+  return ago(Math.floor(months / 12), 'year')
+}
+
+/** Everything the card renders, assembled by the route from the access-facts batch. `imageUrl`
+ *  is the signed brand-card PNG, absent when unavailable. */
+export type UnfurlCard = {
+  title: string | null
+  slug: string
+  description: string | null
+  updatedAt: string
+  imageUrl?: string
+}
+
+/** Block Kit blocks for one site card: bold linked title, the derived blurb, the brand image,
+ *  and a context line with space/site · freshness. Slack renders `text` fields as mrkdwn, so the
+ *  author-controlled strings (title, description) go through `escapeSlack`; the slugs are
+ *  `[a-z0-9-]` and need none. */
+export function buildUnfurlBlocks(card: UnfurlCard, spaceSlug: string, url: string, nowMs: number): SlackBlock[] {
+  const updated = relativeTime(card.updatedAt, nowMs)
+  const meta = [`Glance · ${spaceSlug}/${card.slug}`, ...(updated ? [`Updated ${updated}`] : [])]
   return [
-    { type: 'section', text: { type: 'mrkdwn', text: `*${slackLink(url, site.title ?? site.slug)}*` } },
-    ...(site.description
-      ? [{ type: 'section', text: { type: 'mrkdwn', text: escapeSlack(site.description) } } as SlackBlock]
+    { type: 'section', text: { type: 'mrkdwn', text: `*${slackLink(url, card.title ?? card.slug)}*` } },
+    ...(card.description
+      ? [{ type: 'section', text: { type: 'mrkdwn', text: escapeSlack(card.description) } } as SlackBlock]
       : []),
-    { type: 'context', elements: [{ type: 'mrkdwn', text: `Glance · ${spaceSlug}/${site.slug}` }] },
+    ...(card.imageUrl
+      ? [{ type: 'image', image_url: card.imageUrl, alt_text: card.title ?? card.slug } as SlackBlock]
+      : []),
+    { type: 'context', elements: [{ type: 'mrkdwn', text: meta.join(' · ') }] },
   ]
 }
 

--- a/packages/api/src/lib/slack-unfurl.ts
+++ b/packages/api/src/lib/slack-unfurl.ts
@@ -64,7 +64,8 @@ export function relativeTime(iso: string, nowMs: number): string | null {
  *  is the signed brand-card PNG, absent when unavailable. */
 export type UnfurlCard = {
   title: string | null
-  slug: string
+  spaceSlug: string
+  siteSlug: string
   description: string | null
   updatedAt: string
   imageUrl?: string
@@ -74,16 +75,16 @@ export type UnfurlCard = {
  *  and a context line with space/site · freshness. Slack renders `text` fields as mrkdwn, so the
  *  author-controlled strings (title, description) go through `escapeSlack`; the slugs are
  *  `[a-z0-9-]` and need none. */
-export function buildUnfurlBlocks(card: UnfurlCard, spaceSlug: string, url: string, nowMs: number): SlackBlock[] {
+export function buildUnfurlBlocks(card: UnfurlCard, url: string, nowMs: number): SlackBlock[] {
   const updated = relativeTime(card.updatedAt, nowMs)
-  const meta = [`Glance · ${spaceSlug}/${card.slug}`, ...(updated ? [`Updated ${updated}`] : [])]
+  const meta = [`Glance · ${card.spaceSlug}/${card.siteSlug}`, ...(updated ? [`Updated ${updated}`] : [])]
   return [
-    { type: 'section', text: { type: 'mrkdwn', text: `*${slackLink(url, card.title ?? card.slug)}*` } },
+    { type: 'section', text: { type: 'mrkdwn', text: `*${slackLink(url, card.title ?? card.siteSlug)}*` } },
     ...(card.description
       ? [{ type: 'section', text: { type: 'mrkdwn', text: escapeSlack(card.description) } } as SlackBlock]
       : []),
     ...(card.imageUrl
-      ? [{ type: 'image', image_url: card.imageUrl, alt_text: card.title ?? card.slug } as SlackBlock]
+      ? [{ type: 'image', image_url: card.imageUrl, alt_text: card.title ?? card.siteSlug } as SlackBlock]
       : []),
     { type: 'context', elements: [{ type: 'mrkdwn', text: meta.join(' · ') }] },
   ]

--- a/packages/api/src/routes/slack-events.test.ts
+++ b/packages/api/src/routes/slack-events.test.ts
@@ -146,6 +146,8 @@ describe('POST /api/slack/events — link_shared', () => {
     expect(card).toContain('Q3 Report')
     expect(card).toContain('How the numbers moved')
     expect(card).toContain(url)
+    // The thumbnail: a SIGNED image_url on the CONTENT origin (Slack fetches it unauthenticated).
+    expect(card).toMatch(/content\.example\.com\/_glance\/og\/acme\/report\.png\?sig=[0-9a-f]{64}/)
   })
 
   test('a PRIVATE site the sharer cannot read → no card at all (no title, no existence signal)', async () => {

--- a/packages/api/src/routes/slack-events.ts
+++ b/packages/api/src/routes/slack-events.ts
@@ -1,6 +1,7 @@
 import { type Context, Hono } from 'hono'
 import { getUserByEmail, toSessionUser } from '../db/repo'
 import { fireAndForget } from '../lib/events'
+import { ogImageUrl, signOgSig } from '../lib/og-image'
 import { fetchAccessFacts, siteAccessFromFacts } from '../lib/site-access'
 import { lookupSlackEmail, slackDepsFromEnv, slackUnfurlEnabled } from '../lib/slack'
 import {
@@ -9,6 +10,7 @@ import {
   type ParsedSiteUrl,
   postUnfurl,
   type SlackBlock,
+  type UnfurlCard,
   type UnfurlTarget,
 } from '../lib/slack-unfurl'
 import { verifySlackSignature } from '../lib/slack-verify'
@@ -105,6 +107,7 @@ async function unfurlLinks(c: Context<AppEnv>, event: LinkSharedEvent): Promise<
 
   // One batched access read per site, all in flight together — the sites are independent, and D1's
   // primary is far enough away that serializing these would dominate the whole handler.
+  const now = Date.now()
   const cards = await Promise.all(
     targets.map(async ({ parsed, urls }) => {
       // checkAccess is the single source of truth (lib/access.ts) — archived sites and every
@@ -112,7 +115,18 @@ async function unfurlLinks(c: Context<AppEnv>, event: LinkSharedEvent): Promise<
       const { facts } = await fetchAccessFacts(db, parsed.spaceSlug, parsed.siteSlug, user.id)
       const { site, access } = siteAccessFromFacts(facts, user)
       if (!site || !access.ok) return []
-      return urls.map((url) => [url, { blocks: buildUnfurlBlocks(site, parsed.spaceSlug, url) }] as const)
+      // The card image is fetched by Slack unauthenticated, so its URL carries an HMAC minted
+      // HERE — only sites that already passed the sharer's access check ever get a signed URL.
+      // CONTENT_TOKEN_SECRET because the image is served by the CONTENT worker (lib/og-image.ts).
+      const sig = await signOgSig(c.env.CONTENT_TOKEN_SECRET, parsed.spaceSlug, parsed.siteSlug)
+      const card: UnfurlCard = {
+        title: site.title,
+        slug: site.slug,
+        description: site.description,
+        updatedAt: site.updatedAt,
+        imageUrl: ogImageUrl(c.env.CONTENT_URL, parsed.spaceSlug, parsed.siteSlug, sig),
+      }
+      return urls.map((url) => [url, { blocks: buildUnfurlBlocks(card, parsed.spaceSlug, url, now) }] as const)
     }),
   )
 

--- a/packages/api/src/routes/slack-events.ts
+++ b/packages/api/src/routes/slack-events.ts
@@ -1,7 +1,7 @@
 import { type Context, Hono } from 'hono'
 import { getUserByEmail, toSessionUser } from '../db/repo'
 import { fireAndForget } from '../lib/events'
-import { ogImageUrl, signOgSig } from '../lib/og-image'
+import { signedOgImageUrl } from '../lib/og-image'
 import { fetchAccessFacts, siteAccessFromFacts } from '../lib/site-access'
 import { lookupSlackEmail, slackDepsFromEnv, slackUnfurlEnabled } from '../lib/slack'
 import {
@@ -118,15 +118,15 @@ async function unfurlLinks(c: Context<AppEnv>, event: LinkSharedEvent): Promise<
       // The card image is fetched by Slack unauthenticated, so its URL carries an HMAC minted
       // HERE — only sites that already passed the sharer's access check ever get a signed URL.
       // CONTENT_TOKEN_SECRET because the image is served by the CONTENT worker (lib/og-image.ts).
-      const sig = await signOgSig(c.env.CONTENT_TOKEN_SECRET, parsed.spaceSlug, parsed.siteSlug)
       const card: UnfurlCard = {
         title: site.title,
-        slug: site.slug,
+        spaceSlug: parsed.spaceSlug,
+        siteSlug: parsed.siteSlug,
         description: site.description,
         updatedAt: site.updatedAt,
-        imageUrl: ogImageUrl(c.env.CONTENT_URL, parsed.spaceSlug, parsed.siteSlug, sig),
+        imageUrl: await signedOgImageUrl(c.env.CONTENT_TOKEN_SECRET, c.env.CONTENT_URL, parsed.spaceSlug, parsed.siteSlug),
       }
-      return urls.map((url) => [url, { blocks: buildUnfurlBlocks(card, parsed.spaceSlug, url, now) }] as const)
+      return urls.map((url) => [url, { blocks: buildUnfurlBlocks(card, url, now) }] as const)
     }),
   )
 

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -35,6 +35,10 @@ export interface Bindings {
   // env to capture users.lookupByEmail / chat.postMessage without touching global fetch. Never set in
   // prod — unset → deliverSlack falls back to globalThis.fetch.
   SLACK_FETCH?: typeof fetch
+  // DI seam for the unfurl-card PNG renderer (same idiom as SLACK_FETCH): route tests inject a fake
+  // so the satori/resvg wasm never loads under bun. Never set in prod — unset → lib/og-image's
+  // renderOgPng.
+  OG_RENDER?: (card: { title: string; spaceSlug: string; siteSlug: string }) => Promise<Response>
   SESSION_SECRET: string
   CONTENT_TOKEN_SECRET: string
   // Optional: separate HMAC secret for the shared-backend data-plane tokens (glance.db SDK).

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -1,4 +1,5 @@
 import type { DrizzleD1Database } from 'drizzle-orm/d1'
+import type { OgCard } from './lib/og-image'
 
 /** Worker bindings + secrets/vars. Secrets come from `.dev.vars` locally and
  *  `wrangler secret put` in prod; plain vars can live in wrangler.jsonc `vars`. */
@@ -36,9 +37,9 @@ export interface Bindings {
   // prod — unset → deliverSlack falls back to globalThis.fetch.
   SLACK_FETCH?: typeof fetch
   // DI seam for the unfurl-card PNG renderer (same idiom as SLACK_FETCH): route tests inject a fake
-  // so the satori/resvg wasm never loads under bun. Never set in prod — unset → lib/og-image's
+  // so the satori/resvg wasm never loads under bun. Never set in prod — unset → lib/og-render's
   // renderOgPng.
-  OG_RENDER?: (card: { title: string; spaceSlug: string; siteSlug: string }) => Promise<Response>
+  OG_RENDER?: (card: OgCard) => Promise<Response>
   SESSION_SECRET: string
   CONTENT_TOKEN_SECRET: string
   // Optional: separate HMAC secret for the shared-backend data-plane tokens (glance.db SDK).


### PR DESCRIPTION
Builds on #72 (link_shared → chat.unfurl). Two additions to the unfurl card:

**Signed brand-thumbnail PNG.** The card now carries an `image` block pointing at `GET /_glance/og/:space/:site.png` on the **content** worker. Slack fetches `image_url` server-side and unauthenticated, so the URL is gated by an HMAC (`og:<space>/<site>`, signed with the shared `CONTENT_TOKEN_SECRET` in its existing main→content direction) minted only after the sharer's access check passes. Every failure is the same opaque 404 — no site-enumeration signal, matching the unfurl endpoint's posture. The signature verifies **before** any D1 read; deleted/archived sites stop serving even with a valid sig. The sig is deliberately stable (no expiry): Slack re-fetches after its cache lapses and a dead URL breaks the card forever.

**Bundle discipline.** The satori/resvg wasm (`workers-og`, ~700 KiB gz) lives only in `lib/og-render.ts`, imported solely by the content worker and dynamically inside the function — the main worker mints URLs via the renderer-free `lib/og-image.ts`, and bun tests never load the wasm (routes inject the `OG_RENDER` env DI seam, same idiom as `SLACK_FETCH`).

**Freshness.** The context line gains `Updated 3 days ago` from `sites.updatedAt` (`relativeTime`; unparseable timestamps drop the clause, clock skew clamps to "just now"). Long titles ellipsize at three lines via satori's native `line-clamp`.

Post-review cleanups (thermo-nuclear + simplify pass, f1c6e69): `UnfurlCard` carries both slugs (naming aligned with `OgCard`), `signOgSig`+`ogImageUrl` merged into `signedOgImageUrl` at the only mint site, `OG_RENDER` typed with the real `OgCard`.

## Tests
- `content-og.test.ts`: signature gate (valid / missing / malformed / replayed-from-another-site), deleted+archived stop serving, slug fallback — renderer faked via `OG_RENDER`.
- `og-image.test.ts`: sign/verify roundtrip, tamper matrix, URL minting, card HTML escaping + line-clamp.
- `slack-unfurl.test.ts` / `slack-events.test.ts`: freshness clause, image block, signed URL on the content origin.
- 838 pass · typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tq51J7UKsMUA3KZi8JRimC