### PR TITLE
Unfurl card PNG: halve to 600×315 so Slack shows a card-sized image

### DIFF
--- a/packages/api/src/lib/og-image.test.ts
+++ b/packages/api/src/lib/og-image.test.ts
@@ -27,7 +27,7 @@ describe('og signature', () => {
   test('signedOgImageUrl mints the sig as a query param on the CONTENT origin', async () => {
     const sig = await signOgSig(TEST_SIGNING_KEY, 'acme', 'report')
     expect(await signedOgImageUrl(TEST_SIGNING_KEY, 'https://content.example.com', 'acme', 'report')).toBe(
-      `https://content.example.com/_glance/og/acme/report.png?sig=${sig}`,
+      `https://content.example.com/_glance/og/acme/report.png?sig=${sig}&v=2`,
     )
   })
 })

--- a/packages/api/src/lib/og-image.ts
+++ b/packages/api/src/lib/og-image.ts
@@ -28,14 +28,17 @@ export async function verifyOgSig(secret: string, spaceSlug: string, siteSlug: s
 }
 
 /** The absolute, signed image_url the unfurl card carries — on the CONTENT origin, under the
- *  reserved `_glance` prefix (never a space slug, see content.ts's asset routes). */
+ *  reserved `_glance` prefix (never a space slug, see content.ts's asset routes). `v` is a
+ *  cache-buster for Slack, which caches by full URL and the sig is deliberately stable: bump it
+ *  whenever the rendered card changes visually (v2: 1200×630 → 600×315), else channels keep
+ *  showing the cached old design. The route ignores it. */
 export async function signedOgImageUrl(
   secret: string,
   contentUrl: string,
   spaceSlug: string,
   siteSlug: string,
 ): Promise<string> {
-  return `${contentUrl}/_glance/og/${spaceSlug}/${siteSlug}.png?sig=${await signOgSig(secret, spaceSlug, siteSlug)}`
+  return `${contentUrl}/_glance/og/${spaceSlug}/${siteSlug}.png?sig=${await signOgSig(secret, spaceSlug, siteSlug)}&v=2`
 }
 
 /** What the card renders. Kept to what the picture needs — the route resolves it, the renderer
@@ -53,18 +56,19 @@ const BRAND_MARK_DATA_URI = `data:image/svg+xml;base64,${btoa(BRAND_MARK_SVG)}`
 const esc = (s: string) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;')
 
 /** The card markup (satori's HTML subset: everything display:flex, inline styles only). Brand
- *  palette from the mark: dark #15181e, cream #faf6ec, amber #e0a13a. The title uses satori's
- *  native line-clamp (needs display:block): a long title ends in a visible ellipsis at exactly
- *  three wrapped lines instead of clipping mid-sentence. */
+ *  palette from the mark: dark #15181e, cream #faf6ec, amber #e0a13a. Sizes are for the 600×315
+ *  canvas (og-render.ts) — half the canonical OG 1200×630, scaled 1:1 with it. The title uses
+ *  satori's native line-clamp (needs display:block): a long title ends in a visible ellipsis at
+ *  exactly three wrapped lines instead of clipping mid-sentence. */
 export function ogCardHtml(card: OgCard): string {
-  return `<div style="display:flex;flex-direction:column;justify-content:space-between;width:100vw;height:100vh;background:#15181e;padding:72px;font-family:'IBM Plex Sans'">
+  return `<div style="display:flex;flex-direction:column;justify-content:space-between;width:100vw;height:100vh;background:#15181e;padding:36px;font-family:'IBM Plex Sans'">
   <div style="display:flex;align-items:center">
-    <img src="${BRAND_MARK_DATA_URI}" width="96" height="96" />
-    <span style="margin-left:28px;font-size:44px;font-weight:600;color:#faf6ec">Glance</span>
+    <img src="${BRAND_MARK_DATA_URI}" width="48" height="48" />
+    <span style="margin-left:14px;font-size:22px;font-weight:600;color:#faf6ec">Glance</span>
   </div>
   <div style="display:flex;flex-direction:column">
-    <span style="display:block;line-clamp:3;font-size:64px;font-weight:600;color:#faf6ec;line-height:1.2">${esc(card.title)}</span>
-    <span style="margin-top:24px;font-size:32px;color:#e0a13a">${esc(card.spaceSlug)}/${esc(card.siteSlug)}</span>
+    <span style="display:block;line-clamp:3;font-size:32px;font-weight:600;color:#faf6ec;line-height:1.2">${esc(card.title)}</span>
+    <span style="margin-top:12px;font-size:16px;color:#e0a13a">${esc(card.spaceSlug)}/${esc(card.siteSlug)}</span>
   </div>
 </div>`
 }

--- a/packages/api/src/lib/og-render.ts
+++ b/packages/api/src/lib/og-render.ts
@@ -6,15 +6,18 @@
 
 import { type OgCard, ogCardHtml } from './og-image'
 
-/** workers-og (satori→SVG, resvg→PNG) at Slack's 1200×630. The font loads at render time via
- *  the Workers cache (loadGoogleFont) — bundling a typeface would cost more than the rest of
- *  the worker combined, and Slack's own image cache makes renders rare. */
+/** workers-og (satori→SVG, resvg→PNG) at 600×315 — Slack's 1.91:1 ratio at HALF the canonical
+ *  1200×630. Slack shows an image block at its natural size (capped by the message column), so
+ *  the full-size canvas dominated the channel; half keeps the same layout (ogCardHtml's styles
+ *  are scaled to match) at a card-sized footprint. The font loads at render time via the Workers
+ *  cache (loadGoogleFont) — bundling a typeface would cost more than the rest of the worker
+ *  combined, and Slack's own image cache makes renders rare. */
 export async function renderOgPng(card: OgCard): Promise<Response> {
   const { ImageResponse, loadGoogleFont } = await import('workers-og')
   const font = await loadGoogleFont({ family: 'IBM Plex Sans', weight: 600 })
   return new ImageResponse(ogCardHtml(card), {
-    width: 1200,
-    height: 630,
+    width: 600,
+    height: 315,
     fonts: [{ name: 'IBM Plex Sans', data: font, weight: 600, style: 'normal' }],
   })
 }


### PR DESCRIPTION
Follow-up to #73. Slack renders an `image` block at the image's natural size (capped by the message column), so the canonical-OG 1200×630 canvas dominated the channel.

- Render at **600×315** (same 1.91:1 ratio); every card style in `ogCardHtml` scaled 1:1 with the canvas, so the layout is pixel-identical, just half-size.
- `image_url` gains **`&v=2`**: Slack caches by full URL and the sig is deliberately stable, so without a bump channels would keep showing the cached full-size design. The route ignores the param.

838 tests pass, typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tq51J7UKsMUA3KZi8JRimC