### PR TITLE
Dashboard UI cleanup: URL-driven tabs, conditional Spaces tab, invite-picker modal, brand-mark header

### DIFF
--- a/packages/api/src/routes/spaces.test.ts
+++ b/packages/api/src/routes/spaces.test.ts
@@ -212,18 +212,22 @@ describe('GET /api/spaces/:slug — post-auth D1 request budget + member facts (
     db.resetCounters()
     const asMember = await app.request('/api/spaces/acme', { headers: auth('m2') }, env)
     expect(asMember.status).toBe(200)
-    expect(await asMember.json()).toMatchObject({ slug: 'acme', memberCount: 3, isMember: true })
+    expect(await asMember.json()).toMatchObject({ slug: 'acme', memberCount: 3, isMember: true, isOwner: false })
     expect(postAuthRequests(db)).toBeLessThanOrEqual(2)
 
     db.resetCounters()
     const asOutsider = await app.request('/api/spaces/acme', { headers: auth('out') }, env)
     expect(asOutsider.status).toBe(200)
-    expect(await asOutsider.json()).toMatchObject({ slug: 'acme', memberCount: 3, isMember: false })
+    expect(await asOutsider.json()).toMatchObject({ slug: 'acme', memberCount: 3, isMember: false, isOwner: false })
+
     expect(postAuthRequests(db)).toBeLessThanOrEqual(2)
     // Exact shape: ONE batch carrying all three SELECTs (space row, member count, membership).
     expect(db.counters.loose).toBe(1)
     expect(db.counters.batches).toBe(1)
     expect(db.counters.batchStmts).toBe(3)
+
+    const asOwner = await app.request('/api/spaces/acme', { headers: auth('owner') }, env)
+    expect(await asOwner.json()).toMatchObject({ slug: 'acme', isMember: true, isOwner: true })
   })
 })
 

--- a/packages/api/src/routes/spaces.ts
+++ b/packages/api/src/routes/spaces.ts
@@ -85,7 +85,17 @@ spaces.get('/:slug', requireAuth, async (c) => {
 
   const memberCount = Number(counted[0]?.count ?? 0)
   const isMember = memberRows.length > 0
-  return c.json({ id: space.id, slug: space.slug, name: space.name, type: space.type, memberCount, isMember })
+  // isOwner lets the UI gate owner-only affordances (invite members) instead of offering
+  // actions that can only 403 — the member routes below all enforce createdBy.
+  return c.json({
+    id: space.id,
+    slug: space.slug,
+    name: space.name,
+    type: space.type,
+    memberCount,
+    isMember,
+    isOwner: space.createdBy === user.id,
+  })
 })
 
 // GET /api/spaces/:slug/sites — sites in the space the caller can actually access, in ONE post-auth

