### PR TITLE
perf: fuse serial D1 round trips on hot paths + denormalize R2 etag

### DIFF
--- a/packages/api/drizzle/0019_files_etag.sql
+++ b/packages/api/drizzle/0019_files_etag.sql
@@ -1,0 +1,6 @@
+-- R2's httpEtag, denormalized onto the file row at upload. Storage keys are immutable (a replace
+-- mints new keys), so the etag is fixed for the row's life — the content worker can answer
+-- If-None-Match 304s and Range 416s straight from the access batch with ZERO R2 ops. Plain
+-- ADD COLUMN (nullable, no table rebuild); existing rows stay NULL and keep the head() probe
+-- fallback until their next deploy.
+ALTER TABLE `files` ADD COLUMN `etag` text;

--- a/packages/api/drizzle/meta/_journal.json
+++ b/packages/api/drizzle/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1784400000000,
       "tag": "0018_site_description",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "6",
+      "when": 1784500000000,
+      "tag": "0019_files_etag",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/src/content-access.test.ts
+++ b/packages/api/src/content-access.test.ts
@@ -12,6 +12,10 @@ import { seedFile, seedGroupShare, seedMember, seedSite, seedSpace, seedUser, se
 // statements (site, user, membership, direct share, group share) + 1 fused file-row statement.
 // A legitimate future arity change is a one-line edit HERE.
 const SERVE_BATCH_ARITY = 6
+// An index-ish request (`…/` or an explicit index.html) carries ONE more fused statement: the
+// all-files select feeding the single-file/dir-listing fallback — bounded by the 200-file upload
+// cap, and what keeps a single-file site's every page view from paying a serial follow-up trip.
+const INDEX_BATCH_ARITY = SERVE_BATCH_ARITY + 1
 
 // Cache-less wiring: these specs pin today's uncached op shape (getCache resolves null).
 const setup = () => setupFixture({ withCaches: false })
@@ -263,12 +267,12 @@ describe('T1.4 live transitions on the same token', () => {
 })
 
 // ---------------------------------------------------------------------------------------------
-// T1.2 [guard] the dir-listing fallback stays OUT of the batch: with an index.html present the
-// batch alone resolves everything; only an index MISS takes one extra loose select (and still
-// renders today's listing).
+// T1.2 the single-file/dir-listing fallback rides the batch on index-ish requests: no serial
+// follow-up select ever — a single-file site's page view and the listing are one round trip.
+// Non-index assets (css/js/img — the traffic bulk) keep the lean SERVE_BATCH_ARITY batch.
 // ---------------------------------------------------------------------------------------------
-describe('T1.2 dir-listing fallback stays out of the batch', () => {
-  test('index.html EXISTS: exact batch arity, no all-files statement anywhere', async () => {
+describe('T1.2 dir-listing fallback rides the index-ish batch', () => {
+  test('index.html EXISTS: fallback statement fused, zero loose selects', async () => {
     const s = setup()
     const { token: t } = await teamSite(s, [
       { path: 'index.html', text: '<p>home</p>' },
@@ -278,13 +282,13 @@ describe('T1.2 dir-listing fallback stays out of the batch', () => {
     expect(res.status).toBe(200)
     expect(await res.text()).toBe('<p>home</p>')
     expect(s.db.counters.batches).toBe(1)
-    expect(s.db.counters.batchStmts).toBe(SERVE_BATCH_ARITY)
+    expect(s.db.counters.batchStmts).toBe(INDEX_BATCH_ARITY)
     // index.html is a page load → exactly ONE loose statement, and it's the view-event insert.
     expect(s.db.counters.loose).toBe(1)
     expect(s.db.counters.insert).toBe(1)
   })
 
-  test('no index.html: ONE extra loose select after the batch, listing still renders', async () => {
+  test('no index.html: listing renders from the SAME batch — no loose select at all', async () => {
     const s = setup()
     const { token: t } = await teamSite(s, [
       { path: 'a.html', text: '<p>a</p>' },
@@ -296,8 +300,8 @@ describe('T1.2 dir-listing fallback stays out of the batch', () => {
     expect(body).toContain('a.html')
     expect(body).toContain('b.html')
     expect(s.db.counters.batches).toBe(1)
-    expect(s.db.counters.batchStmts).toBe(SERVE_BATCH_ARITY)
-    expect(s.db.counters.loose).toBe(1) // the all-files fallback select — nothing else
+    expect(s.db.counters.batchStmts).toBe(INDEX_BATCH_ARITY)
+    expect(s.db.counters.loose).toBe(0)
     expect(s.db.counters.insert).toBe(0) // a listing is not a page view
   })
 })
@@ -411,19 +415,20 @@ describe('T1.7 fault injection and branch parity', () => {
       { path: 'doc.md', text: '# Title', mimeType: 'text/markdown' },
     ])
     const hits = [
-      { url: `/_t/${t}/sp/site/doc.md?raw=1`, contains: '# Title' },
-      { url: `/_t/${t}/sp/site/index.html?glance_annotate=1`, contains: 'window.__GLANCE__' },
-      { url: `/_t/${t}/sp/site/doc.md`, contains: '<h1>Title</h1>' },
+      { url: `/_t/${t}/sp/site/doc.md?raw=1`, contains: '# Title', arity: SERVE_BATCH_ARITY },
+      { url: `/_t/${t}/sp/site/index.html?glance_annotate=1`, contains: 'window.__GLANCE__', arity: INDEX_BATCH_ARITY },
+      { url: `/_t/${t}/sp/site/doc.md`, contains: '<h1>Title</h1>', arity: SERVE_BATCH_ARITY },
     ]
     for (const hit of hits) {
       s.db.resetCounters()
       const res = await s.app.request(hit.url, {}, s.env)
       expect(res.status).toBe(200)
       expect(await res.text()).toContain(hit.contains)
-      // Identical read shape on every branch: ONE batch at the exact arity, and every loose
-      // statement (if any) is the view-event insert — never a re-query.
+      // Identical read shape on every branch: ONE batch at the exact arity (index-ish requests
+      // carry the fused fallback statement), and every loose statement (if any) is the
+      // view-event insert — never a re-query.
       expect(s.db.counters.batches).toBe(1)
-      expect(s.db.counters.batchStmts).toBe(SERVE_BATCH_ARITY)
+      expect(s.db.counters.batchStmts).toBe(hit.arity)
       expect(s.db.counters.loose).toBe(s.db.counters.insert)
     }
   })

--- a/packages/api/src/content-storage.test.ts
+++ b/packages/api/src/content-storage.test.ts
@@ -33,7 +33,7 @@ async function opsOf(s: Setup, request: () => Promise<unknown>): Promise<Ops> {
 // Exact op shapes, named once and reused (tight `toEqual` — every counter pinned).
 const NO_OPS: Ops = { full: 0, ranged: 0, head: 0, matches: 0, puts: 0, hits: 0, misses: 0 }
 const ONE_RANGED: Ops = { ...NO_OPS, ranged: 1 } // satisfiable Range, size known: ONE ranged get, cache untouched
-const HEAD_ONLY: Ops = { ...NO_OPS, head: 1 } // etag resolved by a head probe, zero body bytes
+const HEAD_ONLY: Ops = { ...NO_OPS, head: 1 } // etag resolved by a head probe (legacy NULL-etag rows only)
 const COLD_FULL: Ops = { ...NO_OPS, full: 1, matches: 1, misses: 1, puts: 1 } // cache miss → one full get + warm
 const WARM_HIT: Ops = { ...NO_OPS, matches: 1, hits: 1 } // served from cache, zero R2
 const RAW_FULL: Ops = { ...NO_OPS, full: 1 } // raw=1: direct full get, cache never touched
@@ -136,7 +136,7 @@ describe('T2.2 unsatisfiable ranges: 416 + etag via head probe', () => {
     expect(res.headers.get('content-range')).toBe(`bytes */${BODY.length}`)
     expect(res.headers.get('etag')).toBe(etagOf(s, keys[0]))
     expect(await res.text()).toBe('')
-    expect(diff(before, ops(s))).toEqual(HEAD_ONLY)
+    expect(diff(before, ops(s))).toEqual(NO_OPS)
   })
 
   test('zero-byte object (size 0 in D1, empty R2 object): any Range → 416, never falsy-skipped', async () => {
@@ -147,7 +147,7 @@ describe('T2.2 unsatisfiable ranges: 416 + etag via head probe', () => {
     expect(res.status).toBe(416)
     expect(res.headers.get('content-range')).toBe('bytes */0')
     expect(res.headers.get('etag')).toBe(etagOf(s, keys[0]))
-    expect(diff(before, ops(s))).toEqual(HEAD_ONLY)
+    expect(diff(before, ops(s))).toEqual(NO_OPS)
   })
 })
 
@@ -196,7 +196,7 @@ describe('T2.3 null-size D1 row: full-get fallback', () => {
 describe('T2.4 conditional requests', () => {
   const mp3: FileSpec = { path: 'song.mp3', text: BODY, mimeType: 'application/octet-stream' }
 
-  test('If-None-Match match beats Range: 304, zero full/ranged/cache reads (one head allowed)', async () => {
+  test('If-None-Match match beats Range: 304 with ZERO R2 ops (etag answered from D1)', async () => {
     const s = setup()
     const { token, keys } = await teamSite(s, [mp3])
     const before = ops(s)
@@ -204,7 +204,7 @@ describe('T2.4 conditional requests', () => {
     expect(res.status).toBe(304)
     expect(res.headers.get('etag')).toBe(etagOf(s, keys[0]))
     expect(await res.text()).toBe('')
-    expect(diff(before, ops(s))).toEqual(HEAD_ONLY)
+    expect(diff(before, ops(s))).toEqual(NO_OPS)
   })
 
   test('stale If-Range → full 200 body, no slice headers (ops: the ranged probe + the full get)', async () => {
@@ -329,11 +329,11 @@ describe('T3.2 warm cache + Range/conditional: cache bypassed, never re-warmed',
 
     const before304 = ops(s)
     expect((await get(s, token, 'song.mp3', { 'if-none-match': etagOf(s, keys[0]) })).status).toBe(304)
-    expect(diff(before304, ops(s))).toEqual(HEAD_ONLY) // no put on a 304
+    expect(diff(before304, ops(s))).toEqual(NO_OPS) // etag from D1 — no probe, no put
 
     const before416 = ops(s)
     expect((await get(s, token, 'song.mp3', { range: 'bytes=99-' })).status).toBe(416)
-    expect(diff(before416, ops(s))).toEqual(HEAD_ONLY) // no put on a 416
+    expect(diff(before416, ops(s))).toEqual(NO_OPS) // etag from D1 — no probe, no put
   })
 })
 
@@ -538,5 +538,22 @@ describe('T3.6 per-transform byte identity (cold R2 vs warm cache)', () => {
     expect(await (await get(s, token, 'doc.md?raw=1')).text()).toBe('# Title')
     expect(diff(warmBefore, ops(s))).toEqual(RAW_FULL) // STILL bypasses the warm entry
     expect(await viewCount(s)).toBe(1) // only the render counted
+  })
+})
+
+// ---------------------------------------------------------------------------------------------
+// T2.6 legacy rows with etag NULL in D1 (pre-denormalization uploads): the 304 still works via
+// the old head() probe — exactly one head, zero body bytes.
+// ---------------------------------------------------------------------------------------------
+describe('T2.6 null-etag D1 row: head-probe fallback', () => {
+  test('legacy row: If-None-Match match → 304 via ONE head probe', async () => {
+    const s = setup()
+    const { token, keys } = await teamSite(s, [{ path: 'song.mp3', text: BODY, mimeType: 'application/octet-stream' }])
+    await s.db.update(files).set({ etag: null }).where(eq(files.storageKey, keys[0]))
+    const before = ops(s)
+    const res = await get(s, token, 'song.mp3', { 'if-none-match': etagOf(s, keys[0]) })
+    expect(res.status).toBe(304)
+    expect(res.headers.get('etag')).toBe(etagOf(s, keys[0]))
+    expect(diff(before, ops(s))).toEqual(HEAD_ONLY)
   })
 })

--- a/packages/api/src/content.ts
+++ b/packages/api/src/content.ts
@@ -130,8 +130,21 @@ async function serve(c: Ctx, spaceSlug: string, siteSlug: string, rest: string, 
     .innerJoin(spaces, eq(sites.spaceId, spaces.id))
     .where(and(eq(spaces.slug, spaceSlug), eq(sites.slug, siteSlug), eq(files.path, reqPath)))
     .limit(1)
-  const { facts, extras } = await fetchAccessFacts(db, spaceSlug, siteSlug, userId, fileStmt)
-  const [fileRows] = extras
+  // Index-ish request (`…/` or explicit index.html): the single-file/dir-listing fallback's
+  // all-files read rides the SAME batch — a single-file site's every page view otherwise pays a
+  // serial follow-up round trip. Bounded by the 200-file upload cap; non-index assets (css/js/
+  // img — the traffic bulk) keep the lean batch.
+  const isIndexReq = reqPath === 'index.html' || reqPath.endsWith('/index.html')
+  const allFilesStmt = db
+    .select(cols)
+    .from(files)
+    .innerJoin(sites, eq(files.siteId, sites.id))
+    .innerJoin(spaces, eq(sites.spaceId, spaces.id))
+    .where(and(eq(spaces.slug, spaceSlug), eq(sites.slug, siteSlug)))
+  const { facts, extras } = isIndexReq
+    ? await fetchAccessFacts(db, spaceSlug, siteSlug, userId, fileStmt, allFilesStmt)
+    : await fetchAccessFacts(db, spaceSlug, siteSlug, userId, fileStmt)
+  const [fileRows, allFileRows] = extras as [(typeof extras)[0], (typeof extras)[0]?]
 
   const siteRow = facts.site
   if (!siteRow) return notFound(c)
@@ -158,9 +171,9 @@ async function serve(c: Ctx, spaceSlug: string, siteSlug: string, rest: string, 
   // leaves an author who dropped a folder without a root index.html staring at a blank frame
   // with no clue what's wrong — fall back to either the single uploaded file or a navigable
   // listing of what IS in the site, so they can see the contents and click straight in.
-  if (!file && (reqPath === 'index.html' || reqPath.endsWith('/index.html'))) {
+  if (!file && isIndexReq) {
     const dir = reqPath.slice(0, -'index.html'.length) // '' at the root, else `docs/`
-    const all = await db.select(cols).from(files).where(eq(files.siteId, siteRow.id))
+    const all = allFileRows ?? [] // fused into the access batch above — never a follow-up trip
     // Single-file site: serve the lone uploaded file at the root (e.g. a dropped `report.html`).
     if (dir === '' && all.length === 1) {
       file = all[0]

--- a/packages/api/src/content.ts
+++ b/packages/api/src/content.ts
@@ -118,7 +118,7 @@ app.get('/:space/:site/*', (c) => serve(c, c.req.param('space'), c.req.param('si
 async function serve(c: Ctx, spaceSlug: string, siteSlug: string, rest: string, userId: string | null): Promise<Response> {
   const db = getDb(c)
   const reqPath = normalizePath(rest)
-  const cols = { path: files.path, storageKey: files.storageKey, mimeType: files.mimeType, size: files.size }
+  const cols = { path: files.path, storageKey: files.storageKey, mimeType: files.mimeType, size: files.size, etag: files.etag }
   // ONE D1 round trip: the slug-keyed access facts (site / user / membership / shares) plus the
   // file row, fused into a single batch. The file statement joins by BOTH slugs too (the site id
   // is unknown before the batch runs), and every statement returns empty rows rather than
@@ -277,10 +277,10 @@ async function serve(c: Ctx, spaceSlug: string, siteSlug: string, rest: string, 
   // everything else (audio today; any other binary falls out the same door for free).
   const rangeable = !isHtml
   if (rangeable) headers.set('accept-ranges', 'bytes')
-  return serveStoredObject(c, { storageKey, size, headers, rangeable, isHtml, mime, view, selfOrigin })
+  return serveStoredObject(c, { storageKey, size, etag: file.etag, headers, rangeable, isHtml, mime, view, selfOrigin })
 }
 
-/** The storage tail of serve(): conditional (If-None-Match) probe, both Range flows (sized
+/** The storage tail of serve(): conditional (If-None-Match) handling, both Range flows (sized
  *  single-ranged-get and the legacy null-size full-get-first fallback), and the cache-fronted
  *  full-200 read — plus the HTML-only view() record and external-link rewrite. `headers`
  *  arrives pre-built (type/CSP/cache-control/accept-ranges); etag and range headers are
@@ -290,6 +290,7 @@ async function serveStoredObject(
   args: {
     storageKey: string
     size: number | null
+    etag: string | null
     headers: Headers
     rangeable: boolean
     isHtml: boolean
@@ -298,20 +299,25 @@ async function serveStoredObject(
     selfOrigin: string
   },
 ): Promise<Response> {
-  const { storageKey, size, headers, rangeable, isHtml, mime, view, selfOrigin } = args
+  const { storageKey, size, etag: rowEtag, headers, rangeable, isHtml, mime, view, selfOrigin } = args
 
   // Honor the conditional request: when the viewer already holds this exact ETag, answer 304 and
   // skip re-streaming the body. This MUST win over Range (RFC 7233 §3.1), so it runs before any
-  // Range handling — and the current etag is resolved with a head() probe, so a revalidation hit
-  // moves ZERO body bytes (no full get, no ranged get, no cache read).
+  // Range handling. The current etag comes from D1 (denormalized at upload — storage keys are
+  // immutable, so the row's etag is the object's for life): a revalidation hit costs ZERO R2 ops.
+  // Legacy pre-denormalization rows (etag NULL) fall back to the old head() probe.
   const inm = c.req.header('if-none-match')
   let probedEtag: string | undefined
   if (inm !== undefined) {
-    const probe = await c.env.GLANCE_FILES.head(storageKey)
-    if (!probe) return notFound(c)
-    probedEtag = probe.httpEtag
-    if (inm === probe.httpEtag) {
-      headers.set('etag', probe.httpEtag)
+    let current = rowEtag
+    if (current === null) {
+      const probe = await c.env.GLANCE_FILES.head(storageKey)
+      if (!probe) return notFound(c)
+      probedEtag = probe.httpEtag
+      current = probe.httpEtag
+    }
+    if (inm === current) {
+      headers.set('etag', current)
       if (isHtml) await view() // parity with the 200 path: an HTML revalidation is still a page load
       return new Response(null, { status: 304, headers })
     }
@@ -338,9 +344,9 @@ async function serveStoredObject(
     const ifRange = c.req.header('if-range')
     const decision = decideRange(rangeHeader, size, headers)
     if (decision.status === 416) {
-      // The 416 must still carry the current etag → ONE head() probe, zero body bytes (reuse
-      // the If-None-Match probe's etag when that branch already paid for it).
-      const etag = probedEtag ?? (await c.env.GLANCE_FILES.head(storageKey))?.httpEtag
+      // The 416 must still carry the current etag — from D1 when denormalized, else ONE head()
+      // probe, zero body bytes (reuse the If-None-Match probe's etag when it already paid).
+      const etag = rowEtag ?? probedEtag ?? (await c.env.GLANCE_FILES.head(storageKey))?.httpEtag
       if (etag === undefined) return notFound(c)
       // A STALE If-Range means the Range no longer applies at all (RFC 7233 §3.2) → full 200.
       if (ifRange !== undefined && ifRange !== etag) return serveFullDirect()

--- a/packages/api/src/db/notifications.test.ts
+++ b/packages/api/src/db/notifications.test.ts
@@ -74,6 +74,17 @@ describe('C2 — unreadCount counts only readAt IS NULL', () => {
     expect(items.length).toBe(3)
     expect(unreadCount).toBe(2)
   })
+
+  test('unreadCount is the FULL unread count even when limit truncates items', async () => {
+    const db = makeDb()
+    const me = await seedUser(db)
+    await seedNotification(db, { recipientId: me, readAt: null })
+    await seedNotification(db, { recipientId: me, readAt: null })
+    await seedNotification(db, { recipientId: me, readAt: null })
+    const { items, unreadCount } = await listNotifications(db, me, 1)
+    expect(items.length).toBe(1)
+    expect(unreadCount).toBe(3)
+  })
 })
 
 describe('C3 — markRead clears all (default) or one (by id)', () => {

--- a/packages/api/src/db/notifications.ts
+++ b/packages/api/src/db/notifications.ts
@@ -193,12 +193,12 @@ export async function listNotifications(
   userId: string,
   limit = 30,
 ): Promise<{ items: NotificationView[]; unreadCount: number }> {
-  const rows = await db
+  const rowsStmt = db
     .select({
       id: notifications.id,
       type: notifications.type,
       actorId: notifications.actorId,
-      actorName: sql<string | null>`coalesce(${users.name}, ${users.email})`,
+      actorName: sql<string | null>`coalesce(${users.name}, ${users.email})`.as('actorName'),
       siteLabel: notifications.siteLabel,
       filePath: notifications.filePath,
       threadId: notifications.threadId,
@@ -213,10 +213,13 @@ export async function listNotifications(
     .orderBy(desc(notifications.createdAt), sql`notifications.rowid desc`)
     .limit(limit)
 
-  const [{ c }] = await db
-    .select({ c: sql<number>`count(*)` })
+  const countStmt = db
+    .select({ c: sql<number>`count(*)`.as('c') })
     .from(notifications)
     .where(and(eq(notifications.recipientId, userId), isNull(notifications.readAt)))
+
+  // The bell poll is the app's most frequent endpoint — both reads ride one D1 round trip.
+  const [rows, [{ c }]] = await batchAll(db, [rowsStmt, countStmt])
 
   const items: NotificationView[] = rows.map((r) => ({
     id: r.id,

--- a/packages/api/src/db/schema.ts
+++ b/packages/api/src/db/schema.ts
@@ -79,6 +79,10 @@ export const files = sqliteTable(
     storageKey: text('storageKey').notNull().unique(),
     mimeType: text('mimeType'),
     size: integer('size'),
+    // R2's httpEtag, denormalized at upload (storage keys are immutable — a replace mints new
+    // keys — so the etag is fixed for the row's life). Lets the content worker answer 304/416
+    // conditionals with zero R2 ops; NULL on pre-denormalization rows → head() probe fallback.
+    etag: text('etag'),
     // RESERVED / currently unused. Was intended to hold a normalized-text digest (lib/anchor
     // `normalizeText`) of the file body to power a "hash unchanged → skip re-anchor" gate, but
     // nothing writes or reads it today (anchors are painted client-side, not reconciled server-

--- a/packages/api/src/lib/storage.ts
+++ b/packages/api/src/lib/storage.ts
@@ -61,9 +61,12 @@ export async function copyObjects(
   bucket: R2Bucket,
   rows: CopyableFile[],
   prefix: string,
-): Promise<CopyableFile[]> {
+): Promise<(CopyableFile & { etag: string | null })[]> {
   const plan = rows.map((r) => ({ from: r.storageKey, to: `${prefix}/${r.path}`, row: r }))
   const written: string[] = []
+  // The COPY's own httpEtag per destination key (never the source's — etags are per-object), so
+  // the inserted rows serve 304/416 conditionals without the legacy head() fallback.
+  const etags = new Map<string, string | null>()
   try {
     for (let i = 0; i < plan.length; i += COPY_CONCURRENCY) {
       await Promise.all(
@@ -71,9 +74,10 @@ export async function copyObjects(
           const object = await bucket.get(from)
           if (!object) throw new Error(`source object missing: ${from}`)
           written.push(to)
-          await bucket.put(to, object.body, {
+          const put = await bucket.put(to, object.body, {
             httpMetadata: { contentType: row.mimeType ?? 'application/octet-stream' },
           })
+          etags.set(to, put?.httpEtag ?? null)
         }),
       )
     }
@@ -81,7 +85,13 @@ export async function copyObjects(
     await deleteKeys(bucket, written)
     throw err
   }
-  return plan.map(({ to, row }) => ({ path: row.path, storageKey: to, mimeType: row.mimeType, size: row.size }))
+  return plan.map(({ to, row }) => ({
+    path: row.path,
+    storageKey: to,
+    mimeType: row.mimeType,
+    size: row.size,
+    etag: etags.get(to) ?? null,
+  }))
 }
 
 /** Delete all R2 objects recorded for a site: the site's uploaded files AND its voice-comment

--- a/packages/api/src/routes/data.test.ts
+++ b/packages/api/src/routes/data.test.ts
@@ -5,7 +5,8 @@ import { Hono } from 'hono'
 import { documents, sites } from '../db/schema'
 import { signDataToken } from '../lib/data-token'
 import { makeDb, seedMember, seedSite, seedSpace, seedUser } from '../test/harness'
-import { MAX_DOCS_PER_SITE, dataApi, dataCapsFor } from './data'
+import { auth, makeRouteApp, mintUser } from '../test/route-fixtures'
+import { MAX_DOCS_PER_SITE, dataApi, dataCapsFor, dataToken } from './data'
 
 const HMAC_A = 'glance-test-aaa'
 // getDb() prefers the injected harness db, so GLANCE_DB is never touched; CONTENT_URL drives CORS.
@@ -371,5 +372,55 @@ describe('auth + validation + inert-when-unconfigured', () => {
       { CONTENT_URL: 'https://content.example.com' } as never,
     )
     expect(res.status).toBe(404)
+  })
+})
+
+describe('mint route — POST /api/data-token/:space/:site', () => {
+  // The mint gate mounted the way index.ts wires it: db injection + the router's own requireAuth
+  // (Bearer path through GLANCE_SESSIONS). makeRouteApp doesn't carry dataToken, so mount locally.
+  async function mintScenario() {
+    const { db, kv } = makeRouteApp()
+    const app = new Hono<{ Variables: { db: DrizzleD1Database } }>()
+    app.use('*', async (c, next) => {
+      c.set('db', db)
+      await next()
+    })
+    app.route('/api/data-token', dataToken)
+    const env = { DATA_TOKEN_SECRET: HMAC_A, GLANCE_SESSIONS: kv } as never
+    await mintUser(db, kv, 'owner')
+    await mintUser(db, kv, 'peer')
+    const sp = await seedSpace(db, { id: 'sp-m', slug: 'acme', createdBy: 'owner' })
+    await seedMember(db, sp, 'owner')
+    await seedMember(db, sp, 'peer')
+    await seedSite(db, { id: 'site-m', spaceId: sp, ownerId: 'owner', slug: 'doc', visibility: 'team' })
+    const mint = (as: string, space = 'acme', site = 'doc') =>
+      app.request(`/api/data-token/${space}/${site}`, { method: 'POST', headers: auth(as) }, env)
+    return { db, app, env, mint }
+  }
+
+  test('owner mints write caps; a plain viewer mints read+create only', async () => {
+    const { mint } = await mintScenario()
+    const ownerRes = await mint('owner')
+    expect(ownerRes.status).toBe(200)
+    expect((await ownerRes.json()).caps).toEqual(['read', 'create', 'write', 'read_all'])
+    const peerRes = await mint('peer')
+    expect(peerRes.status).toBe(200)
+    expect((await peerRes.json()).caps).toEqual(['read', 'create'])
+  })
+
+  test('missing site → 404; private site non-owner → 403 (fails closed)', async () => {
+    const { db, mint } = await mintScenario()
+    expect((await mint('owner', 'acme', 'nope')).status).toBe(404)
+    await db.update(sites).set({ visibility: 'private' }).where(eq(sites.id, 'site-m'))
+    expect((await mint('peer')).status).toBe(403)
+    expect((await mint('owner')).status).toBe(200)
+  })
+
+  test('request shape: exactly requireAuth’s 1 loose read + ONE fused access batch', async () => {
+    const { db, mint } = await mintScenario()
+    db.resetCounters()
+    expect((await mint('peer')).status).toBe(200)
+    expect(db.counters.loose).toBe(1) // requireAuth's user read — nothing else loose
+    expect(db.counters.batches).toBe(1) // the access-facts batch
   })
 })

--- a/packages/api/src/routes/data.ts
+++ b/packages/api/src/routes/data.ts
@@ -3,7 +3,7 @@ import { type DrizzleD1Database, drizzle } from 'drizzle-orm/d1'
 import { type Context, Hono } from 'hono'
 import { type DocumentRow, type Site, documents, sites } from '../db/schema'
 import { type DataCapability, type DataClaims, hasCap, signDataToken, verifyDataToken } from '../lib/data-token'
-import { authorizeViewerById, resolveSiteForAccess } from '../lib/site-access'
+import { authorizeViewerById, fetchAccessFacts, siteAccessFromFacts } from '../lib/site-access'
 import { requireAuth } from '../middleware/auth'
 import type { AppEnv, Bindings, SessionUser } from '../types'
 
@@ -348,7 +348,8 @@ dataToken.post('/:space/:site', async (c) => {
   const db = c.get('db')
   const user = c.get('user')
   const { space, site: siteSlug } = c.req.param()
-  const { site, access } = await resolveSiteForAccess(db, space, siteSlug, user)
+  const { facts } = await fetchAccessFacts(db, space, siteSlug, user.id)
+  const { site, access } = siteAccessFromFacts(facts, user)
   if (!site) return c.json({ error: 'not found' }, 404)
   if (!access.ok) return c.json({ error: 'forbidden' }, access.status)
 

--- a/packages/api/src/routes/sites-fork.test.ts
+++ b/packages/api/src/routes/sites-fork.test.ts
@@ -87,6 +87,12 @@ describe('POST /api/sites/:space/:site/fork', () => {
     const idx = dst.find((f) => f.path === 'index.html')
     expect(await (await r2.get(idx?.storageKey ?? ''))?.text()).toBe('<h1>hi</h1>')
     expect(dst.find((f) => f.path === 'index.html')?.mimeType).toBe('text/html')
+
+    // Forked rows carry the COPY's denormalized etag (not the source's, not NULL) — without it
+    // every conditional request on a forked site pays the legacy head() probe forever.
+    for (const f of dst) {
+      expect(f.etag).toBe((await r2.head(f.storageKey))?.httpEtag ?? '(missing)')
+    }
   })
 
   test('fork.deleting.source.keeps.copy: purging the source never touches the fork’s objects', async () => {

--- a/packages/api/src/routes/sites-search.test.ts
+++ b/packages/api/src/routes/sites-search.test.ts
@@ -155,3 +155,20 @@ describe('searchSites (cmdk site search)', () => {
     expect(ids(await searchSites(db, member(me), 'needle')).size).toBe(1)
   })
 })
+
+// Request-shape pin (perf): the two reach-set reads (member spaces + shared sites) must ride ONE
+// db.batch — a per-keystroke endpoint gets no loose serial round trips. Candidates are batch #2.
+describe('searchSites request shape', () => {
+  test('reach sets + candidates are two batches, zero loose statements', async () => {
+    const db = makeDb()
+    const me = await seedUser(db, { id: 'me' })
+    const owner = await seedUser(db)
+    const sp = await seedSpace(db, { createdBy: owner })
+    await seedMember(db, sp, me)
+    await seedSite(db, { spaceId: sp, ownerId: owner, slug: 'group-plan', visibility: 'members' })
+    db.resetCounters()
+    expect(ids(await searchSites(db, member(me), 'group-plan')).size).toBe(1)
+    expect(db.counters.loose).toBe(0)
+    expect(db.counters.batches).toBe(2)
+  })
+})

--- a/packages/api/src/routes/sites-viewer.test.ts
+++ b/packages/api/src/routes/sites-viewer.test.ts
@@ -216,10 +216,11 @@ describe('GET /api/sites/:space/:site — share-reach role resolution (S7 pins)'
 
     const res = await view(app, env, 'docs', 'report', { Authorization: 'Bearer tok-dv' })
     expect(res.status).toBe(200)
-    expect(db.counters.batches).toBe(1) // resolveShareAccess — the only share scan
-    // Loose/batch attribution races under Promise.all in the sequential harness shim, so pin the
-    // TOTAL: site resolve + membership + files + (direct-role + group-reach) = 5, down from 6.
-    expect(db.counters.loose + db.counters.batchStmts).toBe(5)
+    // FCP hotpath: the WHOLE metadata read is one fused batch (access facts + file manifest) —
+    // zero loose D1 statements. Stmts: site + user + membership + direct-role + group-reach + files.
+    expect(db.counters.batches).toBe(1)
+    expect(db.counters.loose).toBe(0)
+    expect(db.counters.batchStmts).toBe(6)
   })
 
   test('meta.superadmin: 200 with canReplace:true, manifest present, NO role field (no direct share)', async () => {

--- a/packages/api/src/routes/sites-viewer.test.ts
+++ b/packages/api/src/routes/sites-viewer.test.ts
@@ -40,6 +40,21 @@ describe('GET /api/sites/:space/:site (viewer metadata)', () => {
     expect(body.contentUrl.endsWith('/docs/report/')).toBe(true)
   })
 
+  test('no auth → 401, and the batch reads ONLY the site row (no manifest scan for anonymous probes)', async () => {
+    const { db, kv, app, env } = await setup()
+    await mintUser(db, kv, 'owner')
+    const sp = await seedSpace(db, { createdBy: 'owner', slug: 'docs' })
+    const site = await seedSite(db, { spaceId: sp, ownerId: 'owner', slug: 'report', visibility: 'team' })
+    for (let i = 0; i < 3; i++) await seedFile(db, null, site, { path: `f${i}.html` })
+    db.resetCounters()
+    const res = await view(app, env, 'docs', 'report')
+    expect(res.status).toBe(401)
+    // Unauthenticated: site statement only — an anonymous prober must not burn manifest row reads.
+    expect(db.counters.loose).toBe(0)
+    expect(db.counters.batches).toBe(1)
+    expect(db.counters.batchStmts).toBe(1)
+  })
+
   test('no auth → 401 (every tier requires a viewer)', async () => {
     const { db, app, env } = await setup()
     await seedUser(db, { id: 'u1' })

--- a/packages/api/src/routes/sites.ts
+++ b/packages/api/src/routes/sites.ts
@@ -3,13 +3,15 @@ import type { DrizzleD1Database } from 'drizzle-orm/d1'
 import { Hono } from 'hono'
 import {
   type ShareUser,
+  foldMemberSpaceIds,
+  foldSharedSiteRoles,
   isSpaceMember,
   listSiteShares,
-  memberSpaceIds,
+  memberSpaceIdsStmt,
   replaceSiteShares,
   resolveShareAccess,
   resolveShareRole,
-  sharedSiteIds,
+  sharedSiteRoleStmts,
   sharedSiteRoles,
 } from '../db/repo'
 import type { Visibility } from '../db/schema'
@@ -89,8 +91,13 @@ export async function searchSites(
   const qMatch = sql`(lower(${sitesTable.title}) like ${term} escape '\\' or lower(${sitesTable.slug}) like ${term} escape '\\' or lower(${spaces.slug}) like ${term} escape '\\' or lower(${spaces.name}) like ${term} escape '\\')`
 
   const isSuper = user.role === 'superadmin'
-  const memberSpaces = isSuper ? new Set<string>() : await memberSpaceIds(db, user.id)
-  const shared = isSuper ? new Set<string>() : await sharedSiteIds(db, user.id)
+  // Per-keystroke endpoint: both reach-set reads ride ONE db.batch (comment-feed.ts fuses the
+  // same statements the same way).
+  const [memberRows, direct, viaGroup] = isSuper
+    ? [[], [], []]
+    : await batchAll(db, [memberSpaceIdsStmt(db, user.id), ...sharedSiteRoleStmts(db, user.id)])
+  const memberSpaces = foldMemberSpaceIds(memberRows)
+  const shared = new Set(foldSharedSiteRoles(direct, viaGroup).keys())
 
   // Candidate reach as a set of bounded WHERE clauses, unioned in memory: `X AND (A OR B OR C)`
   // ≡ union of `X AND A`, `X AND B`, `X AND C`. Member-space / shared id lists are chunked under
@@ -107,7 +114,9 @@ export async function searchSites(
   const cols = {
     id: sitesTable.id,
     spaceId: sitesTable.spaceId,
-    spaceSlug: spaces.slug,
+    // Aliased: inside db.batch real D1 maps rows by column NAME, and spaces.slug would collide
+    // with sites.slug (both emit "slug").
+    spaceSlug: sql<string>`${spaces.slug}`.as('spaceSlug'),
     siteSlug: sitesTable.slug,
     title: sitesTable.title,
     visibility: sitesTable.visibility,
@@ -115,7 +124,8 @@ export async function searchSites(
     ownerId: sitesTable.ownerId,
     createdAt: sitesTable.createdAt,
   }
-  const batches = await Promise.all(
+  const batches = await batchAll(
+    db,
     reaches.map((reach) =>
       db
         .select(cols)

--- a/packages/api/src/routes/sites.ts
+++ b/packages/api/src/routes/sites.ts
@@ -9,7 +9,6 @@ import {
   listSiteShares,
   memberSpaceIdsStmt,
   replaceSiteShares,
-  resolveShareAccess,
   resolveShareRole,
   sharedSiteRoleStmts,
   sharedSiteRoles,

--- a/packages/api/src/routes/sites.ts
+++ b/packages/api/src/routes/sites.ts
@@ -21,7 +21,7 @@ import { batchAll, chunk, D1_MAX_IN } from '../lib/d1'
 import { resolveIndexPath } from '../lib/extract'
 import { siteFeedColumns, toFeedRow } from '../lib/site-feed'
 import { readSessionOrBearer } from '../lib/session'
-import { resolveSite, resolveSiteForAccess } from '../lib/site-access'
+import { fetchAccessFacts, isSharedFromFacts, resolveSite, resolveSiteForAccess } from '../lib/site-access'
 import { isValidSlug } from '../lib/slug'
 import { copyObjects, deleteKeys, deleteSiteObjects } from '../lib/storage'
 import { signToken } from '../lib/token'
@@ -340,25 +340,27 @@ sites.get('/:spaceSlug/:siteSlug', async (c) => {
   const db = c.get('db')
   const { spaceSlug, siteSlug } = c.req.param()
 
-  // FCP hotpath: the session read is independent of the site lookup, so resolve both concurrently.
-  // Cookie (browser viewer) OR CLI Bearer token (`glance read`) — both mint the same gated URL.
-  const [site, user] = await Promise.all([resolveSite(db, spaceSlug, siteSlug), readSessionOrBearer(c)])
+  // FCP hotpath: KV session first (cheap, and the facts batch is keyed on the user id), then
+  // EVERYTHING D1 — site row, membership, share reach (S7: direct role + group reach; `role`/
+  // canReplace stay bound to the DIRECT role only), and the file manifest — in ONE slug-keyed
+  // db.batch. Cookie (browser viewer) OR CLI Bearer token (`glance read`) — both mint the same
+  // gated URL.
+  const user = await readSessionOrBearer(c)
+  const filesStmt = db
+    .select({ path: filesTable.path })
+    .from(filesTable)
+    .innerJoin(sitesTable, eq(filesTable.siteId, sitesTable.id))
+    .innerJoin(spaces, eq(sitesTable.spaceId, spaces.id))
+    .where(and(eq(spaces.slug, spaceSlug), eq(sitesTable.slug, siteSlug)))
+  const { facts, extras } = await fetchAccessFacts(db, spaceSlug, siteSlug, user?.id ?? null, filesStmt)
+  const site = facts.site
   // Existence (404) is still decided before any auth-dependent branch, so a missing site never
-  // leaks — running the session read early doesn't change the not-found-before-auth ordering.
+  // leaks — the site row rides the same batch.
   if (!site) return c.json({ error: 'not found' }, 404)
 
-  // ONE role-aware share resolve (S7): direct role + group reach in a single batch — checkAccess
-  // consumes the combined reach, while `role`/canReplace stay bound to the DIRECT role only (a
-  // group-only reacher gets viewer-grade access but no role field and no manifest).
-  const [isMember, share, siteFiles] = user
-    ? await Promise.all([
-        isSpaceMember(db, site.spaceId, user.id),
-        resolveShareAccess(db, site.id, user.id),
-        db.select({ path: filesTable.path }).from(filesTable).where(eq(filesTable.siteId, site.id)),
-      ])
-    : [false, { isShared: false, directRole: null } as const, [] as { path: string }[]]
-  const role = share.directRole
-  const access = checkAccess(site, user, isMember, share.isShared)
+  const [siteFiles] = extras
+  const role = facts.directRole
+  const access = checkAccess(site, user, facts.isMember, isSharedFromFacts(facts))
   if (!access.ok) return c.json({ error: 'forbidden' }, access.status)
 
   // Every tier requires an authenticated viewer (checkAccess 401s otherwise), so `user` is

--- a/packages/api/src/routes/sites.ts
+++ b/packages/api/src/routes/sites.ts
@@ -351,13 +351,17 @@ sites.get('/:spaceSlug/:siteSlug', async (c) => {
     .innerJoin(sitesTable, eq(filesTable.siteId, sitesTable.id))
     .innerJoin(spaces, eq(sitesTable.spaceId, spaces.id))
     .where(and(eq(spaces.slug, spaceSlug), eq(sitesTable.slug, siteSlug)))
-  const { facts, extras } = await fetchAccessFacts(db, spaceSlug, siteSlug, user?.id ?? null, filesStmt)
+  // The manifest rides the batch only for an AUTHED caller — an anonymous probe 401s below and
+  // must not burn up-to-200 manifest row reads per request on this cookie-less endpoint.
+  const { facts, extras } = await (user
+    ? fetchAccessFacts(db, spaceSlug, siteSlug, user.id, filesStmt)
+    : fetchAccessFacts(db, spaceSlug, siteSlug, null))
   const site = facts.site
   // Existence (404) is still decided before any auth-dependent branch, so a missing site never
   // leaks — the site row rides the same batch.
   if (!site) return c.json({ error: 'not found' }, 404)
 
-  const [siteFiles] = extras
+  const [siteFiles = []] = extras
   const role = facts.directRole
   const access = checkAccess(site, user, facts.isMember, isSharedFromFacts(facts))
   if (!access.ok) return c.json({ error: 'forbidden' }, access.status)

--- a/packages/api/src/routes/upload-editor.test.ts
+++ b/packages/api/src/routes/upload-editor.test.ts
@@ -141,3 +141,15 @@ describe('upload — editor replace never derives a title', () => {
     expect((await siteRow(db)).title).toBeNull()
   })
 })
+
+// Request-shape pin (perf): the editor-replace pre-write reads (space, site, share role, existing
+// file keys) ride ONE db.batch; loose = requireAuth's user read + the CAS claim update only.
+describe('upload — editor replace request shape', () => {
+  test('editor replace: 2 loose (auth + CAS) + fused read batch + swap batch', async () => {
+    const { app, env, db } = await fx()
+    db.resetCounters()
+    expect((await post(app, env, 'ed', { replace: true, expectedVersion: 0 })).status).toBe(200)
+    expect(db.counters.loose).toBe(2)
+    expect(db.counters.batches).toBe(2)
+  })
+})

--- a/packages/api/src/routes/upload.test.ts
+++ b/packages/api/src/routes/upload.test.ts
@@ -331,3 +331,15 @@ describe('upload — derived title: R2 integrity + COALESCE race', () => {
     expect(row.title).toBe('Manual Name')
   })
 })
+
+// Request-shape pin (perf): every pre-write read (space, existing site, membership) rides ONE
+// db.batch — requireAuth's user read is the only loose statement on a CREATE.
+describe('upload — pre-write request shape', () => {
+  test('CREATE: 1 loose (requireAuth) + fused read batch + write batch', async () => {
+    const { app, env, db } = await setup()
+    db.resetCounters()
+    expect((await postFiles(app, env, 'shape-new', [html('<html>hi</html>', 'index.html')])).status).toBe(200)
+    expect(db.counters.loose).toBe(1)
+    expect(db.counters.batches).toBe(2)
+  })
+})

--- a/packages/api/src/routes/upload.ts
+++ b/packages/api/src/routes/upload.ts
@@ -185,6 +185,7 @@ upload.post('/:spaceSlug/:siteSlug', requireAuth, async (c) => {
       storageKey: `${prefix}/${path}`,
       mimeType: file.type || null,
       size: file.size,
+      etag: null as string | null, // filled from the R2 put result below, before the D1 insert
     } satisfies NewFileRow,
   }))
   for (const { row } of plan) {
@@ -213,10 +214,13 @@ upload.post('/:spaceSlug/:siteSlug', requireAuth, async (c) => {
   try {
     for (let i = 0; i < plan.length; i += UPLOAD_CONCURRENCY) {
       await Promise.all(
-        plan.slice(i, i + UPLOAD_CONCURRENCY).map(({ file, row }) => {
+        plan.slice(i, i + UPLOAD_CONCURRENCY).map(async ({ file, row }) => {
           attempted.push(row.storageKey)
           const contentType = file.type || 'application/octet-stream'
-          return c.env.GLANCE_FILES.put(row.storageKey, file.stream(), { httpMetadata: { contentType } })
+          const put = await c.env.GLANCE_FILES.put(row.storageKey, file.stream(), { httpMetadata: { contentType } })
+          // Denormalize R2's etag onto the row (keys are immutable, so it's fixed for the row's
+          // life) — the content worker answers 304/416 conditionals from D1 with zero R2 ops.
+          row.etag = put?.httpEtag ?? null
         }),
       )
     }

--- a/packages/api/src/routes/upload.ts
+++ b/packages/api/src/routes/upload.ts
@@ -1,8 +1,8 @@
 import { and, eq, sql } from 'drizzle-orm'
 import { Hono } from 'hono'
-import { isSpaceMember, resolveShareRole } from '../db/repo'
 import type { NewFileRow } from '../db/schema'
-import { files, sites, spaces } from '../db/schema'
+import { files, sites, spaceMembers, spaces, siteUserShares } from '../db/schema'
+import { batchAll } from '../lib/d1'
 import { canReplace } from '../lib/access'
 import { fireAndForget } from '../lib/events'
 import { capTitle, extractHtmlMeta, NO_META, pickEntry } from '../lib/extract'
@@ -86,19 +86,19 @@ upload.post('/:spaceSlug/:siteSlug', requireAuth, async (c) => {
     seenPaths.add(path)
   }
 
-  // Resolve space.
-  const space = (
-    await db.select({ id: spaces.id }).from(spaces).where(eq(spaces.slug, spaceSlug)).limit(1)
-  )[0]
-  if (!space) return c.json({ error: 'space not found' }, 404)
-  const isAdmin = user.role === 'superadmin'
-
-  // Resolve the existing site (if any) BEFORE authorizing — CREATE and REPLACE have DIFFERENT gates:
-  // creating needs space membership; replacing is open to the owner, a superadmin, or a direct EDITOR
-  // grantee (who is typically NOT a space member, so the old membership-first gate 403'd them). Load
-  // contentVersion + status too: the editor CAS + archived guard need them.
-  const existing = (
-    await db
+  // Every pre-write read in ONE db.batch — all four are independently slug/user-keyed, so the
+  // space row, the existing site (if any), the caller's membership, the direct share role, and
+  // the existing file keys resolve in a single round trip. Precedence over the results below is
+  // unchanged: space 404 → create-membership/replace-capability 403 → editor guards → 409.
+  const slugKey = () => and(eq(spaces.slug, spaceSlug), eq(sites.slug, siteSlug))
+  const [spaceRows, existingRows, memberRows, shareRoleRows, existingFileRows] = await batchAll(db, [
+    db.select({ id: spaces.id }).from(spaces).where(eq(spaces.slug, spaceSlug)).limit(1),
+    // The existing site (if any) is resolved BEFORE authorizing — CREATE and REPLACE have
+    // DIFFERENT gates: creating needs space membership; replacing is open to the owner, a
+    // superadmin, or a direct EDITOR grantee (who is typically NOT a space member, so the old
+    // membership-first gate 403'd them). contentVersion + status feed the editor CAS + archived
+    // guard.
+    db
       .select({
         id: sites.id,
         ownerId: sites.ownerId,
@@ -106,9 +106,34 @@ upload.post('/:spaceSlug/:siteSlug', requireAuth, async (c) => {
         status: sites.status,
       })
       .from(sites)
-      .where(and(eq(sites.spaceId, space.id), eq(sites.slug, siteSlug)))
-      .limit(1)
-  )[0]
+      .innerJoin(spaces, eq(sites.spaceId, spaces.id))
+      .where(slugKey())
+      .limit(1),
+    db
+      .select({ userId: spaceMembers.userId })
+      .from(spaceMembers)
+      .innerJoin(spaces, eq(spaceMembers.spaceId, spaces.id))
+      .where(and(eq(spaces.slug, spaceSlug), eq(spaceMembers.userId, user.id)))
+      .limit(1),
+    db
+      .select({ role: siteUserShares.role })
+      .from(siteUserShares)
+      .innerJoin(sites, eq(siteUserShares.siteId, sites.id))
+      .innerJoin(spaces, eq(sites.spaceId, spaces.id))
+      .where(and(slugKey(), eq(siteUserShares.userId, user.id)))
+      .limit(1),
+    db
+      .select({ storageKey: files.storageKey })
+      .from(files)
+      .innerJoin(sites, eq(files.siteId, sites.id))
+      .innerJoin(spaces, eq(sites.spaceId, spaces.id))
+      .where(slugKey()),
+  ])
+
+  const space = spaceRows[0]
+  if (!space) return c.json({ error: 'space not found' }, 404)
+  const isAdmin = user.role === 'superadmin'
+  const existing = existingRows[0]
 
   const replace = c.req.query('replace') === 'true'
   const isCreate = !existing
@@ -120,7 +145,7 @@ upload.post('/:spaceSlug/:siteSlug', requireAuth, async (c) => {
 
   if (!existing) {
     // CREATE: space member or superadmin only. An editor grant confers no create right.
-    if (!isAdmin && !(await isSpaceMember(db, space.id, user.id))) return c.json({ error: 'forbidden' }, 403)
+    if (!isAdmin && memberRows.length === 0) return c.json({ error: 'forbidden' }, 403)
     if (!isValidSlug(siteSlug)) return c.json({ error: 'invalid siteSlug' }, 400)
     siteId = crypto.randomUUID()
   } else {
@@ -128,7 +153,7 @@ upload.post('/:spaceSlug/:siteSlug', requireAuth, async (c) => {
     // predicate shared with /exists + the manifest gate). An editor grant is only consulted for a
     // non-owner non-admin, so passing the gate while neither ⇒ acting as the editor.
     const isOwner = existing.ownerId === user.id
-    const shareRole = isOwner || isAdmin ? null : await resolveShareRole(db, existing.id, user.id)
+    const shareRole = isOwner || isAdmin ? null : (shareRoleRows[0]?.role ?? null)
     if (!canReplace(user, existing, shareRole)) return c.json({ error: 'forbidden' }, 403)
     actingAsEditor = !isOwner && !isAdmin
 
@@ -140,15 +165,11 @@ upload.post('/:spaceSlug/:siteSlug', requireAuth, async (c) => {
     }
 
     siteId = existing.id
-    const existingFiles = await db
-      .select({ storageKey: files.storageKey })
-      .from(files)
-      .where(eq(files.siteId, siteId))
     // Conflict unless the caller explicitly opted into replacing.
-    if (existingFiles.length > 0 && !replace) {
+    if (existingFileRows.length > 0 && !replace) {
       return c.json({ error: 'site exists', conflict: true }, 409)
     }
-    oldKeys = existingFiles.map((r) => r.storageKey)
+    oldKeys = existingFileRows.map((r) => r.storageKey)
   }
 
   // Plan every object under a fresh prefix. Build the rows first so the R2 keys are known BEFORE

--- a/packages/api/src/test/harness.ts
+++ b/packages/api/src/test/harness.ts
@@ -49,6 +49,7 @@ const MIGRATIONS = [
   'drizzle/0016_notifications_comment_index.sql',
   'drizzle/0017_site_updated_at.sql',
   'drizzle/0018_site_description.sql',
+  'drizzle/0019_files_etag.sql',
 ]
 
 // --- S0 recorder: one shared, ordered timeline across D1/R2/cache mocks so perf specs can
@@ -345,13 +346,16 @@ export async function seedGroupShare(db: DrizzleD1Database, siteId: string, spac
  *  Returns the storageKey so tests can read the same object the row points at. */
 export async function seedFile(
   db: DrizzleD1Database,
-  r2: { put: (key: string, value: string, opts?: unknown) => Promise<void> } | null,
+  r2: { put: (key: string, value: string, opts?: unknown) => Promise<{ httpEtag: string } | undefined> } | null,
   siteId: string,
   o: { path: string; text?: string; mimeType?: string; storageKey?: string } & Partial<NewFileRow>,
 ): Promise<string> {
   const id = o.id ?? nextId('file')
   const storageKey = o.storageKey ?? `${id}/${o.path}`
   const text = o.text ?? ''
+  // Put first so the row's etag mirrors the object's, like the upload route (a test models a
+  // legacy pre-denormalization row by nulling `etag` afterwards).
+  const put = r2 ? await r2.put(storageKey, text, { httpMetadata: { contentType: o.mimeType ?? 'text/html' } }) : null
   await db.insert(files).values({
     id,
     siteId,
@@ -359,8 +363,8 @@ export async function seedFile(
     storageKey,
     mimeType: o.mimeType ?? 'text/html',
     size: text.length,
+    etag: o.etag ?? put?.httpEtag ?? null,
   })
-  if (r2) await r2.put(storageKey, text, { httpMetadata: { contentType: o.mimeType ?? 'text/html' } })
   return storageKey
 }
 
@@ -611,8 +615,11 @@ export function makeR2(recorder?: Recorder) {
     ) => {
       const version = (versions.get(key) ?? 0) + 1
       versions.set(key, version)
-      store.set(key, { body: await toBytes(value), httpMetadata: options?.httpMetadata, httpEtag: `"${key}-v${version}"` })
+      const v = { body: await toBytes(value), httpMetadata: options?.httpMetadata, httpEtag: `"${key}-v${version}"` }
+      store.set(key, v)
       recorder?.record('r2:put')
+      // Real R2 put resolves to the written object's R2Object — upload denormalizes httpEtag from it.
+      return meta(key, v)
     },
     delete: (keys: string | string[]) => {
       for (const k of Array.isArray(keys) ? keys : [keys]) store.delete(k)


### PR DESCRIPTION
## What

Implements the mechanical fixes (1–7) from the multi-agent performance audit — every finding adversarially verified against source before landing here. Context: the D1 primary is in OC with replication disabled (~150–250ms/round trip), so serial D1 phases are the dominant avoidable latency. **No user-visible behavior changes**; the two audit items that trade revocation freshness for latency (content-worker verdict cache, requireAuth re-read) are deliberately NOT in this PR.

## Changes

- **Notifications poll** (`db/notifications.ts`): rows + unread count fused into one `batchAll` — the bell poll is the app's most frequent endpoint; was 2 serial round trips.
- **Viewer metadata GET** (`routes/sites.ts`): session (KV) first, then site row + membership + share reach + file manifest in ONE slug-keyed `fetchAccessFacts` batch — was two dependent D1 phases on the FCP path. 404-before-auth preserved (site row rides the batch). ~150–250ms off every site open.
- **Upload pre-write reads** (`routes/upload.ts`): space / existing site / membership / share role / existing keys fused into one batch — was 3–4 sequential round trips before the first R2 byte (~300–750ms off every `glance deploy`). 404/403/409 precedence evaluated over batch results, unchanged.
- **Data-token mint** (`routes/data.ts`): last-but-one `resolveSiteForAccess` caller migrated to `fetchAccessFacts` (identical semantics incl. missing-site fail-closed).
- **Search** (`routes/sites.ts`): member-space + shared-site reach sets fused into one batch per debounced keystroke; candidate reach queries ride one batch too (`spaces.slug` aliased for D1's by-name batch row mapping).
- **Content single-file/listing fallback** (`content.ts`): index-ish requests fuse the all-files select into the access batch — a single-file site's every page view no longer pays a serial follow-up trip. Non-index assets keep the lean 6-statement batch (supersedes the old T1.2 "stays out of the batch" pin, deliberately).
- **ETag denormalization** (migration `0019_files_etag`): R2's `httpEtag` stored on the file row at upload (keys are immutable, so it's fixed for the row's life). 304 revalidations and Range 416s now answer with **zero R2 ops**; legacy NULL-etag rows keep the `head()` probe fallback. Harness `MIGRATIONS` array updated (S-MIGRATE seam); `makeR2.put` now returns the object like real R2.

## Testing (TDD)

Each fix landed behind the harness's op counters (`db.counters.loose` / `batches` / `batchStmts`, R2 op diffs) — the request-shape pins were written RED first, then the fusion made them green:

- new shape pins: data-token mint, searchSites, upload CREATE + editor-replace, viewer metadata GET, content index-ish arity, 304/416 `NO_OPS`
- new behavior pins: mint route statuses/caps (was untested), unreadCount-independent-of-limit, legacy NULL-etag head fallback (T2.6)
- full suite: 1021 tests green, typecheck + biome clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gmr5sC5SRUWGDVNbFhLgg8