### PR TITLE
perf(stats): drop the CLI rollups — 40% of the admin dashboard's D1 reads

### DIFF
--- a/packages/api/src/lib/stats.test.ts
+++ b/packages/api/src/lib/stats.test.ts
@@ -43,17 +43,19 @@ describe('computeStats totals', () => {
     expect(s.totals.comments).toBe(1) // soft-deleted not counted
   })
 
-  test('views vs cli events, and unique viewers (distinct userId)', async () => {
+  test('cli events never inflate views, and unique viewers counts a user once', async () => {
     const { db, u1, u2, siteA } = await fixture()
     await seedEvent(db, { type: 'view', userId: u1, siteId: siteA, siteLabel: 'acme/a' })
     await seedEvent(db, { type: 'view', userId: u1, siteId: siteA, siteLabel: 'acme/a' })
     await seedEvent(db, { type: 'view', userId: u2, siteId: siteA, siteLabel: 'acme/a' })
+    // A cli row is still WRITTEN (auth's hasUsedCli probe reads one) — it must not be counted here.
     await seedEvent(db, { type: 'cli', action: 'upload', userId: u1, cliVersion: '1.0.0' })
 
     const s = await computeStats(db, NOW)
     expect(s.totals.views).toBe(3)
-    expect(s.totals.cliInvocations).toBe(1)
     expect(s.totals.uniqueViewers).toBe(2) // u1 counted once
+    // The CLI rollups were dropped: they cost 40% of the dashboard's D1 rows for two unused figures.
+    expect('cliInvocations' in s.totals).toBe(false)
   })
 })
 
@@ -78,7 +80,9 @@ describe('computeStats window + series', () => {
     expect(s.series[0].date < s.series[29].date).toBe(true) // oldest → newest
     expect(s.series[29].date).toBe('2026-07-03') // today
     expect(s.series[29].views).toBe(2)
-    expect(s.series[24].cli).toBe(1) // 5 days ago = index 24
+    // 5 days ago (index 24) saw ONLY a cli event — no series line may pick it up.
+    expect(s.series[24]).toMatchObject({ views: 0, signups: 0, sites: 0, comments: 0 })
+    expect('cli' in s.series[24]).toBe(false)
   })
 })
 

--- a/packages/api/src/lib/stats.ts
+++ b/packages/api/src/lib/stats.ts
@@ -3,8 +3,16 @@ import type { DrizzleD1Database } from 'drizzle-orm/d1'
 import { comments, events, files, sites, users } from '../db/schema'
 
 // Usage-analytics rollups for the admin dashboard. Everything is derived from existing state
