### PR TITLE
docs(skill): mermaid vs inline-SVG dividing line + palette theming

### DIFF
--- a/glance-cli/SKILL.md
+++ b/glance-cli/SKILL.md
@@ -256,6 +256,14 @@ graph LR
 
 Every mermaid diagram type works (flowchart, sequenceDiagram, stateDiagram-v2, erDiagram, gantt…); each `<pre class="mermaid">` on the page renders independently. Syntax reference: https://mermaid.js.org → "Diagram Syntax".
 
+The dividing line vs hand-written SVG is **auto-layout vs designed geometry**, not size:
+
+- **Mermaid** whenever the visual is a graph of labeled nodes/edges or ordered steps (architecture, flows, sequences, state, ER, dependency maps) — even a 4-box flow. Routing connectors by hand in SVG is where effort goes to die and arrows start overlapping.
+- **Inline SVG** when you want control of the geometry and nothing needs routed connectors: small illustrations, icons, gauges, timelines, badges, decoration. SVG inherits the page's CSS variables/palette, so bespoke visuals stay on-design.
+- **Charts stay recharts/d3** (below) — mermaid's pie/gantt are weak, and hand-SVG charts are wasted effort.
+
+On a designed page, theme mermaid to the palette so diagrams don't look pasted-in: `mermaid.initialize({ startOnLoad: true, theme: 'base', themeVariables: { primaryColor: '…', primaryTextColor: '…', lineColor: '…', fontFamily: '…' } })` — pull the values from the page's CSS custom properties.
+
 ## Building React apps (no build step)
 
 Served HTML has no CSP, so a React SPA is just an `index.html` with an import map — no bundler, no npm install. Paste this `<head>` recipe (pinned versions; add/remove libs as needed):


### PR DESCRIPTION
Follow-up to #77. The mermaid-first section only contrasted mermaid with React Flow — SVG had no lane, so agents either hand-route connector diagrams in SVG or mermaid tiny bespoke visuals that clash with the page design.

- The dividing line is **auto-layout vs designed geometry**, not size: mermaid for any labeled node/edge or step diagram (even 4 boxes); inline SVG for illustrations/icons/gauges/badges that must sit in the page's design system; charts stay recharts/d3.
- Adds the `themeVariables` recipe so mermaid inherits the page palette instead of looking pasted-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gmr5sC5SRUWGDVNbFhLgg8