### PR TITLE
Comment delete is author-only: owner/superadmin lose delete-any

### DIFF
--- a/packages/api/src/routes/comments.test.ts
+++ b/packages/api/src/routes/comments.test.ts
@@ -126,6 +126,28 @@ describe('comments routes — auth / access / authz', () => {
     expect(byAuthor.status).toBe(200)
   })
 
+  test('non-author-member-cannot-delete: another member deleting someone else\'s comment → 403; author can delete own', async () => {
+    const { app, env, db, r2, kv } = await setup()
+    const owner = await mintUser(db, kv, { id: 'owner' })
+    const author = await mintUser(db, kv, { id: 'author' })
+    const other = await mintUser(db, kv, { id: 'other' })
+    const { spaceId } = await seedSiteWithFile(db, r2, owner, 'members')
+    await seedMember(db, spaceId, author)
+    await seedMember(db, spaceId, other)
+    const created = await (await app.request(url(), { method: 'POST', headers: auth(author), body: JSON.stringify({ filePath: 'index.html', body: 'mine', quote: 'fox' }) }, env)).json()
+    const commentId = (await (await app.request(url('?filePath=index.html'), { headers: auth(author) }, env)).json())[0].comments[0].id
+    const path = url(`/${created.threadId}/messages/${commentId}`)
+
+    const byOther = await app.request(path, { method: 'DELETE', headers: auth(other) }, env)
+    expect(byOther.status).toBe(403)
+    // The comment must still be intact — a 403 must not have soft-deleted it.
+    const after = await (await app.request(url('?filePath=index.html'), { headers: auth(author) }, env)).json()
+    expect(after[0].comments[0].deleted).toBe(false)
+
+    const byAuthor = await app.request(path, { method: 'DELETE', headers: auth(author) }, env)
+    expect(byAuthor.status).toBe(200)
+  })
+
   test('owner-superadmin-resolve-and-delete-any: owner resolves + deletes a member comment; member cannot resolve', async () => {
     const { app, env, db, r2, kv } = await setup()
     const owner = await mintUser(db, kv, { id: 'owner' })

--- a/packages/api/src/routes/comments.test.ts
+++ b/packages/api/src/routes/comments.test.ts
@@ -148,21 +148,28 @@ describe('comments routes — auth / access / authz', () => {
     expect(byAuthor.status).toBe(200)
   })
 
-  test('owner-superadmin-resolve-and-delete-any: owner resolves + deletes a member comment; member cannot resolve', async () => {
+  test('delete-is-author-only: owner and superadmin cannot delete a member comment; resolve moderation unchanged', async () => {
     const { app, env, db, r2, kv } = await setup()
     const owner = await mintUser(db, kv, { id: 'owner' })
     const member = await mintUser(db, kv, { id: 'member' })
+    const admin = await mintUser(db, kv, { id: 'admin', role: 'superadmin' })
     const { spaceId } = await seedSiteWithFile(db, r2, owner, 'members')
     await seedMember(db, spaceId, member)
     const created = await (await app.request(url(), { method: 'POST', headers: auth(member), body: JSON.stringify({ filePath: 'index.html', body: 'mine', quote: 'fox' }) }, env)).json()
     const commentId = (await (await app.request(url('?filePath=index.html'), { headers: auth(member) }, env)).json())[0].comments[0].id
+    const msgPath = url(`/${created.threadId}/messages/${commentId}`)
 
     const memberResolve = await app.request(url(`/${created.threadId}`), { method: 'PATCH', headers: auth(member), body: JSON.stringify({ status: 'resolved' }) }, env)
     expect(memberResolve.status).toBe(403)
     const ownerResolve = await app.request(url(`/${created.threadId}`), { method: 'PATCH', headers: auth(owner), body: JSON.stringify({ status: 'resolved' }) }, env)
     expect(ownerResolve.status).toBe(200)
-    const ownerDelete = await app.request(url(`/${created.threadId}/messages/${commentId}`), { method: 'DELETE', headers: auth(owner) }, env)
-    expect(ownerDelete.status).toBe(200)
+
+    const ownerDelete = await app.request(msgPath, { method: 'DELETE', headers: auth(owner) }, env)
+    expect(ownerDelete.status).toBe(403)
+    const adminDelete = await app.request(msgPath, { method: 'DELETE', headers: auth(admin) }, env)
+    expect(adminDelete.status).toBe(403)
+    const authorDelete = await app.request(msgPath, { method: 'DELETE', headers: auth(member) }, env)
+    expect(authorDelete.status).toBe(200)
 
     // soft-delete-keeps-thread-shape: the comment row survives, body redacted.
     const after = await (await app.request(url('?filePath=index.html'), { headers: auth(owner) }, env)).json()

--- a/packages/api/src/routes/comments.ts
+++ b/packages/api/src/routes/comments.ts
@@ -76,7 +76,8 @@ function canComment(_site: ResolvedSite, access: { ok: boolean }): boolean {
   return access.ok
 }
 
-// Site owner or superadmin may resolve/reopen any thread and delete any comment.
+// Site owner or superadmin may resolve/reopen any thread. Deleting a comment is AUTHOR-ONLY —
+// deliberately not a moderation power (nobody, superadmin included, deletes someone else's words).
 const canModerate = (site: ResolvedSite, user: SessionUser): boolean =>
   site.ownerId === user.id || user.role === 'superadmin'
 
@@ -600,13 +601,12 @@ comments.patch('/:space/:site/comments/:threadId/messages/:commentId', async (c)
   return c.json({ ok: true })
 })
 
-// DELETE — soft-delete a comment (author, or owner/superadmin). S9c fused pre-write batch.
+// DELETE — soft-delete a comment (author only, like edit). S9c fused pre-write batch.
 comments.delete('/:space/:site/comments/:threadId/messages/:commentId', async (c) => {
   const gate = await siteWithUrlComment(c)
   if (gate instanceof Response) return gate
-  const { site, comment } = gate
-  const user = c.get('user')
-  if (comment.authorId !== user.id && !canModerate(site, user)) return c.json({ error: 'forbidden' }, 403)
+  const { comment } = gate
+  if (comment.authorId !== c.get('user').id) return c.json({ error: 'forbidden' }, 403)
   // Capture the audio key before the delete nulls it, then hard-delete the recording off the
   // serving path — the row survives redacted, the audio does not (documented voice asymmetry).
   const { audioKey } = comment

--- a/packages/web/src/components/review/ThreadCard.tsx
+++ b/packages/web/src/components/review/ThreadCard.tsx
@@ -68,7 +68,7 @@ export function ThreadCard({
                 </Badge>
               )}
               {c.editedAt && !c.deleted && <span>(edited)</span>}
-              {!c.deleted && (c.authorId === me?.id || canModerate) && (
+              {!c.deleted && c.authorId === me?.id && (
                 <button
                   type="button"
                   onClick={() => run(() => comments.remove(site, thread.id, c.id))}


### PR DESCRIPTION
## What

Restricts comment deletion to the **comment author only**. Site owners and superadmins can no longer delete other users' comments (they previously could via `canModerate`). Resolve/reopen thread moderation is unchanged (still owner/superadmin). Edit was already author-only.

The web UI trash icon now only shows on your own comments.

## Why

Reported as "users can delete other people's comments." Investigation showed the API had enforced author-or-moderator since the comments API landed — the repro was the **intentional** owner/superadmin moderation path, not a missing check. Sam then decided the policy itself should change: nobody deletes someone else's words, no exceptions.

Note: this removes the only way to take down abusive/accidental content (e.g. pasted secrets) when the author is unavailable — accepted trade-off, flagging for the record.

## Tests (RED-first)

- `non-author-member-cannot-delete` (new): member B deleting member A's comment → 403, comment intact after refusal, author delete → 200.
- `delete-is-author-only` (reworked from `owner-superadmin-resolve-and-delete-any`): owner → 403, superadmin → 403, author → 200; member-cannot-resolve + owner-resolve and soft-delete thread-shape assertions preserved.

Full suite: 1014 pass. `biome lint` + `bun run typecheck` clean.

## Other mutation endpoints audited — no holes

- PATCH edit: author-only (was already)
- PATCH resolve/reopen: owner/superadmin (unchanged)
- No other delete paths exist (slack-events, data API, annotate client, content worker all checked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NfXGn1GEmb8zyrP9fsoYPc