### PR TITLE
fix: roomier Slack comment snippet (1500 chars) + ellipsis on truncation

### DIFF
--- a/packages/api/src/db/comment-feed.test.ts
+++ b/packages/api/src/db/comment-feed.test.ts
@@ -730,7 +730,7 @@ describe('assembleCommentFeed', () => {
     expect(authored).toEqual({
       kind: 'authored',
       id: 'authored-payload',
-      snippet: 'x'.repeat(200),
+      snippet: `${'x'.repeat(200)}…`,
       actorName: null,
       spaceSlug: 'authored-space',
       siteSlug: 'authored-site',
@@ -763,8 +763,8 @@ describe('assembleCommentFeed', () => {
       memberSpaceIds: new Set(),
       sharedSiteRoles: new Map(),
     })
-    expect(surrogateItem?.snippet?.length).toBe(199)
-    expect(surrogateItem?.snippet).toBe('x'.repeat(199))
+    expect(surrogateItem?.snippet?.length).toBe(200)
+    expect(surrogateItem?.snippet).toBe(`${'x'.repeat(199)}…`)
 
     // The notification snippet is a write-time snapshot: editing or deleting its source comment
     // later does not change the feed payload.

--- a/packages/api/src/db/comment-feed.ts
+++ b/packages/api/src/db/comment-feed.ts
@@ -127,9 +127,13 @@ type FeedCandidate =
 
 const KIND_RANK = { mention: 0, authored: 1, owned: 2 } as const
 
-export function truncateSnippet(body: string): string {
-  const s = body.slice(0, FEED_SNIPPET_LENGTH)
-  return s.length === FEED_SNIPPET_LENGTH && /[\uD800-\uDBFF]$/.test(s) ? s.slice(0, -1) : s
+/** Cap a comment body for a notification surface. A body within the cap passes through untouched;
+ *  a longer one is cut (never splitting a surrogate pair) and marked with an ellipsis so the cut
+ *  reads as a preview, not a lost message. */
+export function truncateSnippet(body: string, max = FEED_SNIPPET_LENGTH): string {
+  if (body.length <= max) return body
+  const s = body.slice(0, max)
+  return `${/[\uD800-\uDBFF]$/.test(s) ? s.slice(0, -1) : s}…`
 }
 
 function compareFeedCandidates(a: FeedCandidate, b: FeedCandidate): number {

--- a/packages/api/src/lib/slack.ts
+++ b/packages/api/src/lib/slack.ts
@@ -177,6 +177,11 @@ export function formatSlackMessage(input: SlackMessageInput, appUrl: string): st
   return lines.join('\n')
 }
 
+// Slack DMs can carry far more than the in-app feed's 200-char snippet (chat.postMessage allows
+// ~40k chars of text), so the Slack quote gets its own, roomier cap — 1500 keeps a long comment
+// readable in the DM without flooding it.
+export const SLACK_SNIPPET_LENGTH = 1_500
+
 const POST_URL = 'https://slack.com/api/chat.postMessage'
 // Cap on Slack DMs per comment event, mentions first — bounds the blast radius of a wide @-everyone
 // or a large shared audience. Slack-ONLY: the in-app fan-out (createNotifications) is intentionally

--- a/packages/api/src/routes/comments-slack.test.ts
+++ b/packages/api/src/routes/comments-slack.test.ts
@@ -86,6 +86,22 @@ describe('W — comment route fans out to Slack', () => {
     expect(posts[0].text).toContain('&amp;review=1')
   })
 
+  test('W1b: long comment → Slack quote cut at 1500 + ellipsis, in-app snippet cut at 200 + ellipsis', async () => {
+    const { app, env, db, kv, owner } = await seedCommentApp({ ownerEmail: 'owner@x.com', commenterEmail: 'c@x.com' })
+    await kv.put('slackuid:owner@x.com', 'Uowner')
+    const { fetchImpl, posts } = slackFetch()
+    const res = await postComment(app, bindings(env, { SLACK_BOT_TOKEN: 'xoxb', SLACK_FETCH: fetchImpl }), {
+      body: `${'a'.repeat(1500)}TAIL`,
+      filePath: 'index.html',
+    })
+    expect(res.status).toBe(201)
+    expect(posts).toHaveLength(1)
+    expect(posts[0].text).toContain(`> _${'a'.repeat(1500)}…_`) // Slack cap, marked as a cut
+    expect(posts[0].text).not.toContain('TAIL')
+    const inApp = await listNotifications(db, owner)
+    expect(inApp.items[0]?.snippet).toBe(`${'a'.repeat(200)}…`) // feed cap unchanged, marked as a cut
+  })
+
   test('W2: 1 mention + 1 comment recipient → 2 posts, mention body first', async () => {
     const { app, env, db, kv } = await seedCommentApp({ ownerEmail: 'owner@x.com', commenterEmail: 'c@x.com' })
     const mentioned = await seedUser(db, { id: 'mtn', email: 'mtn@x.com' })

--- a/packages/api/src/routes/comments.ts
+++ b/packages/api/src/routes/comments.ts
@@ -22,7 +22,14 @@ import {
   resolveCommentAudience,
   usersEmailsByIds,
 } from '../db/notifications'
-import { deliverSlack, type SlackReason, type SlackRecipient, slackDepsFromEnv, slackEnabled } from '../lib/slack'
+import {
+  deliverSlack,
+  SLACK_SNIPPET_LENGTH,
+  type SlackReason,
+  type SlackRecipient,
+  slackDepsFromEnv,
+  slackEnabled,
+} from '../lib/slack'
 import type { Comment, CommentThread } from '../db/schema'
 import { listMentionableUsers } from '../db/repo'
 import { fireAndForget } from '../lib/events'
@@ -230,11 +237,13 @@ async function notifyForComment(
           audience.map((a) => toRow(a.id, a.reason === 'mention' ? 'mention' : 'comment')),
         )
 
+        // Slack DMs get their own, roomier cut of the SAME body — the 200-char snippet above is
+        // sized for the in-app feed, not for Slack.
         await deliverSlackForComment(c, audience, {
           siteLabel,
           filePath: opts.filePath,
           threadId: opts.threadId,
-          snippet,
+          snippet: truncateSnippet(opts.snippet, SLACK_SNIPPET_LENGTH),
         })
       } catch {
         // Notifications are best-effort — never surface to the caller (mirrors recordEvent).

--- a/packages/api/src/routes/mentions.test.ts
+++ b/packages/api/src/routes/mentions.test.ts
@@ -337,7 +337,7 @@ describe('S2 C1 TRACER — JSON thread without mentions notifies the owner', () 
       filePath: 'index.html',
       threadId: created.threadId,
       commentId: created.openingCommentId,
-      snippet: body.slice(0, 200),
+      snippet: `${body.slice(0, 200)}…`,
     })
   })
 })


### PR DESCRIPTION
## Problem

Slack comment notifications quoted the same 200-char snippet that's sized for the in-app feed, with no ellipsis — a long comment got cut mid-word ("…the pubnub chann") and read as a broken/lost message.

## Changes

- `truncateSnippet` (comment-feed.ts) gains a `max` param and appends `…` only when it actually cuts. Bodies within the cap pass through untouched; the surrogate-pair guard is preserved.
- The Slack fan-out (`deliverSlackForComment`) now receives its own cut of the same body at `SLACK_SNIPPET_LENGTH = 1500` (chat.postMessage allows ~40k, so no Slack-side reason to stay at 200). In-app notification rows and the feed keep the 200-char cap.

## Tests

- New route-level test `W1b`: a 1504-char comment → Slack quote is first 1500 chars + `…`, in-app row is first 200 + `…`.
- Updated pinned expectations (`C3.4`, `S2 C1`) for the ellipsis; at-cap/under-cap bodies still pass through unchanged.
- `bun test packages/api`: 853 pass. `bun run typecheck` + biome lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U9okkQMxHCFCX5J1VgjxBL