-// (users/sites/files/comments) plus the append-only `events` stream (views + CLI), so counts are
-// exact and joinable. Superadmin-only surface (see routes/admin.ts) — read-only aggregation.
+// (users/sites/files/comments) plus the append-only `events` stream, so counts are exact and
+// joinable. Superadmin-only surface (see routes/admin.ts) — read-only aggregation.
+//
+// NO CLI STATS HERE, deliberately. `events` type 'cli' rows are still WRITTEN (middleware/
+// analytics.ts) — /api/auth/me's `hasUsedCli` probe reads one — but the two CLI rollups this file
+// used to expose (an all-time `count(*)` and a 30-day per-day series) measured at 7,329 + 14,657
+// D1 rows read, i.e. 40% of the entire dashboard's cost, for two figures nobody acted on. The CLI
+// is chattier than the site itself (7.3k cli events vs 3k page views), so any all-table aggregate
+// over those rows is the single most expensive thing here. Re-adding either one means paying that
+// again — do it off a rollup table, not a live scan.
 
 export interface StatsTotals {
   users: number
@@ -13,7 +21,6 @@ export interface StatsTotals {
   storageBytes: number
   comments: number
   views: number
-  cliInvocations: number
   uniqueViewers: number
 }
 
@@ -23,7 +30,6 @@ export interface DailyPoint {
   sites: number
   views: number
   comments: number
-  cli: number
 }
 
 export interface TopSite {
@@ -61,82 +67,73 @@ export async function computeStats(db: DrizzleD1Database, now: Date = new Date()
   const sDay = sql<string>`substr(${sites.createdAt}, 1, 10)`
   const cDay = sql<string>`substr(${comments.createdAt}, 1, 10)`
 
-  const [totals, activeViewers30d, signupsByDay, sitesByDay, viewsByDay, commentsByDay, cliByDay, topSites] =
-    await Promise.all([
-      // Headline totals (all-time).
-      (async (): Promise<StatsTotals> => {
-        const [u, s, f, storage, cm, vw, cli, uv] = await Promise.all([
-          scalarCount(db.select({ n: count() }).from(users)),
-          scalarCount(db.select({ n: count() }).from(sites)),
-          scalarCount(db.select({ n: count() }).from(files)),
-          db
-            .select({ n: sql<number>`coalesce(sum(${files.size}), 0)` })
-            .from(files)
-            .then((r) => Number(r[0]?.n ?? 0)),
-          scalarCount(db.select({ n: count() }).from(comments).where(isNull(comments.deletedAt))),
-          scalarCount(db.select({ n: count() }).from(events).where(eq(events.type, 'view'))),
-          scalarCount(db.select({ n: count() }).from(events).where(eq(events.type, 'cli'))),
-          db
-            .select({ n: sql<number>`count(distinct ${events.userId})` })
-            .from(events)
-            .where(eq(events.type, 'view'))
-            .then((r) => Number(r[0]?.n ?? 0)),
-        ])
-        return {
-          users: u,
-          sites: s,
-          files: f,
-          storageBytes: storage,
-          comments: cm,
-          views: vw,
-          cliInvocations: cli,
-          uniqueViewers: uv,
-        }
-      })(),
-      // Distinct viewers active in the window.
-      db
-        .select({ n: sql<number>`count(distinct ${events.userId})` })
-        .from(events)
-        .where(and(eq(events.type, 'view'), gte(events.createdAt, sinceTs)))
-        .then((r) => Number(r[0]?.n ?? 0)),
-      // Per-day series (sparse; zero-filled below).
-      db.select({ date: uDay, n: count() }).from(users).where(gte(users.createdAt, sinceTs)).groupBy(uDay),
-      db.select({ date: sDay, n: count() }).from(sites).where(gte(sites.createdAt, sinceTs)).groupBy(sDay),
-      db
-        .select({ date: day, n: count() })
-        .from(events)
-        .where(and(eq(events.type, 'view'), gte(events.createdAt, sinceTs)))
-        .groupBy(day),
-      db
-        .select({ date: cDay, n: count() })
-        .from(comments)
-        .where(and(isNull(comments.deletedAt), gte(comments.createdAt, sinceTs)))
-        .groupBy(cDay),
-      db
-        .select({ date: day, n: count() })
-        .from(events)
-        .where(and(eq(events.type, 'cli'), gte(events.createdAt, sinceTs)))
-        .groupBy(day),
-      // Most-viewed sites in the window. siteLabel is stable per site, so max() picks it safely.
-      db
-        .select({
-          siteId: events.siteId,
-          siteLabel: sql<string>`max(${events.siteLabel})`,
-          views: count(),
-        })
-        .from(events)
-        .where(and(eq(events.type, 'view'), gte(events.createdAt, sinceTs)))
-        .groupBy(events.siteId)
-        .orderBy(desc(count()))
-        .limit(10),
-    ])
+  const [totals, activeViewers30d, signupsByDay, sitesByDay, viewsByDay, commentsByDay, topSites] = await Promise.all([
+    // Headline totals (all-time).
+    (async (): Promise<StatsTotals> => {
+      const [u, s, f, storage, cm, vw, uv] = await Promise.all([
+        scalarCount(db.select({ n: count() }).from(users)),
+        scalarCount(db.select({ n: count() }).from(sites)),
+        scalarCount(db.select({ n: count() }).from(files)),
+        db
+          .select({ n: sql<number>`coalesce(sum(${files.size}), 0)` })
+          .from(files)
+          .then((r) => Number(r[0]?.n ?? 0)),
+        scalarCount(db.select({ n: count() }).from(comments).where(isNull(comments.deletedAt))),
+        scalarCount(db.select({ n: count() }).from(events).where(eq(events.type, 'view'))),
+        db
+          .select({ n: sql<number>`count(distinct ${events.userId})` })
+          .from(events)
+          .where(eq(events.type, 'view'))
+          .then((r) => Number(r[0]?.n ?? 0)),
+      ])
+      return {
+        users: u,
+        sites: s,
+        files: f,
+        storageBytes: storage,
+        comments: cm,
+        views: vw,
+        uniqueViewers: uv,
+      }
+    })(),
+    // Distinct viewers active in the window.
+    db
+      .select({ n: sql<number>`count(distinct ${events.userId})` })
+      .from(events)
+      .where(and(eq(events.type, 'view'), gte(events.createdAt, sinceTs)))
+      .then((r) => Number(r[0]?.n ?? 0)),
+    // Per-day series (sparse; zero-filled below).
+    db.select({ date: uDay, n: count() }).from(users).where(gte(users.createdAt, sinceTs)).groupBy(uDay),
+    db.select({ date: sDay, n: count() }).from(sites).where(gte(sites.createdAt, sinceTs)).groupBy(sDay),
+    db
+      .select({ date: day, n: count() })
+      .from(events)
+      .where(and(eq(events.type, 'view'), gte(events.createdAt, sinceTs)))
+      .groupBy(day),
+    db
+      .select({ date: cDay, n: count() })
+      .from(comments)
+      .where(and(isNull(comments.deletedAt), gte(comments.createdAt, sinceTs)))
+      .groupBy(cDay),
+    // Most-viewed sites in the window. siteLabel is stable per site, so max() picks it safely.
+    db
+      .select({
+        siteId: events.siteId,
+        siteLabel: sql<string>`max(${events.siteLabel})`,
+        views: count(),
+      })
+      .from(events)
+      .where(and(eq(events.type, 'view'), gte(events.createdAt, sinceTs)))
+      .groupBy(events.siteId)
+      .orderBy(desc(count()))
+      .limit(10),
+  ])
 
   const series = buildSeries(now, {
     signups: signupsByDay,
     sites: sitesByDay,
     views: viewsByDay,
     comments: commentsByDay,
-    cli: cliByDay,
   })
 
   return {
@@ -151,7 +148,8 @@ export async function computeStats(db: DrizzleD1Database, now: Date = new Date()
 // --- Cache front for the admin dashboard ----------------------------------------------------
 //
 // `computeStats` is 13 aggregates and most of them are unavoidable FULL SCANS (all-time counts,
-// `count(distinct userId)`, `sum(files.size)`, the 30-day group-bys) — ~45k D1 rows read per call
+// `count(distinct userId)`, `sum(files.size)`, the 30-day group-bys) — ~33k D1 rows read per call
+// (measured per-aggregate against prod, 2026-07-29; was ~55k before the CLI rollups came out)
 // against a database whose largest table is ~10k rows. The admin page is a React Router loader,
 // so every navigation, back button, and tab switch re-ran the whole thing: measured at ~73% of
 // the account's ENTIRE D1 rows-read budget. Nothing here is real-time by nature (the window is
@@ -167,8 +165,10 @@ export async function computeStats(db: DrizzleD1Database, now: Date = new Date()
 // compute serves every region instead of one per colo.
 
 /** KV key for the single account-wide rollup entry. Namespaced under `stats:` alongside the
- *  namespace's `session:`/`cli:` keys. */
-export const STATS_CACHE_KEY = 'stats:admin'
+ *  namespace's `session:`/`cli:` keys. VERSIONED: the cached value is a serialized `Stats`, so any
+ *  change to that shape must bump `v<n>` — otherwise the deploy keeps serving the previous shape
+ *  until the TTL lapses and the dashboard renders `undefined` for the fields that moved. */
+export const STATS_CACHE_KEY = 'stats:admin:v2'
 
 /** Freshness window for the cached rollup, in seconds. */
 export const STATS_CACHE_SECONDS = 300
@@ -208,10 +208,7 @@ export async function cachedStats(
 type DayRows = { date: string; n: number }[]
 
 /** Zero-fill the window: one row per day (oldest → newest), merging each metric's sparse counts. */
-function buildSeries(
-  now: Date,
-  metrics: Record<'signups' | 'sites' | 'views' | 'comments' | 'cli', DayRows>,
-): DailyPoint[] {
+function buildSeries(now: Date, metrics: Record<'signups' | 'sites' | 'views' | 'comments', DayRows>): DailyPoint[] {
   const index: Record<string, Map<string, number>> = {}
   for (const [key, rows] of Object.entries(metrics)) {
     index[key] = new Map(rows.map((r) => [r.date, Number(r.n)]))
@@ -225,7 +222,6 @@ function buildSeries(
       sites: index.sites.get(date) ?? 0,
       views: index.views.get(date) ?? 0,
       comments: index.comments.get(date) ?? 0,
-      cli: index.cli.get(date) ?? 0,
     })
   }
   return out

--- a/packages/web/src/routes/admin.tsx
+++ b/packages/web/src/routes/admin.tsx
@@ -9,18 +9,11 @@ import {
   FolderOpen,
   HardDrive,
   MessageSquare,
-  Terminal,
   Trash2,
   UserCheck,
   Users2,
 } from 'lucide-react'
-import {
-  type LoaderFunctionArgs,
-  redirect,
-  useLoaderData,
-  useRevalidator,
-  useSearchParams,
-} from 'react-router'
+import { type LoaderFunctionArgs, redirect, useLoaderData, useRevalidator, useSearchParams } from 'react-router'
 import { toast } from 'sonner'
 import { ConfirmDialog } from '@/components/ConfirmDialog'
 import { EmptyState, PageHeader, SectionHeader, Spinner } from '@/components/states'
@@ -28,13 +21,7 @@ import { UserAvatar } from '@/components/UserAvatar'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { VisibilityBadge } from '@/components/visibility'
@@ -88,11 +75,10 @@ interface StatsData {
     storageBytes: number
     comments: number
     views: number
-    cliInvocations: number
     uniqueViewers: number
   }
   activeViewers30d: number
-  series: { date: string; signups: number; sites: number; views: number; comments: number; cli: number }[]
+  series: { date: string; signups: number; sites: number; views: number; comments: number }[]
   topSites: { siteId: string | null; siteLabel: string | null; views: number }[]
   windowDays: number
 }
@@ -290,7 +276,7 @@ function TrendCard({
 
 function StatsPanel({ data }: { data: StatsData }) {
   const { totals, series, topSites, activeViewers30d, windowDays } = data
-  const sum = (key: 'signups' | 'views' | 'cli' | 'comments') => series.reduce((acc, d) => acc + d[key], 0)
+  const sum = (key: 'signups' | 'views' | 'comments') => series.reduce((acc, d) => acc + d[key], 0)
 
   return (
     <div className="space-y-6">
@@ -318,7 +304,6 @@ function StatsPanel({ data }: { data: StatsData }) {
           sub={`last ${windowDays} days`}
         />
         <StatCard icon={MessageSquare} label="Comments" value={formatCount(totals.comments)} />
-        <StatCard icon={Terminal} label="CLI invocations" value={formatCount(totals.cliInvocations)} />
       </div>
 
       {/* 30-day trends. */}
@@ -326,7 +311,7 @@ function StatsPanel({ data }: { data: StatsData }) {
         <SectionHeader title={`Last ${windowDays} days`}>
           <span className="text-sm text-muted-foreground">Daily activity</span>
         </SectionHeader>
-        <div className="mt-3 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        <div className="mt-3 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
           <TrendCard icon={Eye} label="Views" total={sum('views')} values={series.map((d) => d.views)} />
           <TrendCard icon={Users2} label="Signups" total={sum('signups')} values={series.map((d) => d.signups)} />
           <TrendCard
@@ -335,7 +320,6 @@ function StatsPanel({ data }: { data: StatsData }) {
             total={sum('comments')}
             values={series.map((d) => d.comments)}
           />
-          <TrendCard icon={Terminal} label="CLI" total={sum('cli')} values={series.map((d) => d.cli)} />
         </div>
       </div>
 
@@ -491,11 +475,7 @@ function SitesPanel({ data }: { data: SitesData }) {
                           title="Archive this site?"
                           description={`/${s.spaceSlug}/${s.siteSlug} will be hidden from listings but can be restored.`}
                           confirmLabel="Archive"
-                          onConfirm={() =>
-                            mutate('Site archived', () =>
-                              api.patch(`/api/admin/sites/${s.id}/archive`),
-                            )
-                          }
+                          onConfirm={() => mutate('Site archived', () => api.patch(`/api/admin/sites/${s.id}/archive`))}
                         >
                           <Button variant="outline" size="sm">
                             <Archive className="size-3.5" />
@@ -510,9 +490,7 @@ function SitesPanel({ data }: { data: SitesData }) {
                         description={`Hard delete /${s.spaceSlug}/${s.siteSlug} and all its files. This cannot be undone.`}
                         confirmLabel="Delete"
                         destructive
-                        onConfirm={() =>
-                          mutate('Site deleted', () => api.delete(`/api/admin/sites/${s.id}`))
-                        }
+                        onConfirm={() => mutate('Site deleted', () => api.delete(`/api/admin/sites/${s.id}`))}
                       >
                         <Button variant="ghost" size="sm" className="text-destructive hover:text-destructive">
                           <Trash2 className="size-3.5" />
@@ -533,20 +511,10 @@ function SitesPanel({ data }: { data: SitesData }) {
           Page {data.page} of {totalPages} · {data.total} site{data.total === 1 ? '' : 's'}
         </p>
         <div className="flex items-center gap-2">
-          <Button
-            variant="outline"
-            size="sm"
-            disabled={data.page <= 1}
-            onClick={() => setPage(data.page - 1)}
-          >
+          <Button variant="outline" size="sm" disabled={data.page <= 1} onClick={() => setPage(data.page - 1)}>
             Prev
           </Button>
-          <Button
-            variant="outline"
-            size="sm"
-            disabled={data.page >= totalPages}
-            onClick={() => setPage(data.page + 1)}
-          >
+          <Button variant="outline" size="sm" disabled={data.page >= totalPages} onClick={() => setPage(data.page + 1)}>
             Next
           </Button>
         </div>
@@ -596,9 +564,7 @@ function SpacesPanel({ spaces }: { spaces: AdminSpace[] }) {
                       description={`Delete the "${s.name}" space (/${s.slug}). This cannot be undone.`}
                       confirmLabel="Delete"
                       destructive
-                      onConfirm={() =>
-                        mutate('Space deleted', () => api.delete(`/api/spaces/${s.slug}`))
-                      }
+                      onConfirm={() => mutate('Space deleted', () => api.delete(`/api/spaces/${s.slug}`))}
                     >
                       <Button variant="ghost" size="sm" className="text-destructive hover:text-destructive">
                         <Trash2 className="size-3.5" />


### PR DESCRIPTION
Follow-up to #99. That PR capped *how often* the admin rollup runs; this one makes the run itself cheaper.

## Measurement

Ran each of the dashboard's 15 aggregates individually against prod and recorded `rows_read`:

| stat | rows read | table |
|---|---|---|
| `series.cli` | **14,657** | events |
| `totals.cliInvocations` | **7,329** | events |
| `topSites` | 6,472 | events |
| `series.views` | 6,026 | events |
| `totals.files` | 4,422 | files |
| `totals.storageBytes` | 4,422 | files |
| `totals.uniqueViewers` | 3,013 | events |
| `activeViewers30d` | 3,013 | events |
| `totals.views` | 3,012 | events |
| `series.sites` | 1,120 | sites |
| `series.comments` | 611 | comments |
| `totals.sites` | 574 | sites |
| `totals.comments` | 316 | comments |
| `series.signups` | 115 | users |
| `totals.users` | 65 | users |
| **total** | **~55,200** | |

`events` is 79% of the page. The two CLI figures alone are **21,986 rows — 40%** — and `series.cli` is the single most expensive query on the dashboard.

Root cause: **the CLI is chattier than the site itself.** 7,329 cli events vs 3,012 page views, because every authenticated CLI call writes a row. So any all-table aggregate over `events` is dominated by CLI noise. `count(*)` and `count(distinct …)` are questions about every row by definition — no index makes them cheap.

## Change

Drops both CLI rollups from `computeStats` and both cards ("CLI invocations" tile, "CLI" sparkline) from the admin overview. **~55k → ~33k rows per compute.**

`events` type `'cli'` rows are **still written** (`middleware/analytics.ts`) — `/api/auth/me`'s `hasUsedCli` probe reads one to hide the CLI-install banner, and that stays a single indexed `limit(1)` lookup. Only the dashboard aggregates are gone.

`STATS_CACHE_KEY` bumped to `v2`: the cached value is a serialized `Stats`, so without a new key the deploy would keep serving the old shape until the TTL lapsed and the dashboard would render `undefined` for the removed fields.

## Tests

The tests keep seeding cli rows and now assert they **never leak** into the view counts or any series bucket — a stronger invariant than the assertions they replace.

954 pass / 0 fail, `tsc --noEmit` clean on both packages, web build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PbciFznMtdGMjsbH3LNkuh