### PR TITLE
Simplify pass on #88 + 16px brand mark

### DIFF
--- a/packages/web/src/components/AppShell.tsx
+++ b/packages/web/src/components/AppShell.tsx
@@ -6,6 +6,7 @@ import { api } from '@/lib/api'
 import { toggleTheme, useTheme } from '@/components/theme'
 import { CommandPalette } from '@/components/CommandPalette'
 import { HelpButton } from '@/components/HelpButton'
+import { BrandMark } from '@/components/states'
 import { NotificationsBell } from '@/components/NotificationsBell'
 import { WhatsNewButton } from '@/components/WhatsNewButton'
 import { Avatar, AvatarFallback } from '@/components/ui/avatar'
@@ -61,8 +62,7 @@ export function AppShell() {
       <header className="sticky top-0 z-40 border-b border-border/70 bg-background/80 backdrop-blur-md">
         <div className="mx-auto flex h-14 max-w-6xl items-center gap-3 px-4 sm:px-6">
           <Link to="/dashboard" className="flex items-center gap-2 font-mono text-sm font-semibold tracking-tight">
-            {/* The brand mark (favicon.svg), keeping the old yellow box's primary glow. */}
-            <img src="/favicon.svg" alt="" className="size-5 rounded-[5px] shadow-[0_0_12px_1px_var(--primary)]" />
+            <BrandMark />
             glance
           </Link>
           {user && (

--- a/packages/web/src/components/CommandPalette.tsx
+++ b/packages/web/src/components/CommandPalette.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/components/ui/command'
 import { toggleTheme } from '@/components/theme'
 import { api } from '@/lib/api'
+import { newSpaceHref } from '@/lib/nav'
 import { encodePathSegments } from '@/lib/paths'
 import { siteName, useRecents, visibleEntries } from '@/lib/recents'
 import type { Me, SiteSummary, SpaceSummary } from '@/lib/types'
@@ -174,16 +175,7 @@ export function CommandPalette({
               Admin
             </CommandItem>
           )}
-          <CommandItem
-            onSelect={() =>
-              run(() => {
-                // Merge, don't clobber: already on /dashboard means an active ?tab= to preserve.
-                const params = new URLSearchParams(location.pathname === '/dashboard' ? location.search : '')
-                params.set('new', 'space')
-                navigate(`/dashboard?${params}`)
-              })
-            }
-          >
+          <CommandItem onSelect={() => run(() => navigate(newSpaceHref(location)))}>
             <Plus />
             New space
           </CommandItem>

--- a/packages/web/src/components/ShareDialog.tsx
+++ b/packages/web/src/components/ShareDialog.tsx
@@ -1,8 +1,9 @@
-import { useCallback, useState } from 'react'
-import { useNavigate } from 'react-router'
+import { type ReactNode, useCallback, useState } from 'react'
+import { useLocation, useNavigate } from 'react-router'
 import { Check, Plus, Search, Share2 } from 'lucide-react'
 import { toast } from 'sonner'
 import { api } from '@/lib/api'
+import { newSpaceHref } from '@/lib/nav'
 import { buildSharePayload } from '@/lib/shares'
 import type { ShareRole, ShareSet, SpaceSummary, UserLite } from '@/lib/types'
 import { Button } from '@/components/ui/button'
@@ -28,9 +29,12 @@ type Props = {
   // parent (e.g. a dropdown-menu item). Uncontrolled (default) keeps its own Share button.
   open?: boolean
   onOpenChange?: (open: boolean) => void
+  // Uncontrolled trigger's label — tight table rows shorten it to "Share".
+  triggerLabel?: string
 }
 
-function toggle(set: Set<string>, id: string): Set<string> {
+// Shared with the space page's invite dialog — one Set-toggle for every picker selection.
+export function toggle(set: Set<string>, id: string): Set<string> {
   const next = new Set(set)
   if (next.has(id)) next.delete(id)
   else next.add(id)
@@ -49,8 +53,16 @@ function toggleUser(map: Map<string, ShareRole>, id: string): Map<string, ShareR
 // site's visibility tier. Data loads on open via a ref-callback on the dialog content (Radix
 // mounts it on every open — and a controlled/external open does NOT fire Radix onOpenChange,
 // so the load can't live there); Save replaces the whole set via PUT.
-export function ShareDialog({ spaceSlug, siteSlug, title, open: openProp, onOpenChange }: Props) {
+export function ShareDialog({
+  spaceSlug,
+  siteSlug,
+  title,
+  open: openProp,
+  onOpenChange,
+  triggerLabel = 'Share with people & groups',
+}: Props) {
   const navigate = useNavigate()
+  const location = useLocation()
   const [internalOpen, setInternalOpen] = useState(false)
   const controlled = openProp !== undefined
   const open = controlled ? openProp : internalOpen
@@ -63,7 +75,6 @@ export function ShareDialog({ spaceSlug, siteSlug, title, open: openProp, onOpen
   // shared. Groups stay a plain Set — they're always view-only.
   const [selUsers, setSelUsers] = useState<Map<string, ShareRole>>(new Map())
   const [selGroups, setSelGroups] = useState<Set<string>>(new Set())
-  const [q, setQ] = useState('')
 
   const loadOnMount = useCallback(
     () => {
@@ -103,10 +114,6 @@ export function ShareDialog({ spaceSlug, siteSlug, title, open: openProp, onOpen
     }
   }
 
-  const needle = q.trim().toLowerCase()
-  const shownUsers = needle
-    ? users.filter((u) => u.email.toLowerCase().includes(needle) || (u.name ?? '').toLowerCase().includes(needle))
-    : users
   const count = selUsers.size + selGroups.size
 
   return (
@@ -115,7 +122,7 @@ export function ShareDialog({ spaceSlug, siteSlug, title, open: openProp, onOpen
         <DialogTrigger asChild>
           <Button variant="outline" size="sm">
             <Share2 />
-            Share with people &amp; groups
+            {triggerLabel}
           </Button>
         </DialogTrigger>
       )}
@@ -160,7 +167,7 @@ export function ShareDialog({ spaceSlug, siteSlug, title, open: openProp, onOpen
                   className="mt-2"
                   onClick={() => {
                     setOpen(false)
-                    navigate('/dashboard?new=space')
+                    navigate(newSpaceHref(location))
                   }}
                 >
                   <Plus />
@@ -171,38 +178,17 @@ export function ShareDialog({ spaceSlug, siteSlug, title, open: openProp, onOpen
 
             <div className="space-y-1.5">
               <p className="text-xs font-medium text-muted-foreground">People</p>
-              <div className="relative">
-                <Search className="absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
-                <Input
-                  value={q}
-                  onChange={(e) => setQ(e.target.value)}
-                  placeholder="Search people…"
-                  className="pl-8"
-                />
-              </div>
-              <div className="max-h-56 space-y-0.5 overflow-y-auto">
-                {shownUsers.length === 0 ? (
-                  <p className="px-2 py-6 text-center text-sm text-muted-foreground">No people found.</p>
-                ) : (
-                  shownUsers.map((u) => {
-                    const role = selUsers.get(u.id)
-                    return (
-                      <div key={u.id} className="flex items-center gap-2">
-                        <PickerRow
-                          className="flex-1"
-                          checked={role !== undefined}
-                          onToggle={() => setSelUsers((s) => toggleUser(s, u.id))}
-                          label={u.name ?? u.email}
-                          sub={u.name ? u.email : undefined}
-                        />
-                        {role !== undefined && (
-                          <RolePicker role={role} onChange={(r) => setSelUsers((s) => new Map(s).set(u.id, r))} />
-                        )}
-                      </div>
-                    )
-                  })
-                )}
-              </div>
+              <PeoplePicker
+                users={users}
+                checked={(u) => selUsers.has(u.id)}
+                onToggle={(u) => setSelUsers((s) => toggleUser(s, u.id))}
+                trailing={(u) => {
+                  const role = selUsers.get(u.id)
+                  return role !== undefined ? (
+                    <RolePicker role={role} onChange={(r) => setSelUsers((s) => new Map(s).set(u.id, r))} />
+                  ) : null
+                }}
+              />
             </div>
           </div>
         )}
@@ -218,6 +204,53 @@ export function ShareDialog({ spaceSlug, siteSlug, title, open: openProp, onOpen
         </DialogFooter>
       </DialogContent>
     </Dialog>
+  )
+}
+
+// Searchable directory list of PickerRows — the shared core of the share and invite dialogs.
+// Owns its query state, so it resets naturally with the dialog content that hosts it (Radix
+// remounts content on every open). `trailing` renders per-row extras (e.g. the RolePicker).
+export function PeoplePicker({
+  users,
+  checked,
+  onToggle,
+  trailing,
+}: {
+  users: UserLite[]
+  checked: (u: UserLite) => boolean
+  onToggle: (u: UserLite) => void
+  trailing?: (u: UserLite) => ReactNode
+}) {
+  const [q, setQ] = useState('')
+  const needle = q.trim().toLowerCase()
+  const shown = needle
+    ? users.filter((u) => u.email.toLowerCase().includes(needle) || (u.name ?? '').toLowerCase().includes(needle))
+    : users
+  return (
+    <div className="space-y-1.5">
+      <div className="relative">
+        <Search className="absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
+        <Input value={q} onChange={(e) => setQ(e.target.value)} placeholder="Search people…" className="pl-8" />
+      </div>
+      <div className="max-h-56 space-y-0.5 overflow-y-auto">
+        {shown.length === 0 ? (
+          <p className="px-2 py-6 text-center text-sm text-muted-foreground">No people found.</p>
+        ) : (
+          shown.map((u) => (
+            <div key={u.id} className="flex items-center gap-2">
+              <PickerRow
+                className="flex-1"
+                checked={checked(u)}
+                onToggle={() => onToggle(u)}
+                label={u.name ?? u.email}
+                sub={u.name ? u.email : undefined}
+              />
+              {trailing?.(u)}
+            </div>
+          ))
+        )}
+      </div>
+    </div>
   )
 }
 

--- a/packages/web/src/components/ViewerTopBar.tsx
+++ b/packages/web/src/components/ViewerTopBar.tsx
@@ -13,7 +13,7 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { ShareDialog } from '@/components/ShareDialog'
 import { SummarySheet } from '@/components/SummarySheet'
-import { Spinner } from '@/components/states'
+import { BrandMark, Spinner } from '@/components/states'
 
 // The persistent top chrome for the viewer: brand (→ dashboard) + a breadcrumb, then one action
 // row that stays put across modes — Fork, TL;DR, Comments (with an open count, outside review),
@@ -48,8 +48,7 @@ export function ViewerTopBar({
   return (
     <header className="flex h-12 shrink-0 items-center gap-2 border-b bg-background px-3 md:gap-3">
       <Link to="/dashboard" className="flex shrink-0 items-center gap-2 font-mono font-semibold text-sm tracking-tight">
-        {/* The brand mark (favicon.svg), keeping the old yellow box's primary glow. */}
-        <img src="/favicon.svg" alt="" className="size-5 rounded-[5px] shadow-[0_0_12px_1px_var(--primary)]" />
+        <BrandMark />
         glance
       </Link>
 

--- a/packages/web/src/components/siteColumns.tsx
+++ b/packages/web/src/components/siteColumns.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react'
 import { ExternalLink, Mic, Sparkles } from 'lucide-react'
+import { CopyButton } from '@/components/CopyButton'
 import type { Column } from '@/components/SortableTable'
 import { VisibilityBadge } from '@/components/visibility'
 import { Badge } from '@/components/ui/badge'
@@ -83,6 +84,23 @@ export function OpenLinkButton({ url }: { url: string }) {
 // the buttons (Open + kebab / Copy + Open / Open).
 export function actionsColumn<T>(render: (row: T) => ReactNode): Column<T> {
   return { key: 'actions', label: '', headClassName: 'text-right', cellClassName: 'text-right', render }
+}
+
+// The read-only feed table — Name / URL / Visibility / Created plus caller-supplied trailing
+// actions. Shared by the dashboard's "Shared with me" tab and the space page's sites table.
+export function feedColumns<T extends SiteSummary>(actions: (row: T) => ReactNode): Column<T>[] {
+  return [nameColumn(), urlColumn(), visibilityBadgeColumn(), createdColumn(), actionsColumn(actions)]
+}
+
+/** Copy + Open trailing cell; `children` appends row-specific extras (e.g. an owner's Share). */
+export function CopyOpenActions({ url, children }: { url: string; children?: ReactNode }) {
+  return (
+    <div className="flex items-center justify-end gap-1">
+      <CopyButton text={url} label="" variant="outline" />
+      <OpenLinkButton url={url} />
+      {children}
+    </div>
+  )
 }
 
 export function createdColumn<T extends SiteSummary>(key = 'created', label = 'Created'): Column<T> {

--- a/packages/web/src/components/states.tsx
+++ b/packages/web/src/components/states.tsx
@@ -7,7 +7,7 @@ export function Spinner({ className }: { className?: string }) {
 
 /** The brand mark (favicon.svg) with the primary glow — the header logo in AppShell and the viewer. */
 export function BrandMark() {
-  return <img src="/favicon.svg" alt="" className="size-4 rounded-[4px] shadow-[0_0_12px_1px_var(--primary)]" />
+  return <img src="/favicon.svg" alt="" className="size-4 rounded-[4px] shadow-[0_0_8px_0_var(--primary)]" />
 }
 
 export function PageHeader({

--- a/packages/web/src/components/states.tsx
+++ b/packages/web/src/components/states.tsx
@@ -5,6 +5,11 @@ export function Spinner({ className }: { className?: string }) {
   return <Loader2 className={cn('size-4 animate-spin', className)} />
 }
 
+/** The brand mark (favicon.svg) with the primary glow — the header logo in AppShell and the viewer. */
+export function BrandMark() {
+  return <img src="/favicon.svg" alt="" className="size-4 rounded-[4px] shadow-[0_0_12px_1px_var(--primary)]" />
+}
+
 export function PageHeader({
   title,
   description,

--- a/packages/web/src/lib/feedState.test.ts
+++ b/packages/web/src/lib/feedState.test.ts
@@ -95,7 +95,7 @@ describe('deriveFeedState', () => {
 
     expect(state.tabs).toEqual([
       { id: 'sites', label: 'Your sites', count: null, content: { kind: 'loading' } },
-      { id: 'shared', label: 'Shared with me', count: 3, content: { kind: 'rows', rows: theirs } },
+      { id: 'shared', label: 'Shared with me', count: 3, rows: theirs },
       { id: 'team', label: 'Team activity', count: null, content: { kind: 'loading' } },
       { id: 'comments', label: 'Comments', count: null, content: { kind: 'loading' } },
     ])
@@ -122,18 +122,8 @@ describe('deriveFeedState', () => {
 
     expect(state.tabs).toEqual([
       { id: 'sites', label: 'Your sites', count: 1, content: { kind: 'rows', rows: mine } },
-      {
-        id: 'shared',
-        label: 'Shared with me',
-        count: 1,
-        content: { kind: 'rows', rows: [site('s')] },
-      },
-      {
-        id: 'spaces',
-        label: 'Your spaces',
-        count: 1,
-        content: { kind: 'rows', rows: [space('g', 'group')] },
-      },
+      { id: 'shared', label: 'Shared with me', count: 1, rows: [site('s')] },
+      { id: 'spaces', label: 'Your spaces', count: 1, rows: [space('g', 'group')] },
       { id: 'team', label: 'Team activity', count: null, content: { kind: 'error', message: 'D1 exploded' } },
       { id: 'comments', label: 'Comments', count: null, content: { kind: 'loading' } },
     ])
@@ -179,7 +169,7 @@ describe('deriveFeedState', () => {
       id: 'spaces',
       label: 'Your spaces',
       count: 2,
-      content: { kind: 'rows', rows: groups },
+      rows: groups,
     })
   })
 
@@ -321,12 +311,7 @@ describe('deriveFeedState', () => {
         expected: {
           tabs: [
             { id: 'sites', label: 'Your sites', count: null, content: { kind: 'loading' } },
-            {
-              id: 'shared',
-              label: 'Shared with me',
-              count: 1,
-              content: { kind: 'rows', rows: [site('shared')] },
-            },
+            { id: 'shared', label: 'Shared with me', count: 1, rows: [site('shared')] },
             { id: 'team', label: 'Team activity', count: null, content: { kind: 'loading' } },
           ],
           activeTab: 'team',

--- a/packages/web/src/lib/feedState.ts
+++ b/packages/web/src/lib/feedState.ts
@@ -23,9 +23,8 @@ export interface FeedSlots {
   comments: FeedSlot<CommentFeedItem[]>
 }
 
-export type TabId = 'sites' | 'shared' | 'spaces' | 'team' | 'comments'
-
-const TAB_IDS: readonly TabId[] = ['sites', 'shared', 'spaces', 'team', 'comments']
+export const TAB_IDS = ['sites', 'shared', 'spaces', 'team', 'comments'] as const
+export type TabId = (typeof TAB_IDS)[number]
 
 /** Parse a ?tab= URL value: a known tab id passes through, anything else means 'sites'. */
 export const tabFromParam = (value: string | null): TabId =>
@@ -37,10 +36,12 @@ export type TabContent<T> =
   | { kind: 'error'; message: string }
 
 // Discriminated on `id` so the component can switch and get the right row type per tab.
+// Shared and Spaces exist only when their feed resolved with rows, so they carry `rows`
+// directly — a conditional tab being "loading" or "errored" is unrepresentable.
 export type DashboardTab =
   | { id: 'sites'; label: 'Your sites'; count: number | null; content: TabContent<SiteSummary[]> }
-  | { id: 'shared'; label: 'Shared with me'; count: number; content: TabContent<SiteSummary[]> }
-  | { id: 'spaces'; label: 'Your spaces'; count: number; content: TabContent<SpaceSummary[]> }
+  | { id: 'shared'; label: 'Shared with me'; count: number; rows: SiteSummary[] }
+  | { id: 'spaces'; label: 'Your spaces'; count: number; rows: SpaceSummary[] }
   | { id: 'team'; label: 'Team activity'; count: null; content: TabContent<TeamUpload[]> }
   | { id: 'comments'; label: 'Comments'; count: null; content: TabContent<CommentFeedItem[]> }
 
@@ -94,24 +95,10 @@ export function deriveFeedState(slots: FeedSlots, view: { requestedTab: TabId })
       content: contentOf(slots.sites),
     },
     ...(slots.shared.status === 'resolved' && slots.shared.data.length > 0
-      ? [
-          {
-            id: 'shared',
-            label: 'Shared with me',
-            count: slots.shared.data.length,
-            content: { kind: 'rows', rows: slots.shared.data },
-          } as const,
-        ]
+      ? [{ id: 'shared', label: 'Shared with me', count: slots.shared.data.length, rows: slots.shared.data } as const]
       : []),
     ...(groupSpaces !== null && groupSpaces.length > 0
-      ? [
-          {
-            id: 'spaces',
-            label: 'Your spaces',
-            count: groupSpaces.length,
-            content: { kind: 'rows', rows: groupSpaces },
-          } as const,
-        ]
+      ? [{ id: 'spaces', label: 'Your spaces', count: groupSpaces.length, rows: groupSpaces } as const]
       : []),
     { id: 'team', label: 'Team activity', count: null, content: contentOf(slots.team) },
     { id: 'comments', label: 'Comments', count: null, content: contentOf(slots.comments) },
@@ -122,14 +109,11 @@ export function deriveFeedState(slots: FeedSlots, view: { requestedTab: TabId })
     tabs,
     activeTab: exists ? view.requestedTab : 'sites',
     unauthorized: Object.values(slots).some(isUnauthorized),
-    // Only Shared and Spaces can be absent; each goes stale only once its own feed RESOLVES
-    // without the tab. A rejected feed (transient 500, network blip, or the 401 that's about to
-    // redirect to login) proves nothing about the tab's absence — erasing the ?tab= deep link
+    // An absent tab can only be Shared or Spaces; it goes stale only once its own feed RESOLVES
+    // without producing it. A rejected feed (transient 500, network blip, or the 401 that's about
+    // to redirect to login) proves nothing about the tab's absence — erasing the ?tab= deep link
     // there would lose it across a refresh or the login round-trip.
-    staleTab:
-      !exists &&
-      ((view.requestedTab === 'shared' && slots.shared.status === 'resolved') ||
-        (view.requestedTab === 'spaces' && slots.spaces.status === 'resolved')),
+    staleTab: !exists && slots[view.requestedTab].status === 'resolved',
   }
 }
 

--- a/packages/web/src/lib/nav.ts
+++ b/packages/web/src/lib/nav.ts
@@ -1,4 +1,25 @@
-import { redirect } from 'react-router'
+import { redirect, type ShouldRevalidateFunctionArgs } from 'react-router'
+
+// The dashboard keeps UI state in the URL (?tab=, ?new=). React Router's default treats any
+// search change as "re-run every matched loader", so routes whose loaders don't read the search
+// string opt out of same-path search-only navigations with this predicate. Same-URL navigations
+// keep the default — that's how revalidator.revalidate() still reaches them.
+export function skipSearchOnlyRevalidation({
+  currentUrl,
+  nextUrl,
+  defaultShouldRevalidate,
+}: ShouldRevalidateFunctionArgs) {
+  if (currentUrl.pathname === nextUrl.pathname && currentUrl.search !== nextUrl.search) return false
+  return defaultShouldRevalidate
+}
+
+/** Href that opens the create-space dialog (?new=space on /dashboard), preserving the active
+ *  ?tab= when already there — the one spelling of this intent for every navigator. */
+export function newSpaceHref(location: { pathname: string; search: string }): string {
+  const params = new URLSearchParams(location.pathname === '/dashboard' ? location.search : '')
+  params.set('new', 'space')
+  return `/dashboard?${params}`
+}
 
 // Post-login return-URL helpers. The OAuth round-trip carries the intended path as a
 // `next` query param; these keep it same-origin so it can't become an open redirect.

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -12,6 +12,7 @@ import { AppShell } from './components/AppShell'
 import { Button } from './components/ui/button'
 import { Toaster } from './components/ui/sonner'
 import { api, ApiError } from './lib/api'
+import { skipSearchOnlyRevalidation } from './lib/nav'
 import { EMPTY_NOTIFICATIONS, type RootData, notifications } from './lib/notifications'
 import type { Me } from './lib/types'
 import { EMPTY_WHATS_NEW, whatsNew } from './lib/whatsNew'
@@ -78,14 +79,9 @@ const router = createBrowserRouter([
     id: 'root',
     Component: AppShell,
     loader: rootLoader,
-    // Same-path search-only navigations (the dashboard's ?tab= / ?new= params) must not re-run
-    // this loader: it AWAITS /api/auth/me (so every tab click would block on a network round
-    // trip) and would hand the Bell/WhatsNew <Await>s fresh promise identities, re-suspending
-    // them to their unread=0 fallbacks. Mirrors the dashboard route's own shouldRevalidate.
-    shouldRevalidate: ({ currentUrl, nextUrl, defaultShouldRevalidate }) =>
-      currentUrl.pathname === nextUrl.pathname && currentUrl.search !== nextUrl.search
-        ? false
-        : defaultShouldRevalidate,
+    // This loader AWAITS /api/auth/me and its promises feed the Bell/WhatsNew <Await>s — a
+    // search-only re-run would block the navigation and flash those badges to zero.
+    shouldRevalidate: skipSearchOnlyRevalidation,
     ErrorBoundary: RootError,
     children: [
       { index: true, loader: () => redirect('/dashboard') },

--- a/packages/web/src/routes/dashboard.tsx
+++ b/packages/web/src/routes/dashboard.tsx
@@ -1,12 +1,10 @@
-import { type ReactNode, useEffect, useState } from 'react'
+import { type ReactNode, useEffect, useMemo, useState } from 'react'
 import {
   Link,
   Navigate,
-  type ShouldRevalidateFunctionArgs,
   useLoaderData,
   useLocation,
   useNavigate,
-  useRevalidator,
   useRouteLoaderData,
   useSearchParams,
 } from 'react-router'
@@ -18,7 +16,8 @@ import { GettingStarted } from '@/components/GettingStarted'
 import { RecordDialog } from '@/components/record/RecordDialog'
 import {
   actionsColumn,
-  createdColumn,
+  CopyOpenActions,
+  feedColumns,
   nameColumn,
   OpenLinkButton,
   updatedColumn,
@@ -58,9 +57,11 @@ import {
   type DashboardTab,
   type FeedSlot,
   type TabContent,
+  type TabId,
   feedRowPath,
   tabFromParam,
 } from '@/lib/feedState'
+import { skipSearchOnlyRevalidation } from '@/lib/nav'
 import { notificationHref } from '@/lib/mentions'
 import type { RootData } from '@/lib/notifications'
 import { timeAgo } from '@/lib/time'
@@ -89,18 +90,9 @@ export function loader() {
   }
 }
 
-// The active tab (?tab=) and the create-space dialog (?new=space) live in the search params, so a
-// same-path search-only navigation must NOT re-run the loader — that would refire all five feed
-// calls on every tab click. Everything else (path changes, revalidator.revalidate() after a
-// mutation — where the URL is unchanged) keeps the default behavior.
-export function shouldRevalidate({
-  currentUrl,
-  nextUrl,
-  defaultShouldRevalidate,
-}: ShouldRevalidateFunctionArgs) {
-  if (currentUrl.pathname === nextUrl.pathname && currentUrl.search !== nextUrl.search) return false
-  return defaultShouldRevalidate
-}
+// The active tab (?tab=) and the create-space dialog (?new=space) live in the search params — a
+// search-only navigation must not refire all five feed calls.
+export const shouldRevalidate = skipSearchOnlyRevalidation
 
 /** Copy-and-mutate helper for setSearchParams updaters (params come to us read-only). */
 const withParams = (prev: URLSearchParams, mutate: (next: URLSearchParams) => void) => {
@@ -109,19 +101,32 @@ const withParams = (prev: URLSearchParams, mutate: (next: URLSearchParams) => vo
   return next
 }
 
+// All ?tab= WRITE mechanics in one place: clearing a stale param (see FeedState.staleTab — an
+// effect, not a render-time set, since it mutates the URL) and the guarded tab-switch path.
+// The guard dedupes Radix's double-fire: Tabs calls onValueChange twice per click (click, then
+// focus) because the controlled value only catches up after our async URL update, and the refire
+// would be a same-URL navigation — which React Router treats as "revalidate every loader". It
+// compares against the LIVE URL, not render state: the refire lands before the re-render, but
+// history has already been updated synchronously.
+function useSetTabParam(staleTab: boolean): (t: TabId) => void {
+  const [, setSearchParams] = useSearchParams()
+  useEffect(() => {
+    if (staleTab) {
+      setSearchParams((prev) => withParams(prev, (next) => next.delete('tab')), { replace: true })
+    }
+  }, [staleTab, setSearchParams])
+  return (t) => {
+    if (t === tabFromParam(new URLSearchParams(window.location.search).get('tab'))) return
+    setSearchParams(
+      // 'sites' is the default — keep the landing URL clean instead of pinning ?tab=sites.
+      (prev) => withParams(prev, (next) => (t === 'sites' ? next.delete('tab') : next.set('tab', t))),
+      { replace: true },
+    )
+  }
+}
+
 // Sites shared with me — same table shell as Your sites, minus the owner-only actions.
-const SHARED_COLUMNS: Column<SiteSummary>[] = [
-  nameColumn(),
-  urlColumn(),
-  visibilityBadgeColumn(),
-  createdColumn(),
-  actionsColumn((s) => (
-    <div className="flex items-center justify-end gap-1">
-      <CopyButton text={s.url} label="" variant="outline" />
-      <OpenLinkButton url={s.url} />
-    </div>
-  )),
-]
+const SHARED_COLUMNS = feedColumns<SiteSummary>((s) => <CopyOpenActions url={s.url} />)
 
 function SharedSitesTable({ sites }: { sites: SiteSummary[] }) {
   return (
@@ -167,29 +172,27 @@ export function Component() {
     team: Promise<TeamUpload[]>
     comments: Promise<CommentFeedItem[]>
   }
-  const slots = {
-    sites: useFeedSlot(loaded.sites),
-    shared: useFeedSlot(loaded.shared),
-    spaces: useFeedSlot(loaded.spaces),
-    team: useFeedSlot(loaded.team),
-    comments: useFeedSlot(loaded.comments),
-  }
-  const [searchParams, setSearchParams] = useSearchParams()
+  const sites = useFeedSlot(loaded.sites)
+  const shared = useFeedSlot(loaded.shared)
+  const spaces = useFeedSlot(loaded.spaces)
+  const team = useFeedSlot(loaded.team)
+  const comments = useFeedSlot(loaded.comments)
+  const [searchParams] = useSearchParams()
   const location = useLocation()
   // The active tab lives in the URL (?tab=) so a refresh or a shared link lands on the same tab.
   // deriveFeedState reconciles it against the tabs that actually exist; the URL is NOT rewritten
   // on fallback, so a ?tab=shared deep link activates once the Shared tab pops in (#38: an active
-  // Shared tab emptied away falls back to Your sites the same way).
-  const state = deriveFeedState(slots, { requestedTab: tabFromParam(searchParams.get('tab')) })
-
-  // Drop a stale ?tab= (its feed settled without producing the tab) — see FeedState.staleTab.
-  // An effect, not a render-time set: this mutates the URL, and it must also run before the
-  // unauthorized early-return below to keep hook order stable.
-  useEffect(() => {
-    if (state.staleTab) {
-      setSearchParams((prev) => withParams(prev, (next) => next.delete('tab')), { replace: true })
-    }
-  }, [state.staleTab, setSearchParams])
+  // Shared tab emptied away falls back to Your sites the same way). Memoized so `tabs` and every
+  // `rows` array keep their identity across unrelated re-renders (SortableTable's sort memo).
+  const state = useMemo(
+    () =>
+      deriveFeedState(
+        { sites, shared, spaces, team, comments },
+        { requestedTab: tabFromParam(searchParams.get('tab')) },
+      ),
+    [sites, shared, spaces, team, comments, searchParams],
+  )
+  const setTab = useSetTabParam(state.staleTab)
 
   // Any feed 401'd — the session lapsed. Bounce to login, preserving where we were.
   if (state.unauthorized) {
@@ -200,27 +203,11 @@ export function Component() {
 
   return (
     <div className="space-y-10">
-      <ToolbarSection spaces={slots.spaces} />
+      <ToolbarSection spaces={spaces} />
       <AgentSetup />
       {/* Mounted at the route level (not inside a tab), so ?new=space opens it from anywhere. */}
       <NewSpaceDialog />
-      <Tabs
-        value={state.activeTab}
-        onValueChange={(t) => {
-          // Radix fires onValueChange twice per click (click, then focus) because the controlled
-          // value only catches up after our async URL update. The refire would be a same-URL
-          // navigation — which React Router treats as "revalidate every loader". Dedupe against
-          // the LIVE URL (not a closure/state snapshot: the refire happens before the re-render,
-          // but history has already been updated synchronously).
-          if (t === tabFromParam(new URLSearchParams(window.location.search).get('tab'))) return
-          setSearchParams(
-            // 'sites' is the default — keep the landing URL clean instead of pinning ?tab=sites.
-            (prev) => withParams(prev, (next) => (t === 'sites' ? next.delete('tab') : next.set('tab', t))),
-            { replace: true },
-          )
-        }}
-        className="gap-6"
-      >
+      <Tabs value={state.activeTab} onValueChange={(t) => setTab(t as TabId)} className="gap-6">
         <TabsList variant="line">
           {state.tabs.map((tab) => (
             <TabsTrigger key={tab.id} value={tab.id}>
@@ -281,20 +268,12 @@ function TabBody({ tab }: { tab: DashboardTab }) {
           }
         </TabPanel>
       )
+    // Shared and Spaces exist only resolved-with-rows (feedState), so they render rows directly —
+    // no loading/error states to handle. New space lives in the top New menu.
     case 'shared':
-      return (
-        <TabPanel content={tab.content} what="shared sites">
-          {(shared) => <SharedSitesTable sites={shared} />}
-        </TabPanel>
-      )
+      return <SharedSitesTable sites={tab.rows} />
     case 'spaces':
-      // The tab only exists when the feed resolved with GROUP spaces (helper-filtered), so no
-      // empty state; New space lives in the top New menu.
-      return (
-        <TabPanel content={tab.content} what="your spaces">
-          {(groupSpaces) => <SpacesTable spaces={groupSpaces} />}
-        </TabPanel>
-      )
+      return <SpacesTable spaces={tab.rows} />
     case 'team':
       return (
         <TabPanel content={tab.content} what="team activity">
@@ -676,25 +655,20 @@ function SpacesTable({ spaces }: { spaces: SpaceSummary[] }) {
 
 function NewSpaceDialog() {
   const navigate = useNavigate()
-  const revalidator = useRevalidator()
   const [searchParams, setSearchParams] = useSearchParams()
   const [slug, setSlug] = useState('')
   const [name, setName] = useState('')
   const [saving, setSaving] = useState(false)
 
   // Driven ENTIRELY by the URL: NewMenu, CommandPalette and ShareDialog all set ?new=space (even
-  // while already on /dashboard — reading the param each render catches every arrival, #6), and
-  // closing clears the param so the still-present URL doesn't immediately reopen the dialog.
+  // while already on /dashboard — reading the param each render catches every arrival, #6).
+  // Closing — the only transition this dialog owns — clears the param (so the URL doesn't
+  // immediately reopen it) and resets the fields (so a reopen doesn't show a stale draft).
   const open = searchParams.get('new') === 'space'
-  const setOpen = (o: boolean) => {
-    if (!o) {
-      // Reset the fields so a reopened dialog doesn't show a previous attempt's draft.
-      setSlug('')
-      setName('')
-      if (open) {
-        setSearchParams((prev) => withParams(prev, (next) => next.delete('new')), { replace: true })
-      }
-    }
+  const close = () => {
+    setSlug('')
+    setName('')
+    setSearchParams((prev) => withParams(prev, (next) => next.delete('new')), { replace: true })
   }
 
   async function create() {
@@ -706,8 +680,8 @@ function NewSpaceDialog() {
     try {
       const created = await api.post<{ slug: string }>('/api/spaces', { slug, name })
       toast.success('Space created', { description: `/${created.slug}` })
-      setOpen(false)
-      revalidator.revalidate()
+      close()
+      // No revalidate: we navigate away, and returning to /dashboard re-runs the loader anyway.
       navigate(`/${created.slug}`)
     } catch (err) {
       toast.error('Could not create space', {
@@ -719,7 +693,7 @@ function NewSpaceDialog() {
   }
 
   return (
-    <Dialog open={open} onOpenChange={(o) => !saving && setOpen(o)}>
+    <Dialog open={open} onOpenChange={(o) => !saving && !o && close()}>
       <DialogContent>
         <DialogHeader>
           <DialogTitle>Create a space</DialogTitle>

--- a/packages/web/src/routes/space.tsx
+++ b/packages/web/src/routes/space.tsx
@@ -1,19 +1,11 @@
 import { useCallback, useState } from 'react'
 import { type LoaderFunctionArgs, useLoaderData, useNavigate, useRevalidator } from 'react-router'
-import { ExternalLink, Search, Share2, Trash2, UserPlus } from 'lucide-react'
+import { ExternalLink, Trash2, UserPlus } from 'lucide-react'
 import { toast } from 'sonner'
-import { CopyButton } from '@/components/CopyButton'
 import { ConfirmDialog } from '@/components/ConfirmDialog'
-import { PickerRow, ShareDialog } from '@/components/ShareDialog'
-import {
-  actionsColumn,
-  createdColumn,
-  nameColumn,
-  OpenLinkButton,
-  urlColumn,
-  visibilityBadgeColumn,
-} from '@/components/siteColumns'
-import { SortableTable, type Column } from '@/components/SortableTable'
+import { PeoplePicker, ShareDialog, toggle } from '@/components/ShareDialog'
+import { CopyOpenActions, feedColumns } from '@/components/siteColumns'
+import { SortableTable } from '@/components/SortableTable'
 import { EmptyState, PageHeader, SectionHeader, Spinner } from '@/components/states'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -26,7 +18,6 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '@/components/ui/dialog'
-import { Input } from '@/components/ui/input'
 import { MountSensor } from '@/components/ui/mount-sensor'
 import { Separator } from '@/components/ui/separator'
 import { api, ApiError } from '@/lib/api'
@@ -62,12 +53,10 @@ function InviteMembersDialog({ slug }: { slug: string }) {
   const [saving, setSaving] = useState(false)
   const [users, setUsers] = useState<UserLite[]>([])
   const [selected, setSelected] = useState<Set<string>>(new Set()) // emails — the API's invite key
-  const [q, setQ] = useState('')
 
   const loadOnMount = useCallback(() => {
     setBusy(true)
     setSelected(new Set())
-    setQ('')
     api
       .get<UserLite[]>('/api/users')
       .then(setUsers)
@@ -84,29 +73,26 @@ function InviteMembersDialog({ slug }: { slug: string }) {
       const results = await Promise.allSettled(
         picks.map((email) => api.post(`/api/spaces/${slug}/members`, { email })),
       )
-      const failed = picks.filter((_, i) => results[i].status === 'rejected')
-      if (failed.length === 0) {
+      const rejects = results.flatMap((r, i) =>
+        r.status === 'rejected' ? [{ email: picks[i], reason: r.reason }] : [],
+      )
+      if (rejects.length === 0) {
         toast.success(picks.length === 1 ? 'Member invited' : `${picks.length} members invited`)
         setOpen(false)
       } else {
         // Keep ONLY the failed picks selected so the open dialog shows exactly what needs
         // retrying, and name them — a bare count doesn't say which invite went wrong.
-        setSelected(new Set(failed))
-        const first = (results.find((r) => r.status === 'rejected') as PromiseRejectedResult).reason
-        toast.error(`${failed.length} of ${picks.length} invites failed`, {
-          description: `${failed.join(', ')}${first instanceof Error ? ` — ${first.message}` : ''}`,
+        setSelected(new Set(rejects.map((r) => r.email)))
+        const { reason } = rejects[0]
+        toast.error(`${rejects.length} of ${picks.length} invites failed`, {
+          description: `${rejects.map((r) => r.email).join(', ')}${reason instanceof Error ? ` — ${reason.message}` : ''}`,
         })
       }
-      if (failed.length < picks.length) revalidator.revalidate()
+      if (rejects.length < picks.length) revalidator.revalidate()
     } finally {
       setSaving(false)
     }
   }
-
-  const needle = q.trim().toLowerCase()
-  const shown = needle
-    ? users.filter((u) => u.email.toLowerCase().includes(needle) || (u.name ?? '').toLowerCase().includes(needle))
-    : users
 
   return (
     <Dialog open={open} onOpenChange={(o) => !saving && setOpen(o)}>
@@ -128,34 +114,11 @@ function InviteMembersDialog({ slug }: { slug: string }) {
             <Spinner className="size-5" />
           </div>
         ) : (
-          <div className="space-y-1.5">
-            <div className="relative">
-              <Search className="absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
-              <Input value={q} onChange={(e) => setQ(e.target.value)} placeholder="Search people…" className="pl-8" />
-            </div>
-            <div className="max-h-56 space-y-0.5 overflow-y-auto">
-              {shown.length === 0 ? (
-                <p className="px-2 py-6 text-center text-sm text-muted-foreground">No people found.</p>
-              ) : (
-                shown.map((u) => (
-                  <PickerRow
-                    key={u.id}
-                    checked={selected.has(u.email)}
-                    onToggle={() =>
-                      setSelected((s) => {
-                        const next = new Set(s)
-                        if (next.has(u.email)) next.delete(u.email)
-                        else next.add(u.email)
-                        return next
-                      })
-                    }
-                    label={u.name ?? u.email}
-                    sub={u.name ? u.email : undefined}
-                  />
-                ))
-              )}
-            </div>
-          </div>
+          <PeoplePicker
+            users={users}
+            checked={(u) => selected.has(u.email)}
+            onToggle={(u) => setSelected((s) => toggle(s, u.email))}
+          />
         )}
 
         <DialogFooter className="sm:justify-between">
@@ -172,39 +135,14 @@ function InviteMembersDialog({ slug }: { slug: string }) {
   )
 }
 
-// Same table shell as the dashboard feeds; per-row actions add Share for sites the caller owns.
-const SPACE_SITE_COLUMNS: Column<SpaceSite>[] = [
-  nameColumn(),
-  urlColumn(),
-  visibilityBadgeColumn(),
-  createdColumn(),
-  actionsColumn((s) => <SpaceSiteActions site={s} />),
-]
-
-function SpaceSiteActions({ site }: { site: SpaceSite }) {
-  const [shareOpen, setShareOpen] = useState(false)
-  return (
-    <div className="flex items-center justify-end gap-1">
-      <CopyButton text={site.url} label="" variant="outline" />
-      <OpenLinkButton url={site.url} />
-      {site.isOwner && (
-        <>
-          <Button variant="outline" size="sm" onClick={() => setShareOpen(true)}>
-            <Share2 />
-            Share
-          </Button>
-          <ShareDialog
-            spaceSlug={site.spaceSlug}
-            siteSlug={site.siteSlug}
-            title={site.title}
-            open={shareOpen}
-            onOpenChange={setShareOpen}
-          />
-        </>
-      )}
-    </div>
-  )
-}
+// Same table shell as the dashboard feeds; owners get a Share action on their own rows.
+const SPACE_SITE_COLUMNS = feedColumns<SpaceSite>((s) => (
+  <CopyOpenActions url={s.url}>
+    {s.isOwner && (
+      <ShareDialog spaceSlug={s.spaceSlug} siteSlug={s.siteSlug} title={s.title} triggerLabel="Share" />
+    )}
+  </CopyOpenActions>
+))
 
 function DangerZone({ space }: { space: SpaceDetail }) {
   const navigate = useNavigate()


### PR DESCRIPTION
Behavior-preserving simplify pass over the merged #88, driven by a strict code-quality review (net **−55 lines**), plus one visual tweak: the brand mark is now 16px and a shared `BrandMark` component.

## Cleanups

- **`lib/nav.ts` owns the URL policy**: `skipSearchOnlyRevalidation` (the loader-skip predicate previously duplicated byte-for-byte in `main.tsx` and `dashboard.tsx`) and `newSpaceHref` (the `?new=space` intent had three divergent spellings across CommandPalette / ShareDialog / NewMenu; ShareDialog's literal no longer clobbers an active `?tab=`).
- **`PeoplePicker` extracted** from ShareDialog (search + filtered `PickerRow` list + empty state) and reused by the invite dialog — ~35 cloned lines deleted, one home for future picker fixes. `toggle` exported too. ShareDialog gains an optional `triggerLabel`, deleting the space page's bespoke per-row controlled-dialog state (`SpaceSiteActions`).
- **`feedColumns` + `CopyOpenActions`** in `siteColumns.tsx`: the dashboard "Shared with me" table and the space-page sites table compose the same read-only feed columns instead of re-listing them.
- **`feedState`**: `TAB_IDS` is now the single source of the `TabId` union; conditional tabs (Shared/Spaces) carry `rows` directly, making their loading/error states unrepresentable (dead `TabPanel` branches deleted); `staleTab` is a slot lookup instead of per-tab clauses.
- **`dashboard.tsx`**: all `?tab=` write mechanics (stale-param clearing + the Radix double-fire dedupe) live in one `useSetTabParam` hook; `deriveFeedState` is memoized so `rows` identities stay stable for `SortableTable`'s sort memo; `NewSpaceDialog`'s boolean setter with a dead true-branch became `close()`, and the wasted revalidate-before-navigate is gone; `invite()` failure handling is one pass with no `as PromiseRejectedResult` cast.

## Visual change

Brand mark 20px → 16px in both headers:

![16px logo](https://github.com/plivo-labs/glance/releases/download/ui-cleanup-shots/logo-16px.png)

## Verification

183 web + 838 API tests pass; `tsc` and biome clean. Browser-verified: tab clicks still fire **zero** loader refetches, `?tab=` deep links and the invite modal (now on `PeoplePicker`) work, per-row Share opens, logo renders at computed 16px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016dv7KJaqLKi7bsnwQtU8sF
