### PR TITLE
fix(comments): let rendered markdown take comments like HTML does

### DIFF
--- a/packages/api/src/content-annotate.test.ts
+++ b/packages/api/src/content-annotate.test.ts
@@ -83,14 +83,37 @@ describe('annotate injection', () => {
     expect(res.headers.get('cache-control')).toBe('no-store')
   })
 
-  test('markdown-not-injected: markdown keeps script-src none, no annotate script', async () => {
+  test('markdown-injected-with-flag: rendered markdown gets the client under a nonce CSP', async () => {
     const { app, db, r2, env } = setup()
     const { token } = await gatedSite(db, r2, { path: 'index.md', text: '# Title\n\nbody', mimeType: 'text/markdown' })
     const res = await app.request(`/_t/${token}/sam/site/?glance_annotate=1`, {}, env)
     const body = await res.text()
+    expect(body).toContain('/_glance/annotate.js')
+    expect(body).toContain('"filePath":"index.md"')
+    expect(body).toContain('<h1>Title</h1>') // still the RENDERED doc, not raw source
+    // The two injected tags carry the response nonce; the CSP admits that nonce and nothing else,
+    // so any script the markdown itself tried to smuggle in stays blocked.
+    const csp = res.headers.get('content-security-policy') ?? ''
+    const nonce = /script-src 'nonce-([a-f0-9]+)'/.exec(csp)?.[1]
+    expect(nonce).toBeDefined()
+    expect(body).toContain(`<script nonce="${nonce}" src="/_glance/annotate.js`)
+    expect(body).toContain(`<script nonce="${nonce}">window.__GLANCE__=`)
+    expect(csp).not.toContain("'unsafe-inline'; script") // no blanket inline-script escape hatch
+    expect(csp).toContain("style-src 'self' 'unsafe-inline'") // the annotate stylesheet loads
+    // #54: the markdown branch must also send nosniff (parity with the html branch).
+    expect(res.headers.get('x-content-type-options')).toBe('nosniff')
+    // Per-request nonce → these bytes must never be cached or revalidated.
+    expect(res.headers.get('cache-control')).toBe('no-store')
+    expect(res.headers.get('etag')).toBeNull()
+  })
+
+  test('markdown-without-flag-stays-strict: no flag → script-src none, nothing injected', async () => {
+    const { app, db, r2, env } = setup()
+    const { token } = await gatedSite(db, r2, { path: 'index.md', text: '# Title\n\nbody', mimeType: 'text/markdown' })
+    const res = await app.request(`/_t/${token}/sam/site/`, {}, env)
+    const body = await res.text()
     expect(body).not.toContain('/_glance/annotate.js')
     expect(res.headers.get('content-security-policy')).toContain("script-src 'none'")
-    // #54: the markdown branch must also send nosniff (parity with the html branch).
     expect(res.headers.get('x-content-type-options')).toBe('nosniff')
   })
 

--- a/packages/api/src/content.ts
+++ b/packages/api/src/content.ts
@@ -232,10 +232,21 @@ async function serve(c: Ctx, spaceSlug: string, siteSlug: string, rest: string, 
     if (!read) return notFound(c)
     await view()
     const html = await markdown.parse(await new Response(read.body).text())
-    const res = c.html(renderMarkdownDoc(path, html), 200, {
-      'content-security-policy': markdownCsp(frameAncestors),
+    // Annotate mode applies to rendered markdown too — select-to-comment and element pinpointing
+    // work against the rendered DOM exactly like uploaded HTML. Markdown's baseline CSP forbids
+    // scripts outright, so the injected pair runs under a PER-RESPONSE nonce: our two tags are
+    // admitted by name and nothing else is (raw HTML in the source is escaped anyway). Nonce'd
+    // bytes differ per request, hence no-store and no ETag.
+    const annotate = c.req.query('glance_annotate') === '1'
+    const nonce = annotate ? crypto.randomUUID().replace(/-/g, '') : null
+    const doc = nonce
+      ? injectAnnotate(renderMarkdownDoc(path, html), { siteId: siteRow.id, filePath: path, appOrigin: c.env.APP_URL }, nonce)
+      : renderMarkdownDoc(path, html)
+    const res = c.html(doc, 200, {
+      'content-security-policy': markdownCsp(frameAncestors, nonce),
       'x-content-type-options': 'nosniff',
       'referrer-policy': 'no-referrer',
+      ...(nonce ? { 'cache-control': 'no-store' } : {}),
     })
     return openExternalLinksInNewTab(res, selfOrigin)
   }
@@ -437,13 +448,20 @@ export function isHtmlFile(path: string): boolean {
 
 /** Inject the annotate client + boot payload into an HTML document. The payload is the trusted
  *  server-resolved context (siteId, resolved files.path, parent origin); `<` is escaped so a
- *  path can't break out of the inline script. Inserted before </body> (else </head>, else end). */
-export function injectAnnotate(html: string, payload: { siteId: string; filePath: string; appOrigin: string }): string {
+ *  path can't break out of the inline script. Inserted before </body> (else </head>, else end).
+ *  `nonce` (rendered markdown only) stamps both script tags so they pass that branch's
+ *  script-src 'nonce-…' CSP; uploaded HTML passes null and keeps its permissive policy. */
+export function injectAnnotate(
+  html: string,
+  payload: { siteId: string; filePath: string; appOrigin: string },
+  nonce: string | null = null,
+): string {
   const json = JSON.stringify(payload).replace(/</g, '\\u003c')
+  const n = nonce ? ` nonce="${nonce}"` : ''
   const tags =
     `<link rel="stylesheet" href="/_glance/annotate.css?v=${ANNOTATE_VERSION}">` +
-    `<script>window.__GLANCE__=${json}</script>` +
-    `<script src="/_glance/annotate.js?v=${ANNOTATE_VERSION}" defer></script>`
+    `<script${n}>window.__GLANCE__=${json}</script>` +
+    `<script${n} src="/_glance/annotate.js?v=${ANNOTATE_VERSION}" defer></script>`
   // Replacement FUNCTIONS, not strings: `tags` embeds a user-controlled filePath, and `$&`/`$1`/`$$`
   // in a replacement STRING are special (they'd corrupt output). A function's return is used verbatim.
   if (html.includes('</body>')) return html.replace('</body>', () => `${tags}</body>`)
@@ -526,13 +544,16 @@ export { escapeHtml, markdown } from './lib/markdown'
 // styles are allowed because renderMarkdownDoc inlines its stylesheet; images may be
 // self-hosted or data: (markdown can embed both). frame-ancestors is preserved so the
 // app can still iframe the rendered doc.
-function markdownCsp(frameAncestors: string): string {
+// In annotate mode a `nonce` is supplied: script-src then admits EXACTLY the two injected tags
+// (never 'unsafe-inline' — an unnonced script in the document still can't run), and style-src
+// additionally allows 'self' so /_glance/annotate.css loads alongside the inlined shell styles.
+function markdownCsp(frameAncestors: string, nonce: string | null = null): string {
   return [
     "default-src 'none'",
     "img-src 'self' data:",
-    "style-src 'unsafe-inline'",
+    nonce ? "style-src 'self' 'unsafe-inline'" : "style-src 'unsafe-inline'",
     "font-src 'self'",
-    "script-src 'none'",
+    nonce ? `script-src 'nonce-${nonce}'` : "script-src 'none'",
     "object-src 'none'",
     "base-uri 'none'",
     frameAncestors,


### PR DESCRIPTION
## The bug

Text selection on an HTML site opens the comment composer. On a `.md` site, selecting text does nothing at all.

## Root cause

`packages/api/src/content.ts` — the viewer always requests `?glance_annotate=1` (`viewer.tsx:464`), but `serve()` returns from the markdown branch **before** reaching the injection below it, which was itself gated on `isHtml`. So a rendered `.md` page shipped without the annotate client:

- no `selectionchange` listener → no `glance:select` postMessage → composer never opens
- the viewer only learns `filePath` from the client's `glance:ready`, so the whole comment rail stayed dead for markdown

Even if injected, markdown's CSP was `script-src 'none'` and would have blocked it.

## Fix

Inject the same client into the rendered markdown shell when the flag is set, under a **per-response nonce**: exactly the two injected tags are admitted, never `'unsafe-inline'` — so a script smuggled through the markdown source still can't run (it's escaped by `lib/markdown.ts` anyway). `style-src` gains `'self'` so `annotate.css` loads. Nonce'd bytes vary per request → `no-store`, no ETag.

Nothing else gated markdown: `routes/comments.ts` is file-type agnostic, and `viewer.tsx` gates only on `isAudio`.

## Blast radius

- No-flag markdown (`?raw=1`, direct links, CLI pull) is **byte-identical** — only a defaulted arg changed on that path.
- HTML annotate is untouched (`nonce` defaults to `null` → the same tags as before).
- Worst case is today's behavior: if the script were blocked, markdown still renders exactly as it does now. No rendering-regression path.

## Testing

Replaced `markdown-not-injected` (which pinned the buggy behavior) with two tests covering both directions — flag → nonce'd injection under a nonce CSP; no flag → strict `script-src 'none'`. Red before the fix, green after. Full api suite: **854 pass / 0 fail**. Lint clean.

Not browser-verified — no live env had the change. Worth a click-through on a `.md` site in review mode once this deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6efmjPmQcqF4zmBzZ25x8