### PR TITLE
Cloudflare Web Analytics: deploy-time beacon injection via CF_ANALYTICS_TOKEN

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,6 +71,10 @@ jobs:
           # (those are the CloudFront origins). Unset → stays on *.workers.dev (self-host default).
           CF_APP_URL: ${{ vars.CF_APP_URL }}
           CF_CONTENT_URL: ${{ vars.CF_CONTENT_URL }}
+          # Optional Cloudflare Web Analytics beacon token (dash.cloudflare.com → Web Analytics).
+          # Public-by-design (it ships in the served HTML), but kept out of the committed template
+          # so forks don't send RUM to someone else's analytics. Unset → no beacon injected.
+          CF_ANALYTICS_TOKEN: ${{ vars.CF_ANALYTICS_TOKEN }}
         run: |
           : "${CF_ACCOUNT_ID:?set repo Actions variable CF_ACCOUNT_ID}"
           : "${CF_D1_DATABASE_ID:?set repo Actions variable CF_D1_DATABASE_ID}"
@@ -109,6 +113,14 @@ jobs:
                 -e "s#https://glance.${CF_WORKERS_SUBDOMAIN}.workers.dev#${CF_APP_URL}#g" \
                 "$f"
             done
+          fi
+          # Inject the Cloudflare Web Analytics beacon into the SPA shell, if configured. Runs
+          # BEFORE build:web (vite passes the tag through). The committed index.html stays clean —
+          # dev and beaconless self-hosts never load it. _headers already allowlists the beacon
+          # hosts (script-src static.cloudflareinsights.com, connect-src cloudflareinsights.com).
+          if [ -n "${CF_ANALYTICS_TOKEN}" ]; then
+            sed -i "s#</head>#  <script type='module' src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{\"token\": \"${CF_ANALYTICS_TOKEN}\"}'></script>\n  </head>#" packages/web/index.html
+            grep -q cloudflareinsights packages/web/index.html || { echo "beacon injection failed" >&2; exit 1; }
           fi
 
       - name: Build web

--- a/packages/web/public/_headers
+++ b/packages/web/public/_headers
@@ -3,4 +3,4 @@
   X-Content-Type-Options: nosniff
   X-Frame-Options: DENY
   Referrer-Policy: strict-origin-when-cross-origin
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'sha256-GHA4sP6dQXpE9w+vcP6hL8UmlMqDJF0nmaRuONkKD8U='; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data:; media-src 'self' blob: https://glance-content.YOUR-SUBDOMAIN.workers.dev; font-src 'self' https://fonts.gstatic.com; connect-src 'self'; frame-src 'self' https://glance-content.YOUR-SUBDOMAIN.workers.dev; object-src 'none'; base-uri 'self'; form-action 'self'
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'sha256-GHA4sP6dQXpE9w+vcP6hL8UmlMqDJF0nmaRuONkKD8U=' https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data:; media-src 'self' blob: https://glance-content.YOUR-SUBDOMAIN.workers.dev; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://cloudflareinsights.com; frame-src 'self' https://glance-content.YOUR-SUBDOMAIN.workers.dev; object-src 'none'; base-uri 'self'; form-action 'self'


### PR DESCRIPTION
Adds Cloudflare Web Analytics to the SPA without putting the token in the public template.

- **deploy.yml**: when the optional `CF_ANALYTICS_TOKEN` Actions variable is set (it is, for this instance), the beacon `<script>` is sed-injected into `packages/web/index.html` before `build:web`, with a fail-loud grep. Unset → no beacon: the committed `index.html` stays clean, so dev, forks, and beaconless self-hosts never load it (same idiom as the other `CF_*` substitutions). The token is public-by-design (it ships in served HTML) — keeping it out of the repo is about forks not sending RUM to someone else's analytics, not secrecy.
- **`public/_headers` CSP**: `script-src` += `https://static.cloudflareinsights.com`, `connect-src` += `https://cloudflareinsights.com` (the beacon's RUM POST). Inert when no beacon is injected. (`_headers` is skip-worktree — this edits the committed placeholder copy; the local real copy got the same CSP edit.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tq51J7UKsMUA3KZi8JRimC