### PR TITLE
style(stars): dim the unstarred star icon

### DIFF
--- a/packages/web/src/components/ViewerTopBar.tsx
+++ b/packages/web/src/components/ViewerTopBar.tsx
@@ -106,7 +106,7 @@ export function ViewerTopBar({
             aria-pressed={starred}
             onClick={() => void toggleStar()}
           >
-            <Star className={starred ? 'fill-primary text-primary' : undefined} />
+            <Star className={starred ? 'fill-primary text-primary' : 'opacity-60'} />
           </Button>
         )}
         {/* Fork is deliberately NOT gated on site.isOwner (unlike Share): anyone who can read a

--- a/packages/web/src/components/siteColumns.tsx
+++ b/packages/web/src/components/siteColumns.tsx
@@ -31,6 +31,9 @@ export function starColumn<T extends SiteSummary>(): Column<T> {
   }
 }
 
+// A starred row should read as the emphasized state, so the UNstarred icon is dimmed rather than
+// the starred one brightened — it sits in the first column of every row and would otherwise pull
+// the eye across a whole table of pages nobody has starred.
 function StarCell({ site }: { site: SiteSummary }) {
   const { starred, toggle } = useStar(site)
   return (
@@ -42,7 +45,7 @@ function StarCell({ site }: { site: SiteSummary }) {
       aria-pressed={starred}
       onClick={toggle}
     >
-      <Star className={starred ? 'fill-primary text-primary' : undefined} />
+      <Star className={starred ? 'fill-primary text-primary' : 'opacity-60'} />
     </Button>
   )
 }


### PR DESCRIPTION
The star cell is the first column of every site row, so at full strength a table of *unstarred* pages competed with an actual star for attention. This dims the empty state (`opacity-60`) and leaves the starred appearance exactly as-is — emphasis comes from the filled icon, not from everything else being loud.

One line, in the two places the icon renders (`starColumn`'s cell and the viewer top bar).

| Dark | Light |
|---|---|
| <img src="https://github.com/plivo-labs/glance/releases/download/star-page-shots/star-dim-after2.png" width="420"> | <img src="https://github.com/plivo-labs/glance/releases/download/star-page-shots/star-dim-light.png" width="420"> |

Starred `q3-deck` vs unstarred `roadmap`/`notes`; `draft` is private, so it has no control at all (unchanged).

Checked in both themes because opacity reads differently against a light background. Suite unchanged: 969 api + 203 web, typecheck clean.
