### PR TITLE
feat(fork): fork asks first — a modal with Name + Visibility

### DIFF
--- a/packages/api/src/routes/sites-fork.test.ts
+++ b/packages/api/src/routes/sites-fork.test.ts
@@ -128,6 +128,57 @@ describe('POST /api/sites/:space/:site/fork', () => {
     expect((await fork(app, env, 'rd', { slug: 'Not A Slug' })).status).toBe(400)
   })
 
+  test('fork.custom.title: an explicit title is honoured; an omitted one keeps the source’s', async () => {
+    const { db, app, env } = await setup()
+    await fork(app, env, 'rd', { title: '  My Fork  ', slug: 'named' })
+    await fork(app, env, 'rd', { slug: 'unnamed' })
+    const named = (await db.select().from(sitesTable).where(eq(sitesTable.slug, 'named')))[0]
+    const unnamed = (await db.select().from(sitesTable).where(eq(sitesTable.slug, 'unnamed')))[0]
+    expect(named?.title).toBe('My Fork')
+    expect(unnamed?.title).toBe('Doc')
+  })
+
+  // The fork dialog lets the user choose who can see the copy. An OMITTED visibility keeps the old
+  // behaviour (inherit the source's tier) — the dialog just defaults its picker to that.
+  test('fork.visibility.inherited: an omitted visibility still inherits the source tier', async () => {
+    const { db, app, env } = await setup()
+    expect((await fork(app, env, 'rd')).status).toBe(200)
+    const copy = (await db.select().from(sitesTable).where(eq(sitesTable.slug, 'doc-copy')))[0]
+    expect(copy?.visibility).toBe('team')
+  })
+
+  test('fork.visibility.chosen: an explicit tier wins — including narrowing a team site to private', async () => {
+    const { db, app, env } = await setup()
+    expect((await fork(app, env, 'rd', { visibility: 'private', slug: 'priv' })).status).toBe(200)
+    expect((await fork(app, env, 'rd', { visibility: 'members', slug: 'memb' })).status).toBe(200)
+    expect((await fork(app, env, 'rd', { visibility: 'team', slug: 'tier' })).status).toBe(200)
+    const tier = async (slug: string) =>
+      (await db.select().from(sitesTable).where(eq(sitesTable.slug, slug)))[0]?.visibility
+    expect(await tier('priv')).toBe('private')
+    expect(await tier('memb')).toBe('members')
+    expect(await tier('tier')).toBe('team')
+  })
+
+  // Same normalization the PATCH route uses: legacy wire values are mapped, never rejected.
+  test('fork.visibility.legacy: `public` normalizes to team rather than 400ing', async () => {
+    const { db, app, env } = await setup()
+    expect((await fork(app, env, 'rd', { visibility: 'public', slug: 'legacy' })).status).toBe(200)
+    const copy = (await db.select().from(sitesTable).where(eq(sitesTable.slug, 'legacy')))[0]
+    expect(copy?.visibility).toBe('team')
+  })
+
+  test('fork.visibility.invalid: junk 400s and copies nothing', async () => {
+    const { db, app, env, r2 } = await setup()
+    for (const visibility of ['nope', 42, null, {}]) {
+      const res = await fork(app, env, 'rd', { visibility })
+      expect(res.status).toBe(400)
+      expect(await res.json()).toMatchObject({ error: 'invalid visibility' })
+    }
+    // Validation runs before any R2 copy or D1 write — nothing was created.
+    expect((await db.select().from(sitesTable).where(eq(sitesTable.spaceId, 'rd-personal'))).length).toBe(0)
+    expect(r2.store.size).toBe(2)
+  })
+
   test('fork.no.read.403: a stranger with no access cannot fork', async () => {
     const { db, app, env } = await setup()
     await db.update(sitesTable).set({ visibility: 'private' }).where(eq(sitesTable.id, 'site'))

--- a/packages/api/src/routes/sites.ts
+++ b/packages/api/src/routes/sites.ts
@@ -592,12 +592,25 @@ sites.post('/:spaceSlug/:siteSlug/fork', requireAuth, async (c) => {
   if (!site) return c.json({ error: 'not found' }, 404)
   if (!access.ok) return c.json({ error: 'forbidden' }, access.status)
 
-  const body = (await c.req.json().catch(() => null)) as { space?: unknown; slug?: unknown; title?: unknown } | null
+  const body = (await c.req.json().catch(() => null)) as {
+    space?: unknown
+    slug?: unknown
+    title?: unknown
+    visibility?: unknown
+  } | null
   const wantSpace = body?.space
   const wantSlug = body?.slug
   if (wantSpace !== undefined && typeof wantSpace !== 'string') return c.json({ error: 'invalid space' }, 400)
   if (wantSlug !== undefined && typeof wantSlug !== 'string') return c.json({ error: 'invalid slug' }, 400)
   if (typeof wantSlug === 'string' && !isValidSlug(wantSlug)) return c.json({ error: 'invalid slug' }, 400)
+
+  // Same normalize-then-validate as PATCH, so legacy wire tiers are mapped rather than rejected.
+  let wantVisibility: Visibility | undefined
+  if (body?.visibility !== undefined) {
+    const vis = normalizeVisibility(body.visibility)
+    if (!isVisibility(vis)) return c.json({ error: 'invalid visibility' }, 400)
+    wantVisibility = vis
+  }
 
   // Destination: an explicitly named space, else the caller's personal space. A user with neither
   // gets a 400 — never a silent fork into somewhere they didn't ask for.
@@ -652,8 +665,9 @@ sites.post('/:spaceSlug/:siteSlug/fork', requireAuth, async (c) => {
         // A fork COPIES the bytes, so it inherits the blurb derived from them; the next replace
         // re-derives it from whatever the fork's own content becomes.
         description: site.description,
-        // Inherit the source's tier: a fork of a private site is private, not silently widened.
-        visibility: site.visibility,
+        // The forker picks the tier (the fork dialog defaults its picker to the source's). Omit it
+        // and the source's tier is inherited: a fork of a private site is never silently widened.
+        visibility: wantVisibility ?? site.visibility,
         ownerId: user.id,
         forkedFrom: site.id,
       }),

--- a/packages/web/src/components/ForkDialog.test.tsx
+++ b/packages/web/src/components/ForkDialog.test.tsx
@@ -1,0 +1,87 @@
+// Fork asks first: the menu item opens this dialog, and only its Fork button POSTs. The dialog
+// owns the form (name + visibility); the hook still owns the request, the toast and the navigate.
+import { describe, expect, mock, test } from 'bun:test'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { createMemoryRouter, RouterProvider } from 'react-router'
+import type { Visibility } from '@/lib/types'
+import { ForkDialog } from './ForkDialog'
+
+const SITE = { spaceSlug: 'sp', siteSlug: 'my-site', title: 'My Page', visibility: 'members' as Visibility }
+
+type Call = { url: string; body: Record<string, unknown> }
+
+function stubFetch(status = 200, body: unknown = { spaceSlug: 'me', siteSlug: 'my-page-copy' }) {
+  const calls: Call[] = []
+  globalThis.fetch = ((url: string, init?: RequestInit) => {
+    calls.push({ url, body: JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown> })
+    return Promise.resolve(
+      new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } }),
+    )
+  }) as unknown as typeof fetch
+  return calls
+}
+
+// A DATA router: useForkSite navigates to the fork on success. The splat route swallows that
+// navigation so a successful fork doesn't blow up the render.
+function renderDialog(site: typeof SITE = SITE) {
+  const onOpenChange = mock((_open: boolean) => {})
+  const router = createMemoryRouter([
+    { path: '/', element: <ForkDialog site={site} open onOpenChange={onOpenChange} /> },
+    { path: '*', element: null },
+  ])
+  render(<RouterProvider router={router} />)
+  return { onOpenChange, name: screen.getByLabelText('Name') as HTMLInputElement }
+}
+
+const clickFork = () => fireEvent.click(screen.getByRole('button', { name: 'Fork' }))
+
+describe('ForkDialog', () => {
+  test('prefills the name from the source title and shows the slug it derives', () => {
+    const { name } = renderDialog()
+    expect(name.value).toBe('My Page (copy)')
+    expect(document.body.textContent).toContain('my-page-copy')
+  })
+
+  test('a site with NO title falls back to its slug', () => {
+    const { name } = renderDialog({ ...SITE, title: null })
+    expect(name.value).toBe('my-site (copy)')
+    expect(document.body.textContent).toContain('my-site-copy')
+  })
+
+  test('the visibility picker defaults to the source tier (a fork is never silently widened)', () => {
+    renderDialog()
+    expect(screen.getByRole('button', { name: /Members/ })).toBeDefined()
+  })
+
+  test('Fork POSTs the name, the derived slug and the chosen visibility — then closes', async () => {
+    const calls = stubFetch()
+    const { onOpenChange } = renderDialog()
+    clickFork()
+    await waitFor(() => expect(calls.length).toBe(1))
+    expect(calls[0]?.url).toBe('/api/sites/sp/my-site/fork')
+    expect(calls[0]?.body).toEqual({ title: 'My Page (copy)', slug: 'my-page-copy', visibility: 'members' })
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false))
+  })
+
+  test('a name with no usable slug sends NO slug key — the API’s -copy dedupe names the copy', async () => {
+    const calls = stubFetch()
+    const { name } = renderDialog()
+    fireEvent.change(name, { target: { value: '🙂' } })
+    clickFork()
+    await waitFor(() => expect(calls.length).toBe(1))
+    expect(calls[0]?.body).toEqual({ title: '🙂', visibility: 'members' })
+    expect('slug' in (calls[0]?.body ?? {})).toBe(false)
+  })
+
+  test('a 409 slug conflict leaves the dialog OPEN so the name can be edited', async () => {
+    const calls = stubFetch(409, { error: 'a site with this slug already exists in that space', conflict: true })
+    const { onOpenChange, name } = renderDialog()
+    clickFork()
+    await waitFor(() => expect(calls.length).toBe(1))
+    await waitFor(() =>
+      expect((screen.getByRole('button', { name: 'Fork' }) as HTMLButtonElement).disabled).toBe(false),
+    )
+    expect(onOpenChange).not.toHaveBeenCalled()
+    expect(name.isConnected).toBe(true)
+  })
+})