--- a/packages/web/src/components/AppShell.tsx
+++ b/packages/web/src/components/AppShell.tsx
@@ -61,7 +61,8 @@ export function AppShell() {
       <header className="sticky top-0 z-40 border-b border-border/70 bg-background/80 backdrop-blur-md">
         <div className="mx-auto flex h-14 max-w-6xl items-center gap-3 px-4 sm:px-6">
           <Link to="/dashboard" className="flex items-center gap-2 font-mono text-sm font-semibold tracking-tight">
-            <span className="size-2.5 rounded-[3px] bg-primary shadow-[0_0_12px_1px_var(--primary)]" />
+            {/* The brand mark (favicon.svg), keeping the old yellow box's primary glow. */}
+            <img src="/favicon.svg" alt="" className="size-5 rounded-[5px] shadow-[0_0_12px_1px_var(--primary)]" />
             glance
           </Link>
           {user && (

--- a/packages/web/src/components/CommandPalette.tsx
+++ b/packages/web/src/components/CommandPalette.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useMemo, useRef, useState } from 'react'
-import { useNavigate } from 'react-router'
+import { useLocation, useNavigate } from 'react-router'
 import { Copy, ExternalLink, Folder, History, LayoutDashboard, LogOut, Plus, Shield, SunMoon, Terminal } from 'lucide-react'
 import {
   CommandDialog,
@@ -28,6 +28,7 @@ export function CommandPalette({
   user: Me | null
 }) {
   const navigate = useNavigate()
+  const location = useLocation()
   // Data comes from the `api` fetch helper, not useFetcher: useFetcher().load() resolves a
   // React Router route, but /api/* are worker endpoints with no client route (they'd match
   // the splat). Site search is driven by the input; spaces load when the palette opens.
@@ -173,7 +174,16 @@ export function CommandPalette({
               Admin
             </CommandItem>
           )}
-          <CommandItem onSelect={() => run(() => navigate('/dashboard?new=space'))}>
+          <CommandItem
+            onSelect={() =>
+              run(() => {
+                // Merge, don't clobber: already on /dashboard means an active ?tab= to preserve.
+                const params = new URLSearchParams(location.pathname === '/dashboard' ? location.search : '')
+                params.set('new', 'space')
+                navigate(`/dashboard?${params}`)
+              })
+            }
+          >
             <Plus />
             New space
           </CommandItem>

--- a/packages/web/src/components/ShareDialog.tsx
+++ b/packages/web/src/components/ShareDialog.tsx
@@ -239,6 +239,7 @@ export function PickerRow({
     <button
       type="button"
       onClick={onToggle}
+      aria-pressed={checked}
       className={cn('flex w-full items-center gap-3 rounded-md px-2 py-1.5 text-left hover:bg-muted', className)}
     >
       <span

--- a/packages/web/src/components/ShareDialog.tsx
+++ b/packages/web/src/components/ShareDialog.tsx
@@ -139,7 +139,7 @@ export function ShareDialog({ spaceSlug, siteSlug, title, open: openProp, onOpen
                 <p className="text-xs font-medium text-muted-foreground">Other spaces</p>
                 <div className="max-h-32 space-y-0.5 overflow-y-auto">
                   {groups.map((g) => (
-                    <Row
+                    <PickerRow
                       key={g.id}
                       checked={selGroups.has(g.id)}
                       onToggle={() => setSelGroups((s) => toggle(s, g.id))}
@@ -188,7 +188,7 @@ export function ShareDialog({ spaceSlug, siteSlug, title, open: openProp, onOpen
                     const role = selUsers.get(u.id)
                     return (
                       <div key={u.id} className="flex items-center gap-2">
-                        <Row
+                        <PickerRow
                           className="flex-1"
                           checked={role !== undefined}
                           onToggle={() => setSelUsers((s) => toggleUser(s, u.id))}
@@ -221,7 +221,8 @@ export function ShareDialog({ spaceSlug, siteSlug, title, open: openProp, onOpen
   )
 }
 
-function Row({
+// Shared with the space page's invite dialog — one checkbox-row look across both pickers.
+export function PickerRow({
   checked,
   onToggle,
   label,

--- a/packages/web/src/components/ViewerTopBar.tsx
+++ b/packages/web/src/components/ViewerTopBar.tsx
@@ -48,7 +48,8 @@ export function ViewerTopBar({
   return (
     <header className="flex h-12 shrink-0 items-center gap-2 border-b bg-background px-3 md:gap-3">
       <Link to="/dashboard" className="flex shrink-0 items-center gap-2 font-mono font-semibold text-sm tracking-tight">
-        <span className="size-2.5 rounded-[3px] bg-primary shadow-[0_0_12px_1px_var(--primary)]" />
+        {/* The brand mark (favicon.svg), keeping the old yellow box's primary glow. */}
+        <img src="/favicon.svg" alt="" className="size-5 rounded-[5px] shadow-[0_0_12px_1px_var(--primary)]" />
         glance
       </Link>
 

--- a/packages/web/src/lib/feedState.test.ts
+++ b/packages/web/src/lib/feedState.test.ts
@@ -192,16 +192,20 @@ describe('deriveFeedState', () => {
   })
 
   // T10.6 — staleTab: a ?tab= pointing at an absent conditional tab is a legitimate deep link
-  // while the feed is pending, and STALE (component clears the param) once the feed settles
-  // without producing the tab.
-  test('T10.6 staleTab fires only after the governing feed settles without the tab', () => {
+  // while the feed is pending, and STALE (component clears the param) only once the feed RESOLVES
+  // without producing the tab. A rejection (transient error or the 401 heading to login) proves
+  // nothing about absence — the deep link must survive it.
+  test('T10.6 staleTab fires only after the governing feed resolves without the tab', () => {
     const wantSpaces = { requestedTab: 'spaces' } as const
     expect(deriveFeedState(allPending(), wantSpaces).staleTab).toBe(false)
     expect(deriveFeedState({ ...allPending(), spaces: resolved([]) }, wantSpaces).staleTab).toBe(true)
     expect(
       deriveFeedState({ ...allPending(), spaces: resolved([space('p', 'personal')]) }, wantSpaces).staleTab,
     ).toBe(true)
-    expect(deriveFeedState({ ...allPending(), spaces: rejected(new Error('boom')) }, wantSpaces).staleTab).toBe(true)
+    expect(deriveFeedState({ ...allPending(), spaces: rejected(new Error('boom')) }, wantSpaces).staleTab).toBe(false)
+    expect(
+      deriveFeedState({ ...allPending(), spaces: rejected(new ApiError(401, 'Unauthorized')) }, wantSpaces).staleTab,
+    ).toBe(false)
     expect(
       deriveFeedState({ ...allPending(), spaces: resolved([space('g', 'group')]) }, wantSpaces).staleTab,
     ).toBe(false)
@@ -209,6 +213,7 @@ describe('deriveFeedState', () => {
     const wantShared = { requestedTab: 'shared' } as const
     expect(deriveFeedState(allPending(), wantShared).staleTab).toBe(false)
     expect(deriveFeedState({ ...allPending(), shared: resolved([]) }, wantShared).staleTab).toBe(true)
+    expect(deriveFeedState({ ...allPending(), shared: rejected(new Error('boom')) }, wantShared).staleTab).toBe(false)
     expect(deriveFeedState({ ...allPending(), shared: resolved([site('x')]) }, wantShared).staleTab).toBe(false)
 
     // Always-present tabs can never go stale.

--- a/packages/web/src/lib/feedState.test.ts
+++ b/packages/web/src/lib/feedState.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, test } from 'bun:test'
 import { ApiError } from './api'
-import { deriveFeedState, feedRowPath, type FeedSlot, type FeedSlots } from './feedState'
+import { deriveFeedState, feedRowPath, tabFromParam, type FeedSlot, type FeedSlots } from './feedState'
 import { notificationHref } from './mentions'
 import type { CommentFeedItem, SiteSummary, SpaceSummary, TeamUpload } from './types'
 
 // deriveFeedState is the dashboard's per-feed render brain: these tests pin which tabs exist,
-// per-tab content state, 401 signalling, ?new=space steering fire-once, and temporal stability.
+// per-tab content state, 401 signalling, the ?tab= URL parse, and temporal stability.
 // NOTE: a pure-helper suite cannot fail the original bug (the component gating all tabs on one
 // Promise.all before ANY tab painted) — the G4 real-browser progressive-paint smoke is the net
 // for that; these tests guard the derivation the component now renders from.
@@ -61,7 +61,7 @@ const allPending = (): FeedSlots => ({
   comments: pending,
 })
 
-const onSites = { requestedTab: 'sites', wantsNewSpace: false } as const
+const onSites = { requestedTab: 'sites' } as const
 
 // Every state a feed slot can be in — Comments' behavior must be invariant across all of them.
 const commentSlotStates: FeedSlot<CommentFeedItem[]>[] = [
@@ -73,20 +73,18 @@ const commentSlotStates: FeedSlot<CommentFeedItem[]>[] = [
 
 describe('deriveFeedState', () => {
   // T10.1 — mine resolved, everything else still pending: Your sites is renderable with rows
-  // immediately; Shared is ABSENT (not a skeleton tab) until its feed proves it has rows.
-  test('T10.1 sites resolve first: Your sites has rows, Shared absent, rest loading', () => {
+  // immediately; Shared and Spaces are ABSENT (not skeleton tabs) until their feeds prove rows.
+  test('T10.1 sites resolve first: Your sites has rows, Shared/Spaces absent, rest loading', () => {
     const mine = [site('a'), site('b')]
     const state = deriveFeedState({ ...allPending(), sites: resolved(mine) }, onSites)
 
     expect(state.tabs).toEqual([
       { id: 'sites', label: 'Your sites', count: 2, content: { kind: 'rows', rows: mine } },
-      { id: 'spaces', label: 'Your spaces', count: null, content: { kind: 'loading' } },
       { id: 'team', label: 'Team activity', count: null, content: { kind: 'loading' } },
       { id: 'comments', label: 'Comments', count: null, content: { kind: 'loading' } },
     ])
     expect(state.activeTab).toBe('sites')
     expect(state.unauthorized).toBe(false)
-    expect(state.steerTo).toBeNull()
   })
 
   // T10.2 — the Shared tab pops in only when its feed resolves with rows; an empty resolve keeps
@@ -98,7 +96,6 @@ describe('deriveFeedState', () => {
     expect(state.tabs).toEqual([
       { id: 'sites', label: 'Your sites', count: null, content: { kind: 'loading' } },
       { id: 'shared', label: 'Shared with me', count: 3, content: { kind: 'rows', rows: theirs } },
-      { id: 'spaces', label: 'Your spaces', count: null, content: { kind: 'loading' } },
       { id: 'team', label: 'Team activity', count: null, content: { kind: 'loading' } },
       { id: 'comments', label: 'Comments', count: null, content: { kind: 'loading' } },
     ])
@@ -106,7 +103,7 @@ describe('deriveFeedState', () => {
 
   test('T10.2 shared resolves empty: tab stays absent', () => {
     const state = deriveFeedState({ ...allPending(), shared: resolved([]) }, onSites)
-    expect(state.tabs.map((t) => t.id)).toEqual(['sites', 'spaces', 'team', 'comments'])
+    expect(state.tabs.map((t) => t.id)).toEqual(['sites', 'team', 'comments'])
   })
 
   // T10.3 — one failed feed degrades only its own tab; the rest render from their own slots.
@@ -157,37 +154,66 @@ describe('deriveFeedState', () => {
     // A non-401 shared failure means we cannot prove it has rows — the tab stays absent.
     const broken = deriveFeedState({ ...allPending(), shared: rejected(new ApiError(500, 'boom')) }, onSites)
     expect(broken.unauthorized).toBe(false)
-    expect(broken.tabs.map((t) => t.id)).toEqual(['sites', 'spaces', 'team', 'comments'])
+    expect(broken.tabs.map((t) => t.id)).toEqual(['sites', 'team', 'comments'])
   })
 
-  // T10.4 — ?new=space steers IMMEDIATELY (the Spaces tab always exists, so a slow/rejected feed
-  // must not kill the deep link); consuming the signal (requestedTab becomes 'spaces') makes
-  // every later derive return steerTo: null.
-  test('T10.4 ?new=space steers immediately, fires exactly once', () => {
-    const spaces = [space('personal', 'personal'), space('g1', 'group'), space('g2', 'group')]
-    const wants = { requestedTab: 'sites', wantsNewSpace: true } as const
+  // T10.4 — the Spaces tab mirrors Shared: it exists only once its feed resolves with at least
+  // one GROUP space. The personal space never earns the tab; a pending or failed feed keeps it
+  // absent (the toolbar, rendering off the same slot, surfaces a spaces-feed failure).
+  test('T10.4 spaces tab exists only when the feed resolves with group spaces', () => {
+    const absent = (slot: FeedSlot<SpaceSummary[]>) =>
+      deriveFeedState({ ...allPending(), spaces: slot }, onSites).tabs.map((t) => t.id)
 
-    // Pending spaces: steering fires anyway — the tab exists even before its feed settles.
-    const before = deriveFeedState(allPending(), wants)
-    expect(before.steerTo).toBe('spaces')
+    expect(absent(pending)).toEqual(['sites', 'team', 'comments'])
+    expect(absent(rejected(new Error('boom')))).toEqual(['sites', 'team', 'comments'])
+    expect(absent(resolved([]))).toEqual(['sites', 'team', 'comments'])
+    expect(absent(resolved([space('personal', 'personal')]))).toEqual(['sites', 'team', 'comments'])
 
-    // A rejected feed doesn't kill the deep link either.
-    const broken = deriveFeedState({ ...allPending(), spaces: rejected(new Error('boom')) }, wants)
-    expect(broken.steerTo).toBe('spaces')
-
-    // Resolve → count counts only GROUP spaces; steering still on while the active tab is elsewhere.
-    const fired = deriveFeedState({ ...allPending(), spaces: resolved(spaces) }, wants)
-    expect(fired.tabs.find((t) => t.id === 'spaces')?.count).toBe(2)
-    expect(fired.steerTo).toBe('spaces')
-
-    // The component consumes the signal by requesting 'spaces'; re-derives (fresh slot
-    // identities, same data, param still in the URL) must NOT re-fire.
-    const after = deriveFeedState(
-      { ...allPending(), spaces: resolved(spaces.map((s) => ({ ...s }))) },
-      { requestedTab: 'spaces', wantsNewSpace: true },
+    // Group spaces present → tab pops in, counting and listing ONLY the group spaces.
+    const groups = [space('g1', 'group'), space('g2', 'group')]
+    const state = deriveFeedState(
+      { ...allPending(), spaces: resolved([space('personal', 'personal'), ...groups]) },
+      onSites,
     )
-    expect(after.steerTo).toBeNull()
-    expect(after.activeTab).toBe('spaces')
+    expect(state.tabs.find((t) => t.id === 'spaces')).toEqual({
+      id: 'spaces',
+      label: 'Your spaces',
+      count: 2,
+      content: { kind: 'rows', rows: groups },
+    })
+  })
+
+  test('T10.4 requested Spaces without a spaces tab falls back to Your sites', () => {
+    const view = { requestedTab: 'spaces' } as const
+    expect(deriveFeedState(allPending(), view).activeTab).toBe('sites')
+    // The URL keeps ?tab=spaces, so once the feed proves group spaces the tab activates.
+    const landed = deriveFeedState({ ...allPending(), spaces: resolved([space('g', 'group')]) }, view)
+    expect(landed.activeTab).toBe('spaces')
+  })
+
+  // T10.6 — staleTab: a ?tab= pointing at an absent conditional tab is a legitimate deep link
+  // while the feed is pending, and STALE (component clears the param) once the feed settles
+  // without producing the tab.
+  test('T10.6 staleTab fires only after the governing feed settles without the tab', () => {
+    const wantSpaces = { requestedTab: 'spaces' } as const
+    expect(deriveFeedState(allPending(), wantSpaces).staleTab).toBe(false)
+    expect(deriveFeedState({ ...allPending(), spaces: resolved([]) }, wantSpaces).staleTab).toBe(true)
+    expect(
+      deriveFeedState({ ...allPending(), spaces: resolved([space('p', 'personal')]) }, wantSpaces).staleTab,
+    ).toBe(true)
+    expect(deriveFeedState({ ...allPending(), spaces: rejected(new Error('boom')) }, wantSpaces).staleTab).toBe(true)
+    expect(
+      deriveFeedState({ ...allPending(), spaces: resolved([space('g', 'group')]) }, wantSpaces).staleTab,
+    ).toBe(false)
+
+    const wantShared = { requestedTab: 'shared' } as const
+    expect(deriveFeedState(allPending(), wantShared).staleTab).toBe(false)
+    expect(deriveFeedState({ ...allPending(), shared: resolved([]) }, wantShared).staleTab).toBe(true)
+    expect(deriveFeedState({ ...allPending(), shared: resolved([site('x')]) }, wantShared).staleTab).toBe(false)
+
+    // Always-present tabs can never go stale.
+    expect(deriveFeedState(allPending(), onSites).staleTab).toBe(false)
+    expect(deriveFeedState(allPending(), { requestedTab: 'comments' }).staleTab).toBe(false)
   })
 
   // T10.5 — TEMPORAL: revalidation hands the component brand-new promise/slot/object identities
@@ -201,7 +227,7 @@ describe('deriveFeedState', () => {
       team: resolved([upload('t')]),
       comments: pending,
     })
-    const view = { requestedTab: 'team', wantsNewSpace: false } as const
+    const view = { requestedTab: 'team' } as const
 
     const first = deriveFeedState(build(), view)
     const second = deriveFeedState(build(), view)
@@ -212,19 +238,18 @@ describe('deriveFeedState', () => {
   })
 
   test('T10.5 shared pop-in while user sits on Team does not steal the active tab', () => {
-    const view = { requestedTab: 'team', wantsNewSpace: false } as const
+    const view = { requestedTab: 'team' } as const
     const before = deriveFeedState(allPending(), view)
     expect(before.activeTab).toBe('team')
-    expect(before.tabs.map((t) => t.id)).toEqual(['sites', 'spaces', 'team', 'comments'])
+    expect(before.tabs.map((t) => t.id)).toEqual(['sites', 'team', 'comments'])
 
     const after = deriveFeedState({ ...allPending(), shared: resolved([site('x')]) }, view)
-    expect(after.tabs.map((t) => t.id)).toEqual(['sites', 'shared', 'spaces', 'team', 'comments'])
+    expect(after.tabs.map((t) => t.id)).toEqual(['sites', 'shared', 'team', 'comments'])
     expect(after.activeTab).toBe('team')
-    expect(after.steerTo).toBeNull()
   })
 
   test('T10.5 active Shared tab disappearing (feed emptied) falls back to Your sites', () => {
-    const view = { requestedTab: 'shared', wantsNewSpace: false } as const
+    const view = { requestedTab: 'shared' } as const
     const withShared = deriveFeedState({ ...allPending(), shared: resolved([site('x')]) }, view)
     expect(withShared.activeTab).toBe('shared')
 
@@ -235,7 +260,7 @@ describe('deriveFeedState', () => {
   test('C5.1 comments tab is always present across every slot state', () => {
     for (const comments of commentSlotStates) {
       const state = deriveFeedState({ ...allPending(), comments }, onSites)
-      expect(state.tabs.map((tab) => tab.id)).toEqual(['sites', 'spaces', 'team', 'comments'])
+      expect(state.tabs.map((tab) => tab.id)).toEqual(['sites', 'team', 'comments'])
     }
   })
 
@@ -254,10 +279,7 @@ describe('deriveFeedState', () => {
 
   test('C5.1 requested Comments stays active across every slot state', () => {
     for (const comments of commentSlotStates) {
-      const state = deriveFeedState(
-        { ...allPending(), comments },
-        { requestedTab: 'comments', wantsNewSpace: false },
-      )
+      const state = deriveFeedState({ ...allPending(), comments }, { requestedTab: 'comments' })
       expect(state.activeTab).toBe('comments')
     }
   })
@@ -267,16 +289,10 @@ describe('deriveFeedState', () => {
       { ...allPending(), shared: resolved([site('shared')]) },
       onSites,
     )
-    expect(withShared.tabs.map((tab) => tab.id)).toEqual([
-      'sites',
-      'shared',
-      'spaces',
-      'team',
-      'comments',
-    ])
+    expect(withShared.tabs.map((tab) => tab.id)).toEqual(['sites', 'shared', 'team', 'comments'])
 
     const withoutShared = deriveFeedState({ ...allPending(), shared: resolved([]) }, onSites)
-    expect(withoutShared.tabs.map((tab) => tab.id)).toEqual(['sites', 'spaces', 'team', 'comments'])
+    expect(withoutShared.tabs.map((tab) => tab.id)).toEqual(['sites', 'team', 'comments'])
   })
 
   test('C5.2 five-wide derivation preserves representative four-feed goldens', () => {
@@ -287,17 +303,16 @@ describe('deriveFeedState', () => {
         expected: {
           tabs: [
             { id: 'sites', label: 'Your sites', count: null, content: { kind: 'loading' } },
-            { id: 'spaces', label: 'Your spaces', count: null, content: { kind: 'loading' } },
             { id: 'team', label: 'Team activity', count: null, content: { kind: 'loading' } },
           ],
           activeTab: 'sites',
           unauthorized: false,
-          steerTo: null,
+          staleTab: false,
         },
       },
       {
         slots: { ...allPending(), shared: resolved([site('shared')]) },
-        view: { requestedTab: 'team', wantsNewSpace: false } as const,
+        view: { requestedTab: 'team' } as const,
         expected: {
           tabs: [
             { id: 'sites', label: 'Your sites', count: null, content: { kind: 'loading' } },
@@ -307,40 +322,38 @@ describe('deriveFeedState', () => {
               count: 1,
               content: { kind: 'rows', rows: [site('shared')] },
             },
-            { id: 'spaces', label: 'Your spaces', count: null, content: { kind: 'loading' } },
             { id: 'team', label: 'Team activity', count: null, content: { kind: 'loading' } },
           ],
           activeTab: 'team',
           unauthorized: false,
-          steerTo: null,
+          staleTab: false,
         },
       },
       {
         slots: { ...allPending(), shared: resolved([]) },
-        view: { requestedTab: 'shared', wantsNewSpace: false } as const,
+        view: { requestedTab: 'shared' } as const,
         expected: {
           tabs: [
             { id: 'sites', label: 'Your sites', count: null, content: { kind: 'loading' } },
-            { id: 'spaces', label: 'Your spaces', count: null, content: { kind: 'loading' } },
             { id: 'team', label: 'Team activity', count: null, content: { kind: 'loading' } },
           ],
           activeTab: 'sites',
           unauthorized: false,
-          steerTo: null,
+          staleTab: true, // requested Shared, whose feed settled empty
         },
       },
       {
+        // The personal space alone never earns the Spaces tab.
         slots: { ...allPending(), spaces: resolved([space('personal', 'personal')]) },
-        view: { requestedTab: 'sites', wantsNewSpace: true } as const,
+        view: onSites,
         expected: {
           tabs: [
             { id: 'sites', label: 'Your sites', count: null, content: { kind: 'loading' } },
-            { id: 'spaces', label: 'Your spaces', count: 0, content: { kind: 'rows', rows: [] } },
             { id: 'team', label: 'Team activity', count: null, content: { kind: 'loading' } },
           ],
           activeTab: 'sites',
           unauthorized: false,
-          steerTo: 'spaces',
+          staleTab: false,
         },
       },
     ]
@@ -350,6 +363,20 @@ describe('deriveFeedState', () => {
       expect(state.tabs.at(-1)?.id).toBe('comments')
       expect({ ...state, tabs: state.tabs.filter((tab) => tab.id !== 'comments') }).toEqual(expected)
     }
+  })
+})
+
+describe('tabFromParam — the ?tab= URL parse', () => {
+  test('passes through every known tab id', () => {
+    for (const id of ['sites', 'shared', 'spaces', 'team', 'comments'] as const) {
+      expect(tabFromParam(id)).toBe(id)
+    }
+  })
+
+  test('falls back to sites for a missing or unknown value', () => {
+    expect(tabFromParam(null)).toBe('sites')
+    expect(tabFromParam('')).toBe('sites')
+    expect(tabFromParam('bogus')).toBe('sites')
   })
 })
 

--- a/packages/web/src/lib/feedState.ts
+++ b/packages/web/src/lib/feedState.ts
@@ -51,11 +51,11 @@ export interface FeedState {
   activeTab: TabId
   // Any feed rejecting with a 401 means the session lapsed; the component redirects to login.
   unauthorized: boolean
-  // ?tab= names a conditional tab whose feed has SETTLED without producing it (last group space
+  // ?tab= names a conditional tab whose feed has RESOLVED without producing it (last group space
   // deleted, deep link to a tab the user doesn't have). The component clears the param so the URL
   // matches reality — otherwise it's unreachable via the UI (re-clicking the already-active
   // fallback tab fires no onValueChange) and silently re-steals the view if the tab pops back.
-  // While the feed is still pending the param is a legitimate deep link waiting for its tab.
+  // A pending feed is a deep link still waiting for its tab; a rejected feed proves nothing.
   staleTab: boolean
 }
 
@@ -122,11 +122,14 @@ export function deriveFeedState(slots: FeedSlots, view: { requestedTab: TabId })
     tabs,
     activeTab: exists ? view.requestedTab : 'sites',
     unauthorized: Object.values(slots).some(isUnauthorized),
-    // Only Shared and Spaces can be absent; each goes stale once its own feed settles.
+    // Only Shared and Spaces can be absent; each goes stale only once its own feed RESOLVES
+    // without the tab. A rejected feed (transient 500, network blip, or the 401 that's about to
+    // redirect to login) proves nothing about the tab's absence — erasing the ?tab= deep link
+    // there would lose it across a refresh or the login round-trip.
     staleTab:
       !exists &&
-      ((view.requestedTab === 'shared' && slots.shared.status !== 'pending') ||
-        (view.requestedTab === 'spaces' && slots.spaces.status !== 'pending')),
+      ((view.requestedTab === 'shared' && slots.shared.status === 'resolved') ||
+        (view.requestedTab === 'spaces' && slots.spaces.status === 'resolved')),
   }
 }
 

--- a/packages/web/src/lib/feedState.ts
+++ b/packages/web/src/lib/feedState.ts
@@ -1,9 +1,9 @@
 // The dashboard's per-feed render brain. The route used to gate every tab on one Promise.all of
 // all five feeds; now the component holds one slot per feed (pending/resolved/rejected) and this
 // pure function derives the whole tab model from them, so each tab paints as its OWN feed settles.
-// Everything decision-shaped lives here, unit-tested: which tabs exist (Shared pops in only once
-// its feed resolves with rows), per-tab content (rows / skeleton / contained error), 401 → login
-// signal, the ?new=space steering signal, and stability (same data in new slot identities must
+// Everything decision-shaped lives here, unit-tested: which tabs exist (Shared and Spaces pop in
+// only once their feeds resolve with rows), per-tab content (rows / skeleton / contained error),
+// 401 → login signal, the ?tab= URL parse, and stability (same data in new slot identities must
 // derive an identical model, so revalidation can't churn tabs or steal the active one).
 
 import { ApiError } from './api'
@@ -25,6 +25,12 @@ export interface FeedSlots {
 
 export type TabId = 'sites' | 'shared' | 'spaces' | 'team' | 'comments'
 
+const TAB_IDS: readonly TabId[] = ['sites', 'shared', 'spaces', 'team', 'comments']
+
+/** Parse a ?tab= URL value: a known tab id passes through, anything else means 'sites'. */
+export const tabFromParam = (value: string | null): TabId =>
+  TAB_IDS.includes(value as TabId) ? (value as TabId) : 'sites'
+
 export type TabContent<T> =
   | { kind: 'loading' }
   | { kind: 'rows'; rows: T }
@@ -34,7 +40,7 @@ export type TabContent<T> =
 export type DashboardTab =
   | { id: 'sites'; label: 'Your sites'; count: number | null; content: TabContent<SiteSummary[]> }
   | { id: 'shared'; label: 'Shared with me'; count: number; content: TabContent<SiteSummary[]> }
-  | { id: 'spaces'; label: 'Your spaces'; count: number | null; content: TabContent<SpaceSummary[]> }
+  | { id: 'spaces'; label: 'Your spaces'; count: number; content: TabContent<SpaceSummary[]> }
   | { id: 'team'; label: 'Team activity'; count: null; content: TabContent<TeamUpload[]> }
   | { id: 'comments'; label: 'Comments'; count: null; content: TabContent<CommentFeedItem[]> }
 
@@ -45,12 +51,12 @@ export interface FeedState {
   activeTab: TabId
   // Any feed rejecting with a 401 means the session lapsed; the component redirects to login.
   unauthorized: boolean
-  // ?new=space steering: select the Spaces tab so NewSpaceDialog mounts + opens (#6). The Spaces
-  // tab always exists (a failed feed degrades inside it), so this fires immediately — gating on
-  // the feed resolving would kill the deep link whenever the feed is slow or rejected. Fires only
-  // while the active tab is elsewhere — the component consumes it by setting the requested tab,
-  // after which re-derives return null (fire-once).
-  steerTo: TabId | null
+  // ?tab= names a conditional tab whose feed has SETTLED without producing it (last group space
+  // deleted, deep link to a tab the user doesn't have). The component clears the param so the URL
+  // matches reality — otherwise it's unreachable via the UI (re-clicking the already-active
+  // fallback tab fires no onValueChange) and silently re-steals the view if the tab pops back.
+  // While the feed is still pending the param is a legitimate deep link waiting for its tab.
+  staleTab: boolean
 }
 
 const isUnauthorized = (slot: FeedSlot<unknown>): boolean =>
@@ -71,16 +77,15 @@ const contentOf = <T>(slot: FeedSlot<T>): TabContent<T> => {
   }
 }
 
-export function deriveFeedState(
-  slots: FeedSlots,
-  view: { requestedTab: TabId; wantsNewSpace: boolean },
-): FeedState {
+export function deriveFeedState(slots: FeedSlots, view: { requestedTab: TabId }): FeedState {
   const groupSpaces =
     slots.spaces.status === 'resolved' ? slots.spaces.data.filter((s) => s.type === 'group') : null
 
-  // Sites, Spaces, Team and Comments always exist (a failed feed degrades to a contained error INSIDE its
-  // tab). Shared exists only once its feed resolves with rows — no tab for an empty or unknown
-  // feed, so it pops in on resolve and disappears if a revalidation empties it.
+  // Sites, Team and Comments always exist (a failed feed degrades to a contained error INSIDE its
+  // tab). Shared and Spaces exist only once their feeds resolve with rows — no tab for an empty or
+  // unknown feed, so they pop in on resolve and disappear if a revalidation empties them. (For
+  // Spaces, "rows" means GROUP spaces — the personal space never earns the tab. A failed spaces
+  // feed also surfaces via the toolbar, which renders off the same slot.)
   const tabs: DashboardTab[] = [
     {
       id: 'sites',
@@ -98,23 +103,30 @@ export function deriveFeedState(
           } as const,
         ]
       : []),
-    {
-      id: 'spaces',
-      label: 'Your spaces',
-      count: groupSpaces === null ? null : groupSpaces.length,
-      content: groupSpaces === null ? contentOf(slots.spaces) : { kind: 'rows', rows: groupSpaces },
-    },
+    ...(groupSpaces !== null && groupSpaces.length > 0
+      ? [
+          {
+            id: 'spaces',
+            label: 'Your spaces',
+            count: groupSpaces.length,
+            content: { kind: 'rows', rows: groupSpaces },
+          } as const,
+        ]
+      : []),
     { id: 'team', label: 'Team activity', count: null, content: contentOf(slots.team) },
     { id: 'comments', label: 'Comments', count: null, content: contentOf(slots.comments) },
   ]
 
-  const activeTab = tabs.some((t) => t.id === view.requestedTab) ? view.requestedTab : 'sites'
-
+  const exists = tabs.some((t) => t.id === view.requestedTab)
   return {
     tabs,
-    activeTab,
+    activeTab: exists ? view.requestedTab : 'sites',
     unauthorized: Object.values(slots).some(isUnauthorized),
-    steerTo: view.wantsNewSpace && activeTab !== 'spaces' ? 'spaces' : null,
+    // Only Shared and Spaces can be absent; each goes stale once its own feed settles.
+    staleTab:
+      !exists &&
+      ((view.requestedTab === 'shared' && slots.shared.status !== 'pending') ||
+        (view.requestedTab === 'spaces' && slots.spaces.status !== 'pending')),
   }
 }
 

--- a/packages/web/src/lib/types.ts
+++ b/packages/web/src/lib/types.ts
@@ -28,6 +28,7 @@ export interface SpaceSummary {
 export interface SpaceDetail extends SpaceSummary {
   memberCount: number
   isMember: boolean
+  isOwner: boolean
 }
 
 export interface SiteSummary {

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -78,6 +78,14 @@ const router = createBrowserRouter([
     id: 'root',
     Component: AppShell,
     loader: rootLoader,
+    // Same-path search-only navigations (the dashboard's ?tab= / ?new= params) must not re-run
+    // this loader: it AWAITS /api/auth/me (so every tab click would block on a network round
+    // trip) and would hand the Bell/WhatsNew <Await>s fresh promise identities, re-suspending
+    // them to their unread=0 fallbacks. Mirrors the dashboard route's own shouldRevalidate.
+    shouldRevalidate: ({ currentUrl, nextUrl, defaultShouldRevalidate }) =>
+      currentUrl.pathname === nextUrl.pathname && currentUrl.search !== nextUrl.search
+        ? false
+        : defaultShouldRevalidate,
     ErrorBoundary: RootError,
     children: [
       { index: true, loader: () => redirect('/dashboard') },

--- a/packages/web/src/routes/dashboard.tsx
+++ b/packages/web/src/routes/dashboard.tsx
@@ -2,6 +2,7 @@ import { type ReactNode, useEffect, useState } from 'react'
 import {
   Link,
   Navigate,
+  type ShouldRevalidateFunctionArgs,
   useLoaderData,
   useLocation,
   useNavigate,
@@ -9,7 +10,7 @@ import {
   useRouteLoaderData,
   useSearchParams,
 } from 'react-router'
-import { ChevronDown, Download, ExternalLink, Mic, Plus, Rocket, Terminal, Upload } from 'lucide-react'
+import { ChevronDown, Download, Mic, Plus, Rocket, Terminal, Upload, Users } from 'lucide-react'
 import { toast } from 'sonner'
 import { CopyButton } from '@/components/CopyButton'
 import { DeployCard } from '@/components/DeployCard'
@@ -38,7 +39,6 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-  DialogTrigger,
 } from '@/components/ui/dialog'
 import {
   DropdownMenu,
@@ -58,8 +58,8 @@ import {
   type DashboardTab,
   type FeedSlot,
   type TabContent,
-  type TabId,
   feedRowPath,
+  tabFromParam,
 } from '@/lib/feedState'
 import { notificationHref } from '@/lib/mentions'
 import type { RootData } from '@/lib/notifications'
@@ -87,6 +87,26 @@ export function loader() {
     team: observed(api.get<TeamUpload[]>('/api/sites/team')),
     comments: observed(api.get<CommentFeedItem[]>('/api/comments/feed')),
   }
+}
+
+// The active tab (?tab=) and the create-space dialog (?new=space) live in the search params, so a
+// same-path search-only navigation must NOT re-run the loader — that would refire all five feed
+// calls on every tab click. Everything else (path changes, revalidator.revalidate() after a
+// mutation — where the URL is unchanged) keeps the default behavior.
+export function shouldRevalidate({
+  currentUrl,
+  nextUrl,
+  defaultShouldRevalidate,
+}: ShouldRevalidateFunctionArgs) {
+  if (currentUrl.pathname === nextUrl.pathname && currentUrl.search !== nextUrl.search) return false
+  return defaultShouldRevalidate
+}
+
+/** Copy-and-mutate helper for setSearchParams updaters (params come to us read-only). */
+const withParams = (prev: URLSearchParams, mutate: (next: URLSearchParams) => void) => {
+  const next = new URLSearchParams(prev)
+  mutate(next)
+  return next
 }
 
 // Sites shared with me — same table shell as Your sites, minus the owner-only actions.
@@ -154,22 +174,22 @@ export function Component() {
     team: useFeedSlot(loaded.team),
     comments: useFeedSlot(loaded.comments),
   }
-  const [searchParams] = useSearchParams()
+  const [searchParams, setSearchParams] = useSearchParams()
   const location = useLocation()
-  // Controlled tabs (Radix Tabs is otherwise uncontrolled): the user's pick is `requestedTab`;
-  // deriveFeedState reconciles it against the tabs that exist and the two URL/feed-driven steers.
-  const [requestedTab, setRequestedTab] = useState<TabId>('sites')
-  const state = deriveFeedState(slots, {
-    requestedTab,
-    // #6 — a deep link ?new=space (from CommandPalette/ShareDialog, even while already on
-    // /dashboard) must select the Spaces tab so NewSpaceDialog mounts + opens.
-    wantsNewSpace: searchParams.get('new') === 'space',
-  })
-  // Reconcile during render, not in an effect (the repo's idiom). This CONSUMES the steering
-  // signal: once requestedTab is 'spaces', the next derive returns steerTo: null — fire-once.
-  // It also makes the #38 fallback sticky (active Shared tab emptied away → land on Your sites).
-  const target = state.steerTo ?? state.activeTab
-  if (requestedTab !== target) setRequestedTab(target)
+  // The active tab lives in the URL (?tab=) so a refresh or a shared link lands on the same tab.
+  // deriveFeedState reconciles it against the tabs that actually exist; the URL is NOT rewritten
+  // on fallback, so a ?tab=shared deep link activates once the Shared tab pops in (#38: an active
+  // Shared tab emptied away falls back to Your sites the same way).
+  const state = deriveFeedState(slots, { requestedTab: tabFromParam(searchParams.get('tab')) })
+
+  // Drop a stale ?tab= (its feed settled without producing the tab) — see FeedState.staleTab.
+  // An effect, not a render-time set: this mutates the URL, and it must also run before the
+  // unauthorized early-return below to keep hook order stable.
+  useEffect(() => {
+    if (state.staleTab) {
+      setSearchParams((prev) => withParams(prev, (next) => next.delete('tab')), { replace: true })
+    }
+  }, [state.staleTab, setSearchParams])
 
   // Any feed 401'd — the session lapsed. Bounce to login, preserving where we were.
   if (state.unauthorized) {
@@ -182,7 +202,25 @@ export function Component() {
     <div className="space-y-10">
       <ToolbarSection spaces={slots.spaces} />
       <AgentSetup />
-      <Tabs value={state.activeTab} onValueChange={(t) => setRequestedTab(t as TabId)} className="gap-6">
+      {/* Mounted at the route level (not inside a tab), so ?new=space opens it from anywhere. */}
+      <NewSpaceDialog />
+      <Tabs
+        value={state.activeTab}
+        onValueChange={(t) => {
+          // Radix fires onValueChange twice per click (click, then focus) because the controlled
+          // value only catches up after our async URL update. The refire would be a same-URL
+          // navigation — which React Router treats as "revalidate every loader". Dedupe against
+          // the LIVE URL (not a closure/state snapshot: the refire happens before the re-render,
+          // but history has already been updated synchronously).
+          if (t === tabFromParam(new URLSearchParams(window.location.search).get('tab'))) return
+          setSearchParams(
+            // 'sites' is the default — keep the landing URL clean instead of pinning ?tab=sites.
+            (prev) => withParams(prev, (next) => (t === 'sites' ? next.delete('tab') : next.set('tab', t))),
+            { replace: true },
+          )
+        }}
+        className="gap-6"
+      >
         <TabsList variant="line">
           {state.tabs.map((tab) => (
             <TabsTrigger key={tab.id} value={tab.id}>
@@ -206,11 +244,15 @@ export function Component() {
 function ToolbarSection({ spaces }: { spaces: FeedSlot<SpaceSummary[]> }) {
   if (spaces.status === 'pending') return <ToolbarSkeleton />
   if (spaces.status === 'rejected') {
+    // Keep the New menu alive on a failed feed — with the Spaces tab now conditional, it's the
+    // page's only create-space affordance. The deploy pickers degrade inside their own dialogs.
     return (
-      <EmptyState
-        title="Couldn't load the deploy form"
-        description={errorMessage(spaces.error, 'Something went wrong. Try refreshing.')}
-      />
+      <div className="space-y-2">
+        <DashboardToolbar spaces={[]} />
+        <p className="text-destructive text-sm" role="alert">
+          Couldn't load your spaces — {errorMessage(spaces.error, 'something went wrong. Try refreshing.')}
+        </p>
+      </div>
     )
   }
   return <DashboardToolbar spaces={spaces.data} />
@@ -246,30 +288,12 @@ function TabBody({ tab }: { tab: DashboardTab }) {
         </TabPanel>
       )
     case 'spaces':
-      // The New-space row renders in every content state so ?new=space can open the dialog (#6)
-      // even while the feed is still loading. Rows here are the GROUP spaces (helper-filtered).
+      // The tab only exists when the feed resolved with GROUP spaces (helper-filtered), so no
+      // empty state; New space lives in the top New menu.
       return (
-        <div className="space-y-4">
-          <div className="flex justify-end">
-            <NewSpaceDialog />
-          </div>
-          <TabPanel content={tab.content} what="your spaces">
-            {(groupSpaces) =>
-              groupSpaces.length === 0 ? (
-                <EmptyState
-                  title="No group spaces"
-                  description="Create a space to collaborate with teammates."
-                />
-              ) : (
-                <div className="grid gap-3 sm:grid-cols-2">
-                  {groupSpaces.map((s) => (
-                    <SpaceCard key={s.id} space={s} />
-                  ))}
-                </div>
-              )
-            }
-          </TabPanel>
-        </div>
+        <TabPanel content={tab.content} what="your spaces">
+          {(groupSpaces) => <SpacesTable spaces={groupSpaces} />}
+        </TabPanel>
       )
     case 'team':
       return (
@@ -504,9 +528,11 @@ function AgentSetup() {
 }
 
 // One primary button opens a menu: Record audio (RecordDialog) · Upload files (UploadDialog wrapping
-// the bare DeployCard) · Install the CLI (the one-liner). onSelect closes the menu, then opens the
-// controlled dialog rendered as a sibling — no nesting, so focus returns cleanly on close.
+// the bare DeployCard) · Create space (?new=space → the route-level NewSpaceDialog) · Install the
+// CLI (the one-liner). onSelect closes the menu, then opens the controlled dialog rendered as a
+// sibling — no nesting, so focus returns cleanly on close.
 function NewMenu({ spaces }: { spaces: SpaceSummary[] }) {
+  const [, setSearchParams] = useSearchParams()
   const [recordOpen, setRecordOpen] = useState(false)
   const [uploadOpen, setUploadOpen] = useState(false)
   const [installOpen, setInstallOpen] = useState(false)
@@ -534,6 +560,19 @@ function NewMenu({ spaces }: { spaces: SpaceSummary[] }) {
             <div className="flex flex-col">
               <span>Upload files</span>
               <span className="text-muted-foreground text-xs">Drop a folder, get a URL</span>
+            </div>
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onSelect={() =>
+              setSearchParams((prev) => withParams(prev, (next) => next.set('new', 'space')), {
+                replace: true,
+              })
+            }
+          >
+            <Users />
+            <div className="flex flex-col">
+              <span>Create space</span>
+              <span className="text-muted-foreground text-xs">Share sites with a group</span>
             </div>
           </DropdownMenuItem>
           <DropdownMenuSeparator />
@@ -597,17 +636,41 @@ function UploadDialog({
 
 // ─── Your spaces ─────────────────────────────────────────────────────────────
 
-function SpaceCard({ space }: { space: SpaceSummary }) {
-  return (
-    <Card className="gap-0 py-0 transition-colors hover:border-primary/40">
-      <Link to={`/${space.slug}`} className="flex items-center justify-between gap-3 p-4">
-        <div className="min-w-0">
-          <p className="truncate font-medium">{space.name}</p>
-          <p className="font-mono text-sm text-muted-foreground">/{space.slug}</p>
-        </div>
-        <ExternalLink className="size-4 shrink-0 text-muted-foreground" />
+// Same table shell as the site feeds — one system across every collection on the dashboard.
+const SPACE_COLUMNS: Column<SpaceSummary>[] = [
+  {
+    key: 'name',
+    label: 'Name',
+    headClassName: 'max-w-[15rem]',
+    cellClassName: 'max-w-[15rem]',
+    compare: (a, b) => a.name.localeCompare(b.name),
+    render: (s) => (
+      <Link to={`/${s.slug}`} className="block truncate font-medium hover:underline">
+        {s.name}
       </Link>
-    </Card>
+    ),
+  },
+  {
+    key: 'path',
+    label: 'Path',
+    compare: (a, b) => a.slug.localeCompare(b.slug),
+    render: (s) => <span className="font-mono text-sm text-muted-foreground">/{s.slug}</span>,
+  },
+  actionsColumn((s) => (
+    <Button asChild variant="outline" size="sm">
+      <Link to={`/${s.slug}`}>Open</Link>
+    </Button>
+  )),
+]
+
+function SpacesTable({ spaces }: { spaces: SpaceSummary[] }) {
+  return (
+    <SortableTable
+      rows={spaces}
+      columns={SPACE_COLUMNS}
+      getRowKey={(s) => s.id}
+      initialSort={{ key: 'name', dir: 'asc' }}
+    />
   )
 }
 
@@ -615,27 +678,22 @@ function NewSpaceDialog() {
   const navigate = useNavigate()
   const revalidator = useRevalidator()
   const [searchParams, setSearchParams] = useSearchParams()
-  const [internalOpen, setInternalOpen] = useState(false)
   const [slug, setSlug] = useState('')
   const [name, setName] = useState('')
   const [saving, setSaving] = useState(false)
 
-  // Open LIVE from the URL: CommandPalette/ShareDialog navigate to ?new=space while already on
-  // /dashboard, so a mount-time initializer (which never re-runs) would silently no-op (#6).
-  // Reading the param each render catches every arrival.
-  const open = internalOpen || searchParams.get('new') === 'space'
+  // Driven ENTIRELY by the URL: NewMenu, CommandPalette and ShareDialog all set ?new=space (even
+  // while already on /dashboard — reading the param each render catches every arrival, #6), and
+  // closing clears the param so the still-present URL doesn't immediately reopen the dialog.
+  const open = searchParams.get('new') === 'space'
   const setOpen = (o: boolean) => {
-    setInternalOpen(o)
-    // Clear the param on close so the still-present URL doesn't immediately reopen the dialog.
-    if (!o && searchParams.get('new') === 'space') {
-      setSearchParams(
-        (prev) => {
-          const next = new URLSearchParams(prev)
-          next.delete('new')
-          return next
-        },
-        { replace: true },
-      )
+    if (!o) {
+      // Reset the fields so a reopened dialog doesn't show a previous attempt's draft.
+      setSlug('')
+      setName('')
+      if (open) {
+        setSearchParams((prev) => withParams(prev, (next) => next.delete('new')), { replace: true })
+      }
     }
   }
 
@@ -662,12 +720,6 @@ function NewSpaceDialog() {
 
   return (
     <Dialog open={open} onOpenChange={(o) => !saving && setOpen(o)}>
-      <DialogTrigger asChild>
-        <Button variant="outline" size="sm">
-          <Plus />
-          New space
-        </Button>
-      </DialogTrigger>
       <DialogContent>
         <DialogHeader>
           <DialogTitle>Create a space</DialogTitle>

--- a/packages/web/src/routes/space.tsx
+++ b/packages/web/src/routes/space.tsx
@@ -84,14 +84,17 @@ function InviteMembersDialog({ slug }: { slug: string }) {
       const results = await Promise.allSettled(
         picks.map((email) => api.post(`/api/spaces/${slug}/members`, { email })),
       )
-      const failed = results.filter((r) => r.status === 'rejected')
+      const failed = picks.filter((_, i) => results[i].status === 'rejected')
       if (failed.length === 0) {
         toast.success(picks.length === 1 ? 'Member invited' : `${picks.length} members invited`)
         setOpen(false)
       } else {
-        const first = failed[0].reason
+        // Keep ONLY the failed picks selected so the open dialog shows exactly what needs
+        // retrying, and name them — a bare count doesn't say which invite went wrong.
+        setSelected(new Set(failed))
+        const first = (results.find((r) => r.status === 'rejected') as PromiseRejectedResult).reason
         toast.error(`${failed.length} of ${picks.length} invites failed`, {
-          description: first instanceof Error ? first.message : undefined,
+          description: `${failed.join(', ')}${first instanceof Error ? ` — ${first.message}` : ''}`,
         })
       }
       if (failed.length < picks.length) revalidator.revalidate()
@@ -260,7 +263,8 @@ export function Component() {
           </span>
         }
       >
-        {isGroup && <InviteMembersDialog slug={space.slug} />}
+        {/* Invite is owner-only server-side — don't offer a button that can only 403. */}
+        {isGroup && space.isOwner && <InviteMembersDialog slug={space.slug} />}
       </PageHeader>
 
       <section className="space-y-4">

--- a/packages/web/src/routes/space.tsx
+++ b/packages/web/src/routes/space.tsx
@@ -1,45 +1,41 @@
-import {
-  type ActionFunctionArgs,
-  type LoaderFunctionArgs,
-  useFetcher,
-  useLoaderData,
-  useNavigate,
-} from 'react-router'
-import { ExternalLink, Mic, Trash2, UserPlus } from 'lucide-react'
+import { useCallback, useState } from 'react'
+import { type LoaderFunctionArgs, useLoaderData, useNavigate, useRevalidator } from 'react-router'
+import { ExternalLink, Search, Share2, Trash2, UserPlus } from 'lucide-react'
 import { toast } from 'sonner'
 import { CopyButton } from '@/components/CopyButton'
 import { ConfirmDialog } from '@/components/ConfirmDialog'
-import { ShareDialog } from '@/components/ShareDialog'
+import { PickerRow, ShareDialog } from '@/components/ShareDialog'
+import {
+  actionsColumn,
+  createdColumn,
+  nameColumn,
+  OpenLinkButton,
+  urlColumn,
+  visibilityBadgeColumn,
+} from '@/components/siteColumns'
+import { SortableTable, type Column } from '@/components/SortableTable'
 import { EmptyState, PageHeader, SectionHeader, Spinner } from '@/components/states'
-import { VisibilityBadge } from '@/components/visibility'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from '@/components/ui/card'
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
+import { MountSensor } from '@/components/ui/mount-sensor'
 import { Separator } from '@/components/ui/separator'
 import { api, ApiError } from '@/lib/api'
 import { toLogin } from '@/lib/nav'
-import type { SpaceDetail, Visibility } from '@/lib/types'
-import { cn } from '@/lib/utils'
+import type { SiteSummary, SpaceDetail, UserLite } from '@/lib/types'
 
-interface SpaceSite {
-  id: string
-  spaceSlug: string
-  siteSlug: string
-  title: string | null
-  visibility: Visibility
-  status: 'active' | 'archived'
+// GET /api/spaces/:slug/sites returns the shared feed-row shape plus per-row ownership.
+interface SpaceSite extends SiteSummary {
   isOwner: boolean
-  audio?: boolean
-  url: string
-  createdAt: string
 }
 
 export async function loader({ params, request }: LoaderFunctionArgs) {
@@ -55,93 +51,155 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
   }
 }
 
-export async function action({ request, params }: ActionFunctionArgs) {
-  const email = String((await request.formData()).get('email') ?? '')
-  try {
-    await api.post(`/api/spaces/${params.space}/members`, { email })
-    return { ok: true as const }
-  } catch (err) {
-    return { error: err instanceof ApiError ? err.message : 'Invite failed' }
+// Invite members via a modal with the company directory (same picker rows as ShareDialog) instead
+// of a free-text email form. Multi-select, then one POST per pick — the API invites by email and
+// is idempotent for existing members. Directory loads on open via MountSensor (Radix mounts the
+// content each open). On any success the route revalidates so the member count stays honest.
+function InviteMembersDialog({ slug }: { slug: string }) {
+  const revalidator = useRevalidator()
+  const [open, setOpen] = useState(false)
+  const [busy, setBusy] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [users, setUsers] = useState<UserLite[]>([])
+  const [selected, setSelected] = useState<Set<string>>(new Set()) // emails — the API's invite key
+  const [q, setQ] = useState('')
+
+  const loadOnMount = useCallback(() => {
+    setBusy(true)
+    setSelected(new Set())
+    setQ('')
+    api
+      .get<UserLite[]>('/api/users')
+      .then(setUsers)
+      .catch((err) =>
+        toast.error('Could not load people', { description: err instanceof Error ? err.message : undefined }),
+      )
+      .finally(() => setBusy(false))
+  }, [])
+
+  async function invite() {
+    setSaving(true)
+    try {
+      const picks = [...selected]
+      const results = await Promise.allSettled(
+        picks.map((email) => api.post(`/api/spaces/${slug}/members`, { email })),
+      )
+      const failed = results.filter((r) => r.status === 'rejected')
+      if (failed.length === 0) {
+        toast.success(picks.length === 1 ? 'Member invited' : `${picks.length} members invited`)
+        setOpen(false)
+      } else {
+        const first = failed[0].reason
+        toast.error(`${failed.length} of ${picks.length} invites failed`, {
+          description: first instanceof Error ? first.message : undefined,
+        })
+      }
+      if (failed.length < picks.length) revalidator.revalidate()
+    } finally {
+      setSaving(false)
+    }
   }
-}
 
-type InviteResult = { ok?: boolean; error?: string }
-
-function InviteCard() {
-  const fetcher = useFetcher<InviteResult>()
-  const busy = fetcher.state !== 'idle'
-  const data = fetcher.data
+  const needle = q.trim().toLowerCase()
+  const shown = needle
+    ? users.filter((u) => u.email.toLowerCase().includes(needle) || (u.name ?? '').toLowerCase().includes(needle))
+    : users
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>Invite a member</CardTitle>
-        <CardDescription>Add a teammate by email to grant them access to this space.</CardDescription>
-      </CardHeader>
-      <CardContent className="space-y-4">
-        <fetcher.Form method="post" className="flex flex-col gap-3 sm:flex-row sm:items-end">
-          <div className="flex-1 space-y-1.5">
-            <Label htmlFor="invite-email">Email</Label>
-            <Input
-              id="invite-email"
-              name="email"
-              type="email"
-              placeholder="teammate@example.com"
-              required
-              disabled={busy}
-              autoComplete="email"
-            />
+    <Dialog open={open} onOpenChange={(o) => !saving && setOpen(o)}>
+      <DialogTrigger asChild>
+        <Button variant="outline" size="sm">
+          <UserPlus />
+          Invite members
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-md">
+        <MountSensor onMount={loadOnMount} />
+        <DialogHeader>
+          <DialogTitle>Invite members</DialogTitle>
+          <DialogDescription>Pick teammates to grant them access to this space.</DialogDescription>
+        </DialogHeader>
+
+        {busy ? (
+          <div className="flex items-center justify-center py-10 text-muted-foreground">
+            <Spinner className="size-5" />
           </div>
-          <Button type="submit" disabled={busy} className="sm:w-28">
-            {busy ? <Spinner /> : <UserPlus />}
+        ) : (
+          <div className="space-y-1.5">
+            <div className="relative">
+              <Search className="absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
+              <Input value={q} onChange={(e) => setQ(e.target.value)} placeholder="Search people…" className="pl-8" />
+            </div>
+            <div className="max-h-56 space-y-0.5 overflow-y-auto">
+              {shown.length === 0 ? (
+                <p className="px-2 py-6 text-center text-sm text-muted-foreground">No people found.</p>
+              ) : (
+                shown.map((u) => (
+                  <PickerRow
+                    key={u.id}
+                    checked={selected.has(u.email)}
+                    onToggle={() =>
+                      setSelected((s) => {
+                        const next = new Set(s)
+                        if (next.has(u.email)) next.delete(u.email)
+                        else next.add(u.email)
+                        return next
+                      })
+                    }
+                    label={u.name ?? u.email}
+                    sub={u.name ? u.email : undefined}
+                  />
+                ))
+              )}
+            </div>
+          </div>
+        )}
+
+        <DialogFooter className="sm:justify-between">
+          <span className="self-center text-xs text-muted-foreground">
+            {selected.size === 0 ? 'No one selected' : `${selected.size} selected`}
+          </span>
+          <Button onClick={invite} disabled={busy || saving || selected.size === 0}>
+            {saving && <Spinner />}
             Invite
           </Button>
-        </fetcher.Form>
-
-        {data?.ok && (
-          <output className="block rounded-md border border-success/30 bg-success/15 px-3 py-2 text-sm font-medium text-success">
-            Invited.
-          </output>
-        )}
-        {data?.error && (
-          <div
-            role="alert"
-            className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm font-medium text-destructive"
-          >
-            {data.error}
-          </div>
-        )}
-      </CardContent>
-    </Card>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   )
 }
 
-function SiteCard({ site }: { site: SpaceSite }) {
-  const archived = site.status === 'archived'
+// Same table shell as the dashboard feeds; per-row actions add Share for sites the caller owns.
+const SPACE_SITE_COLUMNS: Column<SpaceSite>[] = [
+  nameColumn(),
+  urlColumn(),
+  visibilityBadgeColumn(),
+  createdColumn(),
+  actionsColumn((s) => <SpaceSiteActions site={s} />),
+]
+
+function SpaceSiteActions({ site }: { site: SpaceSite }) {
+  const [shareOpen, setShareOpen] = useState(false)
   return (
-    <Card className={cn(archived && 'opacity-75')}>
-      <CardHeader>
-        <div className="flex flex-wrap items-center gap-2">
-          {site.audio && <Mic className="size-4 shrink-0 text-primary" aria-label="Audio" />}
-          <CardTitle className="min-w-0 truncate text-base">{site.title ?? site.siteSlug}</CardTitle>
-          <VisibilityBadge value={site.visibility} />
-          {archived && <Badge variant="secondary">Archived</Badge>}
-        </div>
-        <CardDescription className="truncate font-mono text-xs">{site.url}</CardDescription>
-      </CardHeader>
-      <CardContent className="flex flex-wrap items-center gap-2">
-        <Button asChild variant="secondary" size="sm">
-          <a href={site.url} target="_blank" rel="noreferrer">
-            <ExternalLink />
-            Open
-          </a>
-        </Button>
-        <CopyButton text={site.url} />
-        {site.isOwner && (
-          <ShareDialog spaceSlug={site.spaceSlug} siteSlug={site.siteSlug} title={site.title} />
-        )}
-      </CardContent>
-    </Card>
+    <div className="flex items-center justify-end gap-1">
+      <CopyButton text={site.url} label="" variant="outline" />
+      <OpenLinkButton url={site.url} />
+      {site.isOwner && (
+        <>
+          <Button variant="outline" size="sm" onClick={() => setShareOpen(true)}>
+            <Share2 />
+            Share
+          </Button>
+          <ShareDialog
+            spaceSlug={site.spaceSlug}
+            siteSlug={site.siteSlug}
+            title={site.title}
+            open={shareOpen}
+            onOpenChange={setShareOpen}
+          />
+        </>
+      )}
+    </div>
   )
 }
 
@@ -201,9 +259,9 @@ export function Component() {
             <span className="font-mono">/{space.slug}</span>
           </span>
         }
-      />
-
-      {isGroup && <InviteCard />}
+      >
+        {isGroup && <InviteMembersDialog slug={space.slug} />}
+      </PageHeader>
 
       <section className="space-y-4">
         <SectionHeader index={1} title="Sites" />
@@ -214,11 +272,12 @@ export function Component() {
             description="No sites you can access here yet."
           />
         ) : (
-          <div className="grid gap-4 sm:grid-cols-2">
-            {sites.map((s) => (
-              <SiteCard key={s.id} site={s} />
-            ))}
-          </div>
+          <SortableTable
+            rows={sites}
+            columns={SPACE_SITE_COLUMNS}
+            getRowKey={(s) => s.id}
+            initialSort={{ key: 'created', dir: 'desc' }}
+          />
         )}
       </section>
 


### PR DESCRIPTION
Dashboard/space-page UX cleanup, per review of the current UI.

## What changed

### Tabs live in the URL
The active dashboard tab is now `?tab=` — refresh and shared links land on the same tab. Search-only navigations skip **both** the dashboard and root loaders (`shouldRevalidate` on each), and Radix Tabs' click+focus double-fire is deduped against the live URL, so a tab click issues **zero** network calls (browser-verified with a fetch counter; previously each click re-ran all 7 loaders including a blocking `/api/auth/me`). A stale `?tab=` pointing at a tab whose feed settled away self-clears.

### "Your spaces" is conditional + a table
The Spaces tab now mirrors "Shared with me": it only exists once the feed resolves with ≥1 group space, and renders in the shared table shell instead of cards. "New space" moved into the top **New** menu ("Create space"); `NewSpaceDialog` is mounted at the route level and driven purely by `?new=space`, so the CommandPalette/ShareDialog deep links keep working from any tab (the palette now merges params instead of clobbering the active tab). The `steerTo` steering machinery in `feedState` is deleted.

### Space page: invite modal with a user picker
The invite-a-member email form became a modal listing the company directory (`GET /api/users`) with search + multi-select — one `POST /members` per pick, member count revalidates. Sites on the space page use the same `SortableTable` as the dashboard feeds, with per-row Copy/Open/Share.

### Header brand mark
The glowing yellow box in `AppShell`/`ViewerTopBar` is replaced with the favicon brand mark, keeping the primary glow.

## Screenshots

| | |
|---|---|
| ![dashboard](https://github.com/plivo-labs/glance/releases/download/ui-cleanup-shots/dashboard-sites.png) | ![new menu](https://github.com/plivo-labs/glance/releases/download/ui-cleanup-shots/new-menu.png) |
| ![spaces tab](https://github.com/plivo-labs/glance/releases/download/ui-cleanup-shots/dashboard-spaces.png) | ![space page](https://github.com/plivo-labs/glance/releases/download/ui-cleanup-shots/space-page.png) |
| ![invite modal](https://github.com/plivo-labs/glance/releases/download/ui-cleanup-shots/invite-modal.png) | |

## Verification
- 179 web tests pass (feedState suite rewritten: conditional Spaces tab, `tabFromParam`, `staleTab`); `tsc` + biome clean.
- Browser-verified on the local stack: refresh keeps the tab, `?tab=spaces&new=space` opens the dialog on the right tab, 3 tab clicks + arrow-key nav = 0 API calls, invited 2 users → member count 1 → 3.
- Two adversarial multi-agent review rounds; round 1's 5 confirmed findings (root-loader revalidation, stale-tab trap, palette param clobber, lost create affordance on feed failure, dialog field reset) are fixed in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016dv7KJaqLKi7bsnwQtU8sF
