### PR TITLE
perf: enable D1 read replication + Sessions API on read paths

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -150,6 +150,21 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: bunx wrangler d1 migrations apply glance-db --remote
 
+      # Read replication (issue #79): a DB-level setting with no wrangler command — REST only.
+      # Reads then route to the nearest replica via the Sessions API adopted in the workers;
+      # billing is unchanged (still rows_read/rows_written). PUT is idempotent per deploy.
+      - name: Ensure D1 read replication is enabled
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CF_ACCOUNT_ID: ${{ vars.CF_ACCOUNT_ID }}
+          CF_D1_DATABASE_ID: ${{ vars.CF_D1_DATABASE_ID }}
+        run: |
+          out="$(curl -sS -X PUT "https://api.cloudflare.com/client/v4/accounts/${CF_ACCOUNT_ID}/d1/database/${CF_D1_DATABASE_ID}" \
+            -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d '{"read_replication": {"mode": "auto"}}')"
+          echo "$out" | grep -q '"success": *true' || { echo "$out" >&2; exit 1; }
+
       - name: Deploy main worker
         working-directory: packages/api
         env:

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -38,6 +38,14 @@ Apply migrations to remote D1:
 cd packages/api && wrangler d1 migrations apply glance-db --remote
 ```
 
+Enable D1 read replication (reads route to the nearest replica via the Sessions API; billing is unchanged — still rows_read/rows_written). It's a database-level setting with no wrangler command: use the dashboard (D1 → glance-db → Settings) or the REST API with a `D1:Edit` token:
+
+```bash
+curl -X PUT "https://api.cloudflare.com/client/v4/accounts/<account_id>/d1/database/<database_id>" \
+  -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" -H "Content-Type: application/json" \
+  -d '{"read_replication": {"mode": "auto"}}'
+```
+
 ## 2. Secrets
 
 Both workers need `SESSION_SECRET` and `CONTENT_TOKEN_SECRET` (keep them distinct). The main worker also needs `BOOTSTRAP_TOKEN` for first-run admin setup.

--- a/packages/api/src/content.ts
+++ b/packages/api/src/content.ts
@@ -1,6 +1,7 @@
 import { and, eq } from 'drizzle-orm'
-import { type DrizzleD1Database, drizzle } from 'drizzle-orm/d1'
+import type { DrizzleD1Database } from 'drizzle-orm/d1'
 import { type Context, Hono } from 'hono'
+import { sessionDb } from './db/client'
 import { ANNOTATE_CSS, ANNOTATE_JS, ANNOTATE_VERSION } from './annotate/bundle'
 import { GLANCE_DB_JS, GLANCE_DB_VERSION } from './glancedb/bundle'
 import { type NewEvent, files, sites, spaces } from './db/schema'
@@ -33,8 +34,11 @@ const app = new Hono<ContentEnv>()
 
 // Per-request drizzle client. The D1 binding is request-scoped, so the client must not be
 // memoized across requests; tests inject a harness db via c.set('db').
+// 'first-unconstrained': every read may hit the nearest replica. Replica lag on this origin is
+// an accepted posture — a just-uploaded site can already miss transiently (404s are no-store,
+// see notFound), and share revocation propagating within seconds matches KV session semantics.
 function getDb(c: Ctx): DrizzleD1Database {
-  return c.get('db') ?? drizzle(c.env.GLANCE_DB)
+  return c.get('db') ?? sessionDb(c.env.GLANCE_DB, 'first-unconstrained')
 }
 
 // The edge cache for full-200 object reads. In the Workers runtime this is the global

--- a/packages/api/src/db/client.test.ts
+++ b/packages/api/src/db/client.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from 'bun:test'
+import { sql } from 'drizzle-orm'
+import { Hono } from 'hono'
+import type { AppEnv } from '../types'
+import { BOOKMARK_HEADER, sessionDb, withDb } from './client'
+
+// D1 Sessions wiring (issue #79): every /api request runs its drizzle client over a
+// D1DatabaseSession so reads can route to the nearest replica, with the session bookmark
+// round-tripped to the browser for cross-request read-your-write consistency.
+
+function fakeEnv(bookmarkAfter: string | null = 'bm-after') {
+  const anchors: (string | undefined)[] = []
+  const session = {
+    prepare: () => {
+      throw new Error('no query expected in this test')
+    },
+    batch: () => {
+      throw new Error('no query expected in this test')
+    },
+    getBookmark: () => bookmarkAfter,
+  }
+  const withSession = (a?: string) => {
+    anchors.push(a)
+    return session
+  }
+  const env = { GLANCE_DB: { withSession } } as never
+  return { env, anchors }
+}
+
+function mount() {
+  const app = new Hono<AppEnv>()
+  app.use('*', withDb)
+  app.get('/x', (c) => c.text('ok'))
+  return app
+}
+
+describe('withDb — D1 session anchoring + bookmark round-trip', () => {
+  test('browser request without a bookmark → first-unconstrained; response carries the session bookmark', async () => {
+    const { env, anchors } = fakeEnv()
+    const res = await mount().request('/x', {}, env)
+    expect(res.status).toBe(200)
+    expect(anchors).toEqual(['first-unconstrained'])
+    expect(res.headers.get(BOOKMARK_HEADER)).toBe('bm-after')
+  })
+
+  test('browser echoes a bookmark → session anchored at it (read-your-write across requests)', async () => {
+    const { env, anchors } = fakeEnv()
+    await mount().request('/x', { headers: { [BOOKMARK_HEADER]: 'bm-prev' } }, env)
+    expect(anchors).toEqual(['bm-prev'])
+  })
+
+  test('no query ran (null bookmark) → response carries no bookmark header', async () => {
+    const { env } = fakeEnv(null)
+    const res = await mount().request('/x', {}, env)
+    expect(res.headers.get(BOOKMARK_HEADER)).toBeNull()
+  })
+})
+
+describe('sessionDb — session-backed drizzle client (content/data workers)', () => {
+  test('anchors one session at the given constraint and runs queries through it', async () => {
+    const prepared: string[] = []
+    const anchors: string[] = []
+    const statement = {
+      bind: () => statement,
+      all: async () => ({ results: [], success: true, meta: {} }),
+      run: async () => ({ results: [], success: true, meta: {} }),
+      raw: async () => [],
+    }
+    const binding = {
+      withSession: (a: string) => {
+        anchors.push(a)
+        const prepare = (q: string) => {
+          prepared.push(q)
+          return statement
+        }
+        return { prepare, getBookmark: () => null }
+      },
+    } as unknown as D1Database
+
+    const db = sessionDb(binding, 'first-primary')
+    await db.run(sql`select 1`)
+    await db.run(sql`select 2`)
+
+    expect(anchors).toEqual(['first-primary'])
+    expect(prepared).toEqual(['select 1', 'select 2'])
+  })
+})

--- a/packages/api/src/db/client.ts
+++ b/packages/api/src/db/client.ts
@@ -2,9 +2,28 @@ import { drizzle } from 'drizzle-orm/d1'
 import { createMiddleware } from 'hono/factory'
 import type { AppEnv } from '../types'
 
+/** Round-trips the D1 session bookmark to the browser: sent on responses, echoed back on the
+ *  next request so a session anchored at it reads its own prior writes (issue #79). */
+export const BOOKMARK_HEADER = 'x-glance-d1-bookmark'
+
+/** Drizzle client over a D1 session so reads route to the nearest replica (read replication).
+ *  The cast is required: D1DatabaseSession deliberately omits exec/dump, which drizzle's
+ *  D1Database type carries but never calls at runtime. */
+export function sessionDb(binding: D1Database, anchor: D1SessionConstraint | D1SessionBookmark) {
+  return drizzle(binding.withSession(anchor) as unknown as D1Database)
+}
+
 // Per-request drizzle client — the D1 binding is request-scoped in Workers, so the
 // client must not be memoized across requests. Attaches c.get('db').
+//
+// The client runs over a D1 session (not the bare binding) so reads route to the nearest
+// replica once read replication is enabled. Anchoring at the browser-echoed bookmark keeps
+// cross-request read-your-write consistency; without one, 'first-unconstrained' lets even
+// the first query hit a replica.
 export const withDb = createMiddleware<AppEnv>(async (c, next) => {
-  c.set('db', drizzle(c.env.GLANCE_DB))
+  const session = c.env.GLANCE_DB.withSession(c.req.header(BOOKMARK_HEADER) ?? 'first-unconstrained')
+  c.set('db', drizzle(session as unknown as D1Database))
   await next()
+  const bookmark = session.getBookmark()
+  if (bookmark) c.header(BOOKMARK_HEADER, bookmark)
 })

--- a/packages/api/src/routes/comment-feed.test.ts
+++ b/packages/api/src/routes/comment-feed.test.ts
@@ -108,7 +108,8 @@ describe('comment feed route — C4.6 root-app composition', () => {
     const env = {
       APP_URL,
       CONTENT_URL: 'https://content.example.com',
-      GLANCE_DB: {},
+      // Minimal binding shape withDb needs; the request 401s before any query runs.
+      GLANCE_DB: { withSession: () => ({ getBookmark: () => null }) },
       GLANCE_SESSIONS: makeKv(),
     } as unknown as AppEnv['Bindings']
 

--- a/packages/api/src/routes/data.ts
+++ b/packages/api/src/routes/data.ts
@@ -1,6 +1,7 @@
 import { and, count, desc, eq } from 'drizzle-orm'
-import { type DrizzleD1Database, drizzle } from 'drizzle-orm/d1'
+import type { DrizzleD1Database } from 'drizzle-orm/d1'
 import { type Context, Hono } from 'hono'
+import { sessionDb } from '../db/client'
 import { type DocumentRow, type Site, documents, sites } from '../db/schema'
 import { type DataCapability, type DataClaims, hasCap, signDataToken, verifyDataToken } from '../lib/data-token'
 import { authorizeViewerById, fetchAccessFacts, siteAccessFromFacts } from '../lib/site-access'
@@ -37,8 +38,12 @@ const SHARED_PREFIX = 'shared-'
 type DataEnv = { Bindings: Bindings; Variables: { db?: DrizzleD1Database; claims: DataClaims } }
 type DataCtx = Context<DataEnv>
 
+// 'first-primary': the auth middleware's site lookup is always the session's first query, so it
+// anchors the session at the primary's current state — an SDK create followed by a list stays
+// read-your-write with no client-side bookmark threading (the SDK/broker never see D1 headers).
+// Later queries in the request still ride replicas consistent with that anchor.
 function getDb(c: DataCtx): DrizzleD1Database {
-  return c.get('db') ?? drizzle(c.env.GLANCE_DB)
+  return c.get('db') ?? sessionDb(c.env.GLANCE_DB, 'first-primary')
 }
 
 export const dataApi = new Hono<DataEnv>()

--- a/packages/web/src/lib/api.test.ts
+++ b/packages/web/src/lib/api.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, test } from 'bun:test'
+import { __resetDbBookmark, api, BOOKMARK_HEADER, captureDbBookmark } from './api'
+
+// D1 session bookmark threading (issue #79): the API echoes the newest bookmark it saw on a
+// response header; sending it back anchors the server's next D1 session so a user reads
+// their own prior writes even when the read lands on a replica.
+
+function stubFetch(headers: Record<string, string> = {}) {
+  const calls: Array<{ url: string; init?: RequestInit }> = []
+  globalThis.fetch = ((url: string, init?: RequestInit) => {
+    calls.push({ url, init })
+    return Promise.resolve(
+      new Response('{}', { status: 200, headers: { 'content-type': 'application/json', ...headers } }),
+    )
+  }) as unknown as typeof fetch
+  return calls
+}
+
+const sentBookmark = (call: { init?: RequestInit }) =>
+  (call.init?.headers as Record<string, string> | undefined)?.[BOOKMARK_HEADER]
+
+describe('api — D1 bookmark round-trip', () => {
+  beforeEach(__resetDbBookmark)
+
+  test('first request sends no bookmark header', async () => {
+    const calls = stubFetch()
+    await api.get('/api/spaces')
+    expect(sentBookmark(calls[0])).toBeUndefined()
+  })
+
+  test('a response bookmark is echoed on the next request', async () => {
+    const calls = stubFetch({ [BOOKMARK_HEADER]: 'bm-1' })
+    await api.post('/api/spaces', { name: 'x' })
+    await api.get('/api/spaces')
+    expect(sentBookmark(calls[1])).toBe('bm-1')
+  })
+
+  test('captureDbBookmark (XHR upload seam) feeds the next request; null is a no-op', async () => {
+    const calls = stubFetch()
+    captureDbBookmark('bm-upload')
+    captureDbBookmark(null)
+    await api.get('/api/sites')
+    expect(sentBookmark(calls[0])).toBe('bm-upload')
+  })
+
+  test('a response without a bookmark keeps the last one', async () => {
+    let calls = stubFetch({ [BOOKMARK_HEADER]: 'bm-1' })
+    await api.get('/api/a')
+    calls = stubFetch()
+    await api.get('/api/b')
+    await api.get('/api/c')
+    expect(sentBookmark(calls[1])).toBe('bm-1')
+  })
+})

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -11,8 +11,28 @@ export class ApiError extends Error {
   }
 }
 
+/** D1 session bookmark round-trip (issue #79): the server tags responses with the newest
+ *  bookmark; echoing it back anchors its next D1 session so reads on a replica still see
+ *  this browser's prior writes. */
+export const BOOKMARK_HEADER = 'x-glance-d1-bookmark'
+
+let dbBookmark: string | null = null
+export const __resetDbBookmark = () => {
+  dbBookmark = null
+}
+
+/** Feed a bookmark captured outside this wrapper (the XHR upload path) into the round-trip. */
+export const captureDbBookmark = (bookmark: string | null) => {
+  dbBookmark = bookmark ?? dbBookmark
+}
+
+/** Current bookmark, for requests made outside this wrapper (the XHR upload path). */
+export const getDbBookmark = () => dbBookmark
+
 async function request<T>(path: string, init?: RequestInit): Promise<T> {
-  const res = await fetch(path, { credentials: 'include', ...init })
+  const headers = dbBookmark ? { ...init?.headers, [BOOKMARK_HEADER]: dbBookmark } : init?.headers
+  const res = await fetch(path, { credentials: 'include', ...init, headers })
+  captureDbBookmark(res.headers.get(BOOKMARK_HEADER))
   if (!res.ok) {
     let message = res.statusText
     try {

--- a/packages/web/src/lib/uploadWithProgress.ts
+++ b/packages/web/src/lib/uploadWithProgress.ts
@@ -1,3 +1,4 @@
+import { BOOKMARK_HEADER, captureDbBookmark, getDbBookmark } from './api'
 import { type DroppedFile, stripCommonRoot } from './walkFiles'
 
 // fetch() cannot report upload progress — XHR is required. Posts a multipart form to the
@@ -33,10 +34,15 @@ export function uploadFiles(
     const xhr = new XMLHttpRequest()
     xhr.open('POST', url)
     xhr.withCredentials = true
+    // D1 bookmark round-trip (issue #79): XHR bypasses the api.ts wrapper, but an upload is the
+    // write whose result the very next read must see — thread the bookmark both ways by hand.
+    const bookmark = getDbBookmark()
+    if (bookmark) xhr.setRequestHeader(BOOKMARK_HEADER, bookmark)
     xhr.upload.onprogress = (e) => {
       if (e.lengthComputable) opts.onProgress?.(Math.round((e.loaded / e.total) * 100))
     }
     xhr.onload = () => {
+      captureDbBookmark(xhr.getResponseHeader(BOOKMARK_HEADER))
       if (xhr.status >= 200 && xhr.status < 300) {
         try {
           resolve(JSON.parse(xhr.responseText) as UploadResult)

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -176,6 +176,29 @@ fi
 note "Applying D1 migrations to the remote database"
 wrangler d1 migrations apply glance-db --remote
 
+# --- D1 read replication (issue #79): reads route to the nearest replica via the Sessions API
+# the workers use; billing is unchanged (still rows_read/rows_written). A DB-level setting with
+# no wrangler command — REST only, so the OAuth login can't authenticate it. Best-effort here;
+# CI (deploy.yml) also ensures it on every deploy.
+note "Enabling D1 read replication (glance-db)"
+if wrangler d1 info glance-db --json 2>/dev/null | grep -q '"mode": *"auto"'; then
+  echo "   already enabled — skipping"
+elif [[ -n "${CLOUDFLARE_API_TOKEN:-}" ]]; then
+  ACCT="${CLOUDFLARE_ACCOUNT_ID:-$(wrangler whoami 2>/dev/null | grep -oE "$HEX32" | head -1 || true)}"
+  DBID="$(grep '"database_id"' wrangler.jsonc | grep -oiE "$UUID" | head -1 || true)"
+  if [[ -n "$ACCT" && -n "$DBID" ]] && curl -sS -X PUT "https://api.cloudflare.com/client/v4/accounts/$ACCT/d1/database/$DBID" \
+      -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" -H 'Content-Type: application/json' \
+      -d '{"read_replication":{"mode":"auto"}}' | grep -q '"success": *true'; then
+    echo "   read replication → auto"
+  else
+    warn "Could not enable read replication via the API — enable it in the dashboard:"
+    warn "   dash.cloudflare.com → Storage & Databases → D1 → glance-db → Settings"
+  fi
+else
+  warn "Needs a REST call (no wrangler command). Enable it in the dashboard (D1 → glance-db →"
+  warn "Settings) or export CLOUDFLARE_API_TOKEN (D1:Edit) and re-run."
+fi
+
 # --- wire live URLs into config (single sentinel replace — safe, see PLAN Step 11) ---
 # APP_URL is kept an explicit var (NOT request-derived): the bootstrap same-origin/CSRF
 # check and cookie `secure` flag must not trust a spoofable Host header.


### PR DESCRIPTION
Closes #79.

Every D1 query round-trips to the OC primary (~150-250ms from India/US). PR #78 cut the round-trip *count*; this cuts the round-trip *cost*: reads route to the nearest replica via the D1 Sessions API, with the session bookmark threaded for read-after-write consistency.

## What changed

- **Main API (`withDb`)** — per-request drizzle client now runs over `GLANCE_DB.withSession()`, anchored at the browser-echoed bookmark (else `first-unconstrained`). The response carries the session bookmark in `x-glance-d1-bookmark`.
- **SPA (`web/lib/api.ts`)** — captures the bookmark from every response and echoes it on every request, so a user posting a comment sees it on their next read even from a replica. The XHR upload path (bypasses the wrapper; biggest write) threads it by hand via `getDbBookmark`/`captureDbBookmark`.
- **Content worker** — `first-unconstrained` session via the shared `sessionDb` helper. Replica lag here is an accepted posture: post-upload 404s are already no-store by design, and share-revocation propagating within seconds matches KV session semantics.
- **Data plane (`/api/_data`)** — `first-primary`: the auth middleware's site lookup is always the session's first query, anchoring at current primary state, so SDK create→list stays read-your-write with zero SDK/broker protocol changes.
- **Enabling the mode** — `read_replication.mode` is DB-level and REST-only (no wrangler command, not a wrangler.jsonc key). Added an idempotent PUT to the CI deploy (existing `CLOUDFLARE_API_TOKEN`, fails loud), a best-effort step in `setup.sh`, and a DEPLOY.md section. Billing unchanged (rows_read/rows_written).

## Consistency semantics

- Same user: read-your-write across requests via the bookmark round-trip (matches Cloudflare's canonical pattern).
- Other viewers on the content origin: may see a replaced site's previous version / a brief 404 on a brand-new site for a few seconds of replica lag — uncached, self-healing.
- Writes always hit the primary (D1 guarantee).

## Tests

TDD throughout: `packages/api/src/db/client.test.ts` (session anchoring, bookmark echo, null-bookmark no-op, `sessionDb` helper), `packages/web/src/lib/api.test.ts` (round-trip + XHR capture seam). 852 api + 179 web tests pass; typecheck + lint clean. One existing fixture updated (`comment-feed.test.ts` real-app fake now provides `withSession`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gmr5sC5SRUWGDVNbFhLgg8