### PR TITLE
docs(whats-new): announce glance.db + live pages

### DIFF
--- a/packages/api/src/routes/whats-new.test.ts
+++ b/packages/api/src/routes/whats-new.test.ts
@@ -14,9 +14,10 @@ import { whatsNew } from './whats-new'
 const APP_URL = 'https://glance.example.com'
 // A watermark inside the real catalog's range: older than 2026-07-01 (voice) but newer than
 // 2026-06-20 (links). Everything published after it counts as unread.
-// CATALOG-COUPLED: the unreadCount literals below (`4`) = the number of releases dated after MID.
+// CATALOG-COUPLED: the unreadCount literals below (`5`) = the number of releases dated after MID.
 // Adding a release note NEWER than MID bumps them — rebuild with `bun run build:whatsnew`, then
-// bump these. (links 06-20 | MID | voice 07-01, comments-tab 07-11, fork 07-14, tldr 07-14T18 → 4 unread.)
+// bump these. (links 06-20 | MID | voice 07-01, comments-tab 07-11, fork 07-14, tldr 07-14T18,
+// live-data 07-29 → 5 unread.)
 const MID = '2026-06-25T00:00:00.000Z'
 
 function setup() {
@@ -59,7 +60,7 @@ describe('C6 route.auth.401 — unauthenticated GET and POST both 401, watermark
 })
 
 describe('C7 route.get.exactJSON — exact ordered items, unreadCount, throughDate', () => {
-  test('mid watermark → exact slugs/dates/bodies + unreadCount 4 + throughDate===newest', async () => {
+  test('mid watermark → exact slugs/dates/bodies + unreadCount 5 + throughDate===newest', async () => {
     const { app, db, kv, env } = setup()
     const id = await seedUser(db, { id: 'u1' })
     await db.update(users).set({ lastSeenReleaseAt: MID }).where(eq(users.id, id))
@@ -68,7 +69,7 @@ describe('C7 route.get.exactJSON — exact ordered items, unreadCount, throughDa
     // Whole-response deep-equal, not key-presence: a dropped item field or an extra top-level key fails.
     expect(await res.json()).toEqual({
       items: JSON.parse(JSON.stringify(RELEASES)),
-      unreadCount: 4,
+      unreadCount: 5,
       throughDate: NEWEST_RELEASE_DATE,
     })
   })
@@ -143,6 +144,6 @@ describe('B3 relogin.noReset — the existing-user branch must not clear an exis
     await findOrCreateUser(db, { SUPERADMIN_EMAIL: 'boss@example.com' } as never, { sub: 'g1', name: 'A2' } as never, 'a@example.com')
     expect(await getWatermark(db, first.id)).toBe(before as string)
     const res = await app.request('/api/whats-new', { headers: await mintBearer(kv, first.id) }, env)
-    expect(((await res.json()) as { unreadCount: number }).unreadCount).toBe(4)
+    expect(((await res.json()) as { unreadCount: number }).unreadCount).toBe(5)
   })
 })

--- a/packages/api/src/whats-new/catalog.ts
+++ b/packages/api/src/whats-new/catalog.ts
@@ -4,6 +4,13 @@ import type { Release } from './bake'
 
 export const RELEASES: Release[] = [
   {
+    "slug": "live-data",
+    "title": "Live data on any page",
+    "date": "2026-07-29T09:00:00.000Z",
+    "featured": true,
+    "bodyHtml": "<p>A page you deploy can now <strong>store data and update itself</strong> — no backend to run, nothing to host. Ask for a form, a poll, a board or a dashboard, and it gets a real data store: <code>glance.db</code>.</p>\n<ul>\n<li><strong>Anyone who can open the site can add to it</strong>, attributed to them — so forms and surveys just work</li>\n<li><strong>Changes are pushed, not polled.</strong> Every open page updates the moment something lands, with no refresh button</li>\n<li><strong>Your scripts can write too</strong> — a cron job or CI step posts to the site and every dashboard watching it reacts</li>\n<li>By default you only see what <strong>you</strong> added; a <code>shared-…</code> collection is one everybody watching sees together</li>\n<li>The site <strong>owner</strong> can edit or remove any entry, so a public board stays moderatable</li>\n</ul>\n<p>Leave a page open overnight and it catches up on whatever it missed — no stale tab, no reload.</p>\n"
+  },
+  {
     "slug": "tldr-summaries",
     "title": "TL;DR any site",
     "date": "2026-07-14T18:00:00.000Z",
@@ -40,4 +47,4 @@ export const RELEASES: Release[] = [
   }
 ]
 
-export const NEWEST_RELEASE_DATE: string | null = "2026-07-14T18:00:00.000Z"
+export const NEWEST_RELEASE_DATE: string | null = "2026-07-29T09:00:00.000Z"

--- a/packages/api/src/whats-new/notes/2026-07-29-live-data.md
+++ b/packages/api/src/whats-new/notes/2026-07-29-live-data.md
@@ -1,0 +1,15 @@
+---
+title: Live data on any page
+slug: live-data
+date: 2026-07-29T09:00:00.000Z
+featured: true
+---
+A page you deploy can now **store data and update itself** — no backend to run, nothing to host. Ask for a form, a poll, a board or a dashboard, and it gets a real data store: `glance.db`.
+
+- **Anyone who can open the site can add to it**, attributed to them — so forms and surveys just work
+- **Changes are pushed, not polled.** Every open page updates the moment something lands, with no refresh button
+- **Your scripts can write too** — a cron job or CI step posts to the site and every dashboard watching it reacts
+- By default you only see what **you** added; a `shared-…` collection is one everybody watching sees together
+- The site **owner** can edit or remove any entry, so a public board stays moderatable
+
+Leave a page open overnight and it catches up on whatever it missed — no stale tab, no reload.


### PR DESCRIPTION
Realtime push shipped in #93 and `glance.db` itself (#8 / #9) was never announced, so the newest entry in the What's New sheet is still TL;DR from 07-14.

Adds **one combined note** rather than two — the store and the push read as a single feature to a user, and "changes are pushed, not polled" means nothing to someone who has never heard of the store.

### Copy

> **Live data on any page** · featured
>
> A page you deploy can now **store data and update itself** — no backend to run, nothing to host. Ask for a form, a poll, a board or a dashboard, and it gets a real data store: `glance.db`.
>
> - **Anyone who can open the site can add to it**, attributed to them — so forms and surveys just work
> - **Changes are pushed, not polled.** Every open page updates the moment something lands, with no refresh button
> - **Your scripts can write too** — a cron job or CI step posts to the site and every dashboard watching it reacts
> - By default you only see what **you** added; a `shared-…` collection is one everybody watching sees together
> - The site **owner** can edit or remove any entry, so a public board stays moderatable
>
> Leave a page open overnight and it catches up on whatever it missed — no stale tab, no reload.

Internals stay out: no Durable Object, no cursor replay, no free-plan quota math. What's in it is what a user can act on.

### Changes

- `notes/2026-07-29-live-data.md` — the authored note, `featured: true`
- `whats-new/catalog.ts` — rebaked via `bun run build:whatsnew` (6 releases, newest `2026-07-29T09:00:00.000Z`)
- `routes/whats-new.test.ts` — the two catalog-coupled `unreadCount` literals `4 → 5`, exactly as that file's own `CATALOG-COUPLED` comment instructs

928 API tests + 5 web tests pass, typecheck and biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XmuFkH67ZJnGzjH1yeEpDD