--- a/packages/web/src/components/ForkDialog.tsx
+++ b/packages/web/src/components/ForkDialog.tsx
@@ -1,0 +1,101 @@
+import { useCallback, useState } from 'react'
+import { forkSlug, useForkSite } from '@/hooks/useForkSite'
+import type { Visibility } from '@/lib/types'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { MountSensor } from '@/components/ui/mount-sensor'
+import { Spinner } from '@/components/states'
+import { VisibilityMenu } from '@/components/visibility'
+
+type ForkSource = { spaceSlug: string; siteSlug: string; title: string | null; visibility: Visibility }
+
+const forkName = (site: ForkSource) => `${site.title ?? site.siteSlug} (copy)`
+
+// Fork used to be fire-and-forget: an empty POST body, a `-copy` slug the user never saw and the
+// source's visibility inherited in silence. This dialog is the ask — a name and a tier — and it is
+// the ONLY way either call site (viewer hamburger, dashboard kebab) reaches useForkSite.
+//
+// The URL slug is derived from the name rather than typed: one field to fill, and the destination
+// path is shown under it so the derivation is never a surprise. The destination SPACE is
+// deliberately not offered — a fork still lands in the caller's personal space.
+export function ForkDialog({
+  site,
+  open,
+  onOpenChange,
+}: {
+  site: ForkSource
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}) {
+  const { fork, forking } = useForkSite(site)
+  const [name, setName] = useState(() => forkName(site))
+  const [visibility, setVisibility] = useState<Visibility>(site.visibility)
+  const slug = forkSlug(name)
+  const nameId = `fork-${site.spaceSlug}-${site.siteSlug}`
+
+  // Reseed the form each time the dialog opens, on a plain sensor element rather than a ref on
+  // DialogContent: Radix recomposes content refs on every render, which would snap the name field
+  // back on every keystroke (cf. RenameDialog in SitesTable).
+  const seed = useCallback(() => {
+    setName(forkName(site))
+    setVisibility(site.visibility)
+  }, [site])
+
+  async function confirm() {
+    if (await fork({ title: name, visibility })) onOpenChange(false)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !forking && onOpenChange(o)}>
+      <DialogContent>
+        <MountSensor onMount={seed} />
+        <DialogHeader>
+          <DialogTitle>Fork site</DialogTitle>
+          <DialogDescription>
+            Copies <span className="font-mono">{`${site.spaceSlug}/${site.siteSlug}`}</span> into your personal space.
+            The copy is independent — its own files, no shares, no comments.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-1.5">
+          {/* Per-row id, like RenameDialog/MoveDialog: the dashboard mounts one of these per site. */}
+          <Label htmlFor={nameId}>Name</Label>
+          <Input id={nameId} value={name} disabled={forking} onChange={(e) => setName(e.target.value)} />
+          <p className="text-muted-foreground text-xs">
+            {slug ? (
+              <>
+                URL: <span className="font-mono">{slug}</span>
+              </>
+            ) : (
+              // Nothing usable to derive — the API falls back to its own `<slug>-copy` dedupe.
+              <>That name has no usable URL slug, so one is picked from the original.</>
+            )}
+          </p>
+        </div>
+        <div className="space-y-1.5">
+          <Label>Visibility</Label>
+          <div>
+            <VisibilityMenu value={visibility} onChange={setVisibility} disabled={forking} />
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="outline" disabled={forking} onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button disabled={forking} onClick={() => void confirm()}>
+            {forking && <Spinner />}
+            Fork
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/packages/web/src/components/SitesTable.tsx
+++ b/packages/web/src/components/SitesTable.tsx
@@ -3,6 +3,7 @@ import { useRevalidator } from 'react-router'
 import { Copy, FolderInput, GitFork, MoreVertical, Pencil, Share2, Sparkles, Trash2 } from 'lucide-react'
 import { toast } from 'sonner'
 import { ConfirmDialog } from '@/components/ConfirmDialog'
+import { ForkDialog } from '@/components/ForkDialog'
 import { ShareDialog } from '@/components/ShareDialog'
 import { SummarySheet } from '@/components/SummarySheet'
 import {
@@ -37,7 +38,6 @@ import {
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { MountSensor } from '@/components/ui/mount-sensor'
-import { useForkSite } from '@/hooks/useForkSite'
 import { api } from '@/lib/api'
 import type { SiteSummary, SpaceSummary, Visibility } from '@/lib/types'
 
@@ -92,14 +92,12 @@ function OwnerVisibilityCell({ site }: { site: SiteSummary }) {
   return <VisibilityMenu trigger="chip" value={visibility} onChange={changeVisibility} />
 }
 
-type RowDialog = 'rename' | 'move' | 'share' | 'summary' | 'delete' | null
+type RowDialog = 'rename' | 'move' | 'share' | 'summary' | 'fork' | 'delete' | null
 
 // Open + a kebab that collapses Rename / Move / Share / Copy link / Fork / Delete.
 function OwnerActions({ site }: { site: SiteSummary }) {
   const revalidator = useRevalidator()
   const [dialog, setDialog] = useState<RowDialog>(null)
-  // Fork needs no dialog: it POSTs an empty body and the API picks the destination + free slug.
-  const { fork, forking } = useForkSite(site)
   const refresh = () => revalidator.revalidate()
   const close = () => setDialog(null)
 
@@ -142,7 +140,7 @@ function OwnerActions({ site }: { site: SiteSummary }) {
             <Copy />
             Copy link
           </DropdownMenuItem>
-          <DropdownMenuItem disabled={forking} onSelect={() => void fork()}>
+          <DropdownMenuItem onSelect={() => setDialog('fork')}>
             <GitFork />
             Fork
           </DropdownMenuItem>
@@ -165,6 +163,7 @@ function OwnerActions({ site }: { site: SiteSummary }) {
         open={dialog === 'share'}
         onOpenChange={(o) => !o && close()}
       />
+      <ForkDialog site={site} open={dialog === 'fork'} onOpenChange={(o) => !o && close()} />
       <SummarySheet
         spaceSlug={site.spaceSlug}
         siteSlug={site.siteSlug}

--- a/packages/web/src/components/ViewerTopBar.tsx
+++ b/packages/web/src/components/ViewerTopBar.tsx
@@ -1,12 +1,12 @@
 import { ChevronRight, Command, GitFork, History, Menu, MessageSquare, Share2, Sparkles, Star } from 'lucide-react'
 import { useState } from 'react'
 import { Link } from 'react-router'
-import { useForkSite } from '@/hooks/useForkSite'
 import { useStar } from '@/hooks/useStar'
 import type { ViewerSite } from '@/lib/types'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu'
+import { ForkDialog } from '@/components/ForkDialog'
 import { ShareDialog } from '@/components/ShareDialog'
 import { SummarySheet } from '@/components/SummarySheet'
 import { BrandMark } from '@/components/states'
@@ -21,7 +21,7 @@ import { BrandMark } from '@/components/states'
 //
 // The row is the same three controls at EVERY breakpoint: only Star and Comments earn a permanent
 // slot; Recently opened / Search / Fork / TL;DR / Share live in the hamburger menu. Those menu
-// items are driven from shared state (useForkSite, SummarySheet, ShareDialog) held here, so the
+// items are driven from shared state (ForkDialog, SummarySheet, ShareDialog) held here, so the
 // menu item and the sheet/dialog it opens are one action.
 export function ViewerTopBar({
   site,
@@ -42,7 +42,7 @@ export function ViewerTopBar({
 }) {
   const [summaryOpen, setSummaryOpen] = useState(false)
   const [shareOpen, setShareOpen] = useState(false)
-  const { fork, forking } = useForkSite(site)
+  const [forkOpen, setForkOpen] = useState(false)
   // Star has a permanent slot in the row, so it is the one action with no menu-item twin.
   const { starred, toggle: toggleStar } = useStar(site)
   return (
@@ -111,7 +111,7 @@ export function ViewerTopBar({
             </DropdownMenuItem>
             {/* Fork is deliberately NOT gated on site.isOwner (unlike Share): anyone who can read a
                 site can fork it, so a plain viewer gets this too. */}
-            <DropdownMenuItem disabled={forking} onSelect={() => void fork()}>
+            <DropdownMenuItem onSelect={() => setForkOpen(true)}>
               <GitFork />
               Fork
             </DropdownMenuItem>
@@ -128,8 +128,9 @@ export function ViewerTopBar({
           </DropdownMenuContent>
         </DropdownMenu>
       </div>
-      {/* Both render through a portal, so they can live inside the header without affecting layout.
-          Controlled (no inline trigger) — their menu items drive this state. */}
+      {/* All three render through a portal, so they can live inside the header without affecting
+          layout. Controlled (no inline trigger) — their menu items drive this state. */}
+      <ForkDialog site={site} open={forkOpen} onOpenChange={setForkOpen} />
       <SummarySheet
         spaceSlug={site.spaceSlug}
         siteSlug={site.siteSlug}

--- a/packages/web/src/hooks/useForkSite.ts
+++ b/packages/web/src/hooks/useForkSite.ts
@@ -2,13 +2,16 @@ import { useState } from 'react'
 import { useNavigate } from 'react-router'
 import { toast } from 'sonner'
 import { api } from '@/lib/api'
+import { slugify } from '@/lib/slug'
+import type { Visibility } from '@/lib/types'
 
 // Fork = copy a site's files into a space of your own. ANY user who can READ a site can fork it,
 // so this is offered to plain viewers too — not just owners/editors (cf. the owner-only kebab
 // actions, which are gated by the table they live in).
 //
-// The empty body is the happy path: the API forks into the caller's personal space under
-// `<slug>-copy` (auto-deduped to `-copy-2`…), so the UI needs no dialog and no inputs.
+// Fork asks first: ForkDialog collects the name and the visibility tier and calls this hook, which
+// owns the POST, the toast and the navigate. The destination space is NOT asked for — the fork
+// always lands in the caller's personal space, which is what an empty `space` means to the API.
 // On success we navigate to the fork — the response carries its space/site — which both shows the
 // result and (on the dashboard) leaves a route whose loader refetches the site list on return.
 interface ForkedSite {
@@ -17,24 +20,38 @@ interface ForkedSite {
   url: string
 }
 
+// The API's slug rules bottom out at 3 characters (packages/api/src/lib/slug.ts), so a name that
+// slugifies to nothing ("🙂", "---") or to a stub ("hi") would 400. Send no slug at all in that
+// case and let the fork route's own `<slug>-copy` dedupe name the copy.
+export function forkSlug(name: string): string | undefined {
+  const slug = slugify(name)
+  return slug.length >= 3 ? slug : undefined
+}
+
 export function useForkSite(site: { spaceSlug: string; siteSlug: string }) {
   const navigate = useNavigate()
   const [forking, setForking] = useState(false)
 
-  async function fork() {
-    if (forking) return
+  // Resolves true only when the fork landed. The dialog closes on true and STAYS OPEN on false, so
+  // a rejected name (the 409 slug conflict) can be edited and retried instead of being lost.
+  async function fork({ title, visibility }: { title: string; visibility: Visibility }): Promise<boolean> {
+    if (forking) return false
     setForking(true)
     try {
-      const forked = await api.post<ForkedSite>(
-        `/api/sites/${site.spaceSlug}/${site.siteSlug}/fork`,
-        {},
-      )
+      const slug = forkSlug(title)
+      const forked = await api.post<ForkedSite>(`/api/sites/${site.spaceSlug}/${site.siteSlug}/fork`, {
+        title,
+        visibility,
+        ...(slug ? { slug } : {}),
+      })
       toast.success('Site forked', { description: `${forked.spaceSlug}/${forked.siteSlug}` })
       navigate(`/${forked.spaceSlug}/${forked.siteSlug}`)
+      return true
     } catch (err) {
       toast.error('Could not fork site', {
         description: err instanceof Error ? err.message : undefined,
       })
+      return false
     } finally {
       setForking(false)
     }


### PR DESCRIPTION
## Before / after

| | before | after |
| --- | --- | --- |
| Clicking Fork | POSTs an **empty body** immediately | opens a **modal**; only its Fork button POSTs |
| Name | none — API names the copy `<slug>-copy` (`-copy-2`… on collision) | text input, prefilled `<title> (copy)`, falling back to the slug when the site has no title |
| URL slug | never shown | derived from the name via the existing `slugify`, shown read-only under the field |
| Visibility | source's tier, silently | `VisibilityMenu`, **defaulted to the source's tier** |
| Destination space | caller's personal space | unchanged — deliberately not asked for |

Both entry points go through the same modal: the viewer hamburger (`ViewerTopBar`) and the dashboard owner kebab (`SitesTable`). Neither imports `useForkSite` any more — the hook is instantiated once, inside `ForkDialog`, so there is **one fork code path**, not two.

## API — one new optional field

`POST /api/sites/:spaceSlug/:siteSlug/fork` now accepts an optional `visibility`, validated with the **existing** `normalizeVisibility` + `isVisibility` pair that `PATCH /api/sites/:spaceSlug/:siteSlug` already uses (no new validator):

- **omitted → inherit the source's tier.** Today's behaviour, byte-for-byte. Every existing caller (the CLI included) is unaffected.
- **present and valid → that tier wins**, including *narrowing* a `team` source to `private`.
- **`'public'` → `'team'`** — legacy wire values are normalized, not rejected, exactly as PATCH does.
- **junk (`'nope'`, `42`, `null`, `{}`) → `400 { error: 'invalid visibility' }`**, raised before any R2 copy or D1 write. A test asserts nothing was created on that path.

The "Inherit the source's tier" comment was updated so it stops claiming the fork always inherits.

## The 409 keeps the dialog open

`useForkSite.fork()` now returns `Promise<boolean>` — true only when the fork landed. The dialog closes on true and **stays open on false**, so a real slug conflict (`{ error: 'a site with this slug already exists in that space', conflict: true }`) surfaces in the error toast with the typed name still in the field, ready to edit and retry, instead of the dialog vanishing and taking the name with it. The hook still owns the POST, both toasts and the navigate.

## Two judgement calls worth reviewing

1. **`forkSlug` omits the slug below 3 characters, not just when empty.** The API's `isValidSlug` requires 3–40 chars, so `"Hi"` → `"hi"` would 400 where `"🙂"` → `""` would not. Web `slugify` already guarantees the rest of the rule (lowercase alnum + hyphens, no edge hyphens, ≤40), so the length floor is exactly the missing condition. Anything unusable sends **no `slug` key** and falls through to the API's own `-copy` dedupe. A name that slugifies onto a *reserved* slug (`"Public"` → `public`) still 400s — the dialog surfaces it and stays open, and the API's reserved list was not duplicated into web.
2. **The path hint shows the derived slug, not `<spaceSlug>/<slug>`.** The fork lands in the *caller's* personal space, and the only space slug the dialog has is the *source's* — printing it would be wrong on every fork. The dialog's description says "Copies `<source path>` into your personal space" and the field hint shows `URL: <derived-slug>`.

## Gates

| gate | result |
| --- | --- |
| `cd packages/api && bun test` | **1073 pass, 0 fail** (87 files) |
| `cd packages/web && bun test` | **294 pass, 0 fail** (30 files) — baseline 288 + 6 new `ForkDialog` tests, nothing dropped |
| `cd packages/web && bunx tsc --noEmit` | clean |
| `bunx biome check` on every file authored here (`ForkDialog.tsx`, `ForkDialog.test.tsx`, `useForkSite.ts`, `ViewerTopBar.tsx`) | clean, no fixes applied |
| `bunx tsc -p packages/api --noEmit` | **216 errors — identical count on a stashed baseline**, all the pre-existing missing-`worker-configuration.d.ts` class (`crypto`, `D1Database`, `R2Bucket`…). Unrelated to this change and unchanged by it |

Tests were written **red first**: the API tests failed 2/16 before the route change, and `ForkDialog.test.tsx` failed with `Cannot find module './ForkDialog'`.

**Tests added.** API (`sites-fork.test.ts`, +5): explicit title honoured / omitted keeps the source's; visibility inherited when omitted; explicit tier wins across all three tiers incl. narrowing; `'public'` normalizes to `team`; junk 400s and copies nothing. Web (`ForkDialog.test.tsx`, 6 new): title prefill + derived slug hint; `title: null` → slug fallback; picker defaults to the source tier; Fork POSTs `{ title, slug, visibility }` to the right URL then closes; a name with no usable slug POSTs **no `slug` key**; a 409 leaves the dialog open. The web test stubs `globalThis.fetch` the way `lib/api.test.ts` does — no `mock.module`, so nothing leaks process-wide.

## Two things to know

- **`biome check` stays red on `sites.ts`, `sites-fork.test.ts` and `SitesTable.tsx`** — all three were **already failing on `main`** (verified with `git stash`: 3 errors, same files, all `format`). I parsed biome's proposed diff per file and confirmed **zero overlap with any line this PR adds or changes**: the complaints sit at `sites.ts` 46/175-177/222-224/562, `sites-fork.test.ts` 6/42/57-59/79/106/113, and `SitesTable.tsx` 292-314 (`MoveDialog`). Running `--write` would have pulled a whole import block and two unrelated functions into this diff, so I left them alone.
- **No screenshot is attached.** `bun run dev:api` dies immediately with `The directory specified by the "assets.directory" field … does not exist: packages/web/dist` — it needs a `bun run build:web` first — and even with the API up, reaching a viewer page needs a real Google OAuth round trip plus a deployed site to open. The new dialog is covered by the 6 component tests instead.
