### PR TITLE
Unfurl: legacy attachment (400px-capped image) + satori entity fix

### DIFF
--- a/packages/api/src/lib/og-image.test.ts
+++ b/packages/api/src/lib/og-image.test.ts
@@ -27,16 +27,17 @@ describe('og signature', () => {
   test('signedOgImageUrl mints the sig as a query param on the CONTENT origin', async () => {
     const sig = await signOgSig(TEST_SIGNING_KEY, 'acme', 'report')
     expect(await signedOgImageUrl(TEST_SIGNING_KEY, 'https://content.example.com', 'acme', 'report')).toBe(
-      `https://content.example.com/_glance/og/acme/report.png?sig=${sig}&v=2`,
+      `https://content.example.com/_glance/og/acme/report.png?sig=${sig}&v=3`,
     )
   })
 })
 
 describe('ogCardHtml', () => {
-  test('escapes the author-controlled title and shows the space/site pair', () => {
+  test('neutralizes markup in the author-controlled title WITHOUT entities (workers-og never decodes them — &amp; would render literally)', () => {
     const html = ogCardHtml({ title: '<b>&"Q3"', spaceSlug: 'acme', siteSlug: 'report' })
-    expect(html).toContain('&lt;b&gt;&amp;&quot;Q3&quot;')
+    expect(html).toContain('‹b›&"Q3"') // angle-quote lookalikes; & and " stay raw
     expect(html).not.toContain('<b>')
+    expect(html).not.toContain('&amp;')
     expect(html).toContain('acme/report')
     expect(html).toContain('data:image/svg+xml;base64,') // the brand mark rides inline
   })

--- a/packages/api/src/lib/og-image.ts
+++ b/packages/api/src/lib/og-image.ts
@@ -30,15 +30,15 @@ export async function verifyOgSig(secret: string, spaceSlug: string, siteSlug: s
 /** The absolute, signed image_url the unfurl card carries — on the CONTENT origin, under the
  *  reserved `_glance` prefix (never a space slug, see content.ts's asset routes). `v` is a
  *  cache-buster for Slack, which caches by full URL and the sig is deliberately stable: bump it
- *  whenever the rendered card changes visually (v2: 1200×630 → 600×315), else channels keep
- *  showing the cached old design. The route ignores it. */
+ *  whenever the rendered card changes visually (v3: entity-decode fix, back to 1200×630), else
+ *  channels keep showing the cached old design. The route ignores it. */
 export async function signedOgImageUrl(
   secret: string,
   contentUrl: string,
   spaceSlug: string,
   siteSlug: string,
 ): Promise<string> {
-  return `${contentUrl}/_glance/og/${spaceSlug}/${siteSlug}.png?sig=${await signOgSig(secret, spaceSlug, siteSlug)}&v=2`
+  return `${contentUrl}/_glance/og/${spaceSlug}/${siteSlug}.png?sig=${await signOgSig(secret, spaceSlug, siteSlug)}&v=3`
 }
 
 /** What the card renders. Kept to what the picture needs — the route resolves it, the renderer
@@ -51,24 +51,26 @@ const BRAND_MARK_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512
 
 const BRAND_MARK_DATA_URI = `data:image/svg+xml;base64,${btoa(BRAND_MARK_SVG)}`
 
-// Not lib/markdown's escapeHtml: that module imports Marked at top level, which the main worker
-// (importing this file to mint URLs) must not bundle.
-const esc = (s: string) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;')
+// NOT entity-escaping (and not lib/markdown's escapeHtml): workers-og's HTML parser never
+// decodes entities, so `&amp;` renders LITERALLY on the card (seen live with a title containing
+// `&`). Raw `&`/`"` are plain text to that parser; only `<`/`>` could open markup, so they're
+// swapped for lookalike angle quotes — injection-proof and faithful for every real title.
+const esc = (s: string) => s.replace(/</g, '‹').replace(/>/g, '›')
 
 /** The card markup (satori's HTML subset: everything display:flex, inline styles only). Brand
- *  palette from the mark: dark #15181e, cream #faf6ec, amber #e0a13a. Sizes are for the 600×315
- *  canvas (og-render.ts) — half the canonical OG 1200×630, scaled 1:1 with it. The title uses
- *  satori's native line-clamp (needs display:block): a long title ends in a visible ellipsis at
- *  exactly three wrapped lines instead of clipping mid-sentence. */
+ *  palette from the mark: dark #15181e, cream #faf6ec, amber #e0a13a. Sizes are for the 1200×630
+ *  canvas (og-render.ts). The title uses satori's native line-clamp (needs display:block): a
+ *  long title ends in a visible ellipsis at exactly three wrapped lines instead of clipping
+ *  mid-sentence. */
 export function ogCardHtml(card: OgCard): string {
-  return `<div style="display:flex;flex-direction:column;justify-content:space-between;width:100vw;height:100vh;background:#15181e;padding:36px;font-family:'IBM Plex Sans'">
+  return `<div style="display:flex;flex-direction:column;justify-content:space-between;width:100vw;height:100vh;background:#15181e;padding:72px;font-family:'IBM Plex Sans'">
   <div style="display:flex;align-items:center">
-    <img src="${BRAND_MARK_DATA_URI}" width="48" height="48" />
-    <span style="margin-left:14px;font-size:22px;font-weight:600;color:#faf6ec">Glance</span>
+    <img src="${BRAND_MARK_DATA_URI}" width="96" height="96" />
+    <span style="margin-left:28px;font-size:44px;font-weight:600;color:#faf6ec">Glance</span>
   </div>
   <div style="display:flex;flex-direction:column">
-    <span style="display:block;line-clamp:3;font-size:32px;font-weight:600;color:#faf6ec;line-height:1.2">${esc(card.title)}</span>
-    <span style="margin-top:12px;font-size:16px;color:#e0a13a">${esc(card.spaceSlug)}/${esc(card.siteSlug)}</span>
+    <span style="display:block;line-clamp:3;font-size:64px;font-weight:600;color:#faf6ec;line-height:1.2">${esc(card.title)}</span>
+    <span style="margin-top:24px;font-size:32px;color:#e0a13a">${esc(card.spaceSlug)}/${esc(card.siteSlug)}</span>
   </div>
 </div>`
 }

--- a/packages/api/src/lib/og-render.ts
+++ b/packages/api/src/lib/og-render.ts
@@ -6,18 +6,17 @@
 
 import { type OgCard, ogCardHtml } from './og-image'
 
-/** workers-og (satori→SVG, resvg→PNG) at 600×315 — Slack's 1.91:1 ratio at HALF the canonical
- *  1200×630. Slack shows an image block at its natural size (capped by the message column), so
- *  the full-size canvas dominated the channel; half keeps the same layout (ogCardHtml's styles
- *  are scaled to match) at a card-sized footprint. The font loads at render time via the Workers
- *  cache (loadGoogleFont) — bundling a typeface would cost more than the rest of the worker
- *  combined, and Slack's own image cache makes renders rare. */
+/** workers-og (satori→SVG, resvg→PNG) at the canonical OG 1200×630. Displayed size is Slack's
+ *  call, not ours: the card ships as a legacy attachment whose image_url is capped at 400×500
+ *  (slack-unfurl.ts), so the full canvas just makes that 400px display retina-crisp. The font
+ *  loads at render time via the Workers cache (loadGoogleFont) — bundling a typeface would cost
+ *  more than the rest of the worker combined, and Slack's own image cache makes renders rare. */
 export async function renderOgPng(card: OgCard): Promise<Response> {
   const { ImageResponse, loadGoogleFont } = await import('workers-og')
   const font = await loadGoogleFont({ family: 'IBM Plex Sans', weight: 600 })
   return new ImageResponse(ogCardHtml(card), {
-    width: 600,
-    height: 315,
+    width: 1200,
+    height: 630,
     fonts: [{ name: 'IBM Plex Sans', data: font, weight: 600, style: 'normal' }],
   })
 }

--- a/packages/api/src/lib/slack-unfurl.test.ts
+++ b/packages/api/src/lib/slack-unfurl.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 import { countingKv } from '../test/harness'
-import { buildUnfurlBlocks, parseSiteUrl, postUnfurl, relativeTime, type UnfurlCard } from './slack-unfurl'
+import { buildUnfurlAttachment, parseSiteUrl, postUnfurl, relativeTime, type UnfurlCard } from './slack-unfurl'
 import type { SlackHttpDeps } from './slack'
 
 const APP = 'https://glance.example.com'
@@ -53,7 +53,7 @@ describe('relativeTime', () => {
   })
 })
 
-describe('buildUnfurlBlocks', () => {
+describe('buildUnfurlAttachment', () => {
   const NOW = Date.parse('2026-07-27T12:00:00Z')
   const card: UnfurlCard = {
     title: 'Q3 Report',
@@ -62,44 +62,43 @@ describe('buildUnfurlBlocks', () => {
     description: 'How the numbers moved',
     updatedAt: '2026-07-24T12:00:00Z',
   }
-  const build = (over: Partial<UnfurlCard>) => buildUnfurlBlocks({ ...card, ...over }, `${APP}/acme/report`, NOW)
+  const build = (over: Partial<UnfurlCard>) => buildUnfurlAttachment({ ...card, ...over }, `${APP}/acme/report`, NOW)
 
-  test('links the title and includes the blurb plus a context line with freshness', () => {
-    const json = JSON.stringify(build({}))
-    expect(json).toContain(`<${APP}/acme/report|Q3 Report>`)
-    expect(json).toContain('How the numbers moved')
-    expect(json).toContain('Glance · acme/report · Updated 3 days ago')
+  test('a legacy-style attachment (NOT blocks — an image block always renders full-width): linked title, blurb, footer with freshness', () => {
+    expect(build({})).toEqual({
+      title: 'Q3 Report',
+      title_link: `${APP}/acme/report`,
+      text: 'How the numbers moved',
+      footer: 'Glance · acme/report · Updated 3 days ago',
+    })
   })
 
   test('falls back to the slug when the site has no title, and drops the blurb when absent', () => {
-    const blocks = build({ title: null, description: null })
-    expect(JSON.stringify(blocks)).toContain('|report>')
-    expect(blocks).toHaveLength(2) // title section + context, no description section
+    const attachment = build({ title: null, description: null })
+    expect(attachment.title).toBe('report')
+    expect(attachment).not.toHaveProperty('text')
   })
 
   test('an unparseable updatedAt drops the freshness clause, not the card', () => {
-    const json = JSON.stringify(build({ updatedAt: 'garbage' }))
-    expect(json).toContain('Glance · acme/report')
-    expect(json).not.toContain('Updated')
+    expect(build({ updatedAt: 'garbage' }).footer).toBe('Glance · acme/report')
   })
 
-  test('an imageUrl renders as an image block with the title as alt text', () => {
-    const blocks = build({ imageUrl: `${APP}/api/og/acme/report.png?sig=abc` })
-    const image = blocks.find((b) => b.type === 'image')
-    expect(image).toMatchObject({ image_url: `${APP}/api/og/acme/report.png?sig=abc`, alt_text: 'Q3 Report' })
-    expect(JSON.stringify(build({}))).not.toContain('"image"')
+  test('an imageUrl rides as the attachment image_url (400px-capped by Slack), absent otherwise', () => {
+    expect(build({ imageUrl: `${APP}/api/og/acme/report.png?sig=abc` }).image_url).toBe(
+      `${APP}/api/og/acme/report.png?sig=abc`,
+    )
+    expect(build({})).not.toHaveProperty('image_url')
   })
 
   test('escapes mrkdwn metacharacters in the author-controlled title and description', () => {
-    const json = JSON.stringify(build({ title: '<script>&x', description: 'a > b & c < d' }))
-    expect(json).toContain('&lt;script&gt;&amp;x')
-    expect(json).toContain('a &gt; b &amp; c &lt; d')
-    expect(json).not.toContain('<script>')
+    const attachment = build({ title: '<script>&x', description: 'a > b & c < d' })
+    expect(attachment.title).toBe('&lt;script&gt;&amp;x')
+    expect(attachment.text).toBe('a &gt; b &amp; c &lt; d')
   })
 })
 
 describe('postUnfurl', () => {
-  const unfurls = { [`${APP}/acme/report`]: { blocks: [{ type: 'section' }] } }
+  const unfurls = { [`${APP}/acme/report`]: { title: 'Q3', title_link: `${APP}/acme/report`, footer: 'Glance' } }
 
   /** Capture the JSON body chat.unfurl was called with (null when it was never called). */
   function capture() {

--- a/packages/api/src/lib/slack-unfurl.ts
+++ b/packages/api/src/lib/slack-unfurl.ts
@@ -7,15 +7,22 @@
 // stay fully gated (lib/access.ts is untouched), and we can authorize the card against the person
 // who pasted the link. Docs: https://docs.slack.dev/messaging/unfurling-links-in-messages/
 
-import { escapeSlack, slackLink, slackPost, type SlackHttpDeps } from './slack'
+import { escapeSlack, slackPost, type SlackHttpDeps } from './slack'
 import { RESERVED_SLUGS } from './slug'
 
 const UNFURL_URL = 'https://slack.com/api/chat.unfurl'
 
-/** A Block Kit block. Slack's schema is open-ended (dozens of block/element types), so this pins the
- *  one field every block has rather than pretending to model the union — still far tighter than the
- *  `object` it replaces. */
-export type SlackBlock = { type: string } & Record<string, unknown>
+/** The unfurl card as a LEGACY-style attachment, deliberately not Block Kit: Slack renders an
+ *  attachment's `image_url` capped at 400×500 (the native link-preview look), while a Block Kit
+ *  `image` block always stretches to the full message column — the image size is the whole
+ *  reason this stays on the legacy shape. */
+export type SlackAttachment = {
+  title: string
+  title_link: string
+  text?: string
+  image_url?: string
+  footer: string
+}
 
 /** The site slugs a pasted URL points at. Deliberately NOT the in-site file path: the card links the
  *  pasted URL verbatim, so nothing downstream needs the path split out. */
@@ -71,23 +78,20 @@ export type UnfurlCard = {
   imageUrl?: string
 }
 
-/** Block Kit blocks for one site card: bold linked title, the derived blurb, the brand image,
- *  and a context line with space/site · freshness. Slack renders `text` fields as mrkdwn, so the
- *  author-controlled strings (title, description) go through `escapeSlack`; the slugs are
- *  `[a-z0-9-]` and need none. */
-export function buildUnfurlBlocks(card: UnfurlCard, url: string, nowMs: number): SlackBlock[] {
+/** One site card: linked title, the derived blurb, the brand image (400px-capped, see
+ *  SlackAttachment), and a footer with space/site · freshness. The author-controlled strings
+ *  (title, description) go through `escapeSlack` (Slack requires `&<>` escaped in all text);
+ *  the slugs are `[a-z0-9-]` and need none. */
+export function buildUnfurlAttachment(card: UnfurlCard, url: string, nowMs: number): SlackAttachment {
   const updated = relativeTime(card.updatedAt, nowMs)
   const meta = [`Glance · ${card.spaceSlug}/${card.siteSlug}`, ...(updated ? [`Updated ${updated}`] : [])]
-  return [
-    { type: 'section', text: { type: 'mrkdwn', text: `*${slackLink(url, card.title ?? card.siteSlug)}*` } },
-    ...(card.description
-      ? [{ type: 'section', text: { type: 'mrkdwn', text: escapeSlack(card.description) } } as SlackBlock]
-      : []),
-    ...(card.imageUrl
-      ? [{ type: 'image', image_url: card.imageUrl, alt_text: card.title ?? card.siteSlug } as SlackBlock]
-      : []),
-    { type: 'context', elements: [{ type: 'mrkdwn', text: meta.join(' · ') }] },
-  ]
+  return {
+    title: escapeSlack(card.title ?? card.siteSlug),
+    title_link: url,
+    ...(card.description ? { text: escapeSlack(card.description) } : {}),
+    ...(card.imageUrl ? { image_url: card.imageUrl } : {}),
+    footer: meta.join(' · '),
+  }
 }
 
 /** The `link_shared` fields that say WHICH message to attach the unfurl to. `unfurl_id`+`source` is
@@ -101,7 +105,7 @@ export type UnfurlTarget = { unfurl_id?: string; source?: string; channel?: stri
 export async function postUnfurl(
   deps: SlackHttpDeps,
   target: UnfurlTarget,
-  unfurls: Record<string, { blocks: SlackBlock[] }>,
+  unfurls: Record<string, SlackAttachment>,
 ): Promise<void> {
   if (Object.keys(unfurls).length === 0) return
   await slackPost(deps, UNFURL_URL, {

--- a/packages/api/src/routes/slack-events.ts
+++ b/packages/api/src/routes/slack-events.ts
@@ -5,11 +5,11 @@ import { signedOgImageUrl } from '../lib/og-image'
 import { fetchAccessFacts, siteAccessFromFacts } from '../lib/site-access'
 import { lookupSlackEmail, slackDepsFromEnv, slackUnfurlEnabled } from '../lib/slack'
 import {
-  buildUnfurlBlocks,
+  buildUnfurlAttachment,
   parseSiteUrl,
   type ParsedSiteUrl,
   postUnfurl,
-  type SlackBlock,
+  type SlackAttachment,
   type UnfurlCard,
   type UnfurlTarget,
 } from '../lib/slack-unfurl'
@@ -126,9 +126,9 @@ async function unfurlLinks(c: Context<AppEnv>, event: LinkSharedEvent): Promise<
         updatedAt: site.updatedAt,
         imageUrl: await signedOgImageUrl(c.env.CONTENT_TOKEN_SECRET, c.env.CONTENT_URL, parsed.spaceSlug, parsed.siteSlug),
       }
-      return urls.map((url) => [url, { blocks: buildUnfurlBlocks(card, url, now) }] as const)
+      return urls.map((url) => [url, buildUnfurlAttachment(card, url, now)] as const)
     }),
   )
 
-  await postUnfurl(deps, event, Object.fromEntries(cards.flat()) as Record<string, { blocks: SlackBlock[] }>)
+  await postUnfurl(deps, event, Object.fromEntries(cards.flat()) as Record<string, SlackAttachment>)
 }


### PR DESCRIPTION
Fixes the two live issues from #74's smoke: the image still rendered full-width (just blurrier), and titles containing `&` showed a literal `&amp;` on the card.

**Why shrinking the PNG didn't work:** Slack renders a Block Kit `image` *block* at full message-column width regardless of the image's natural size. A legacy attachment `image_url`, per Slack's docs, is "resized to a maximum width of 400px or a maximum height of 500px" — that's the native link-preview look (and exactly the medium size native OG unfurls get). So the unfurl now ships as a legacy attachment (`title`/`title_link`/`text`/`image_url`/`footer`) instead of blocks; `SlackBlock`/`buildUnfurlBlocks` → `SlackAttachment`/`buildUnfurlAttachment`. PNG back to crisp 1200×630 (downscaled to 400px display = retina-sharp), URL cache-buster bumped to `v=3`.

**Entity fix:** workers-og's HTML parser has an escaper but no entity *decoder* (verified in its bundle), so `&amp;` renders literally. The card escaper now swaps `<`/`>` for lookalike angle quotes (`‹›`) and leaves `&`/`"` raw — injection-proof and faithful for every real title.

838 tests pass, typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tq51J7UKsMUA3KZi8JRimC