### PR TITLE
feat(comments): page comments on every view, not just audio (#112)

### DIFF
--- a/packages/web/src/components/review/ReviewRail.test.tsx
+++ b/packages/web/src/components/review/ReviewRail.test.tsx
@@ -56,6 +56,7 @@ function renderRail(threads: Thread[], focusRequest: { id: string; nonce: number
       onChanged={() => {}}
       onFocusAnchor={() => {}}
       onClose={() => {}}
+      onStartComment={() => {}}
       focusRequest={focusRequest}
     />,
   )
@@ -79,11 +80,66 @@ describe('ReviewRail — the header ✕ closes the panel (C2b: replaces the View
         onChanged={() => {}}
         onFocusAnchor={() => {}}
         onClose={onClose}
+        onStartComment={() => {}}
         focusRequest={null}
       />,
     )
     fireEvent.click(screen.getByRole('button', { name: 'Close comments' }))
     expect(called).toBe(true)
+  })
+})
+
+// #112 — page comments used to be an audio-only affordance: `onStartComment` was optional, viewer
+// passed it only when isAudio, and the rail rendered the trigger only when it was set. It is now
+// REQUIRED and always rendered, so a page comment can be written from any content type. The
+// alternative considered — an always-mounted textarea instead of this button — was rejected: the
+// rail's `composing` and the popover's own composer are independent states, so an always-open
+// textarea makes "two live drafts at once" the default on every text selection.
+describe('ReviewRail — the page-comment trigger (#112)', () => {
+  function renderWithStart(extra: { getCurrentTime?: () => number } = {}) {
+    let started = 0
+    const view = render(
+      <ReviewRail
+        site={SITE}
+        me={ME}
+        threads={[]}
+        composing={null}
+        onCancelComposer={() => {}}
+        onCreate={() => {}}
+        onCreateVoice={() => {}}
+        onChanged={() => {}}
+        onFocusAnchor={() => {}}
+        onClose={() => {}}
+        onStartComment={() => {
+          started++
+        }}
+        focusRequest={null}
+        {...extra}
+      />,
+    )
+    return { ...view, startedCount: () => started }
+  }
+
+  test('the trigger is offered with no audio player present, and clicking it starts a page comment', () => {
+    // No getCurrentTime — i.e. an HTML page, the exact case the old gate excluded.
+    const { startedCount } = renderWithStart()
+    fireEvent.click(screen.getByRole('button', { name: 'Add comment' }))
+    expect(startedCount()).toBe(1)
+  })
+
+  test('the empty state names BOTH creation paths on a page you can select text in', () => {
+    renderWithStart()
+    const empty = screen.getByText(/Add a comment above/)
+    // Naming only the button would leave the selection path undiscoverable now that the rail no
+    // longer says "Select text to comment."
+    expect(empty.textContent).toContain('select text')
+  })
+
+  test('the audio empty state does NOT offer a select-text path (there is no DOM to select in)', () => {
+    renderWithStart({ getCurrentTime: () => 0 })
+    const empty = screen.getByText(/Add a comment above/)
+    expect(empty.textContent).not.toContain('select text')
+    expect(empty.textContent).toContain('timestamp')
   })
 })
 
@@ -122,6 +178,7 @@ describe('ReviewRail — reveal-by-nonce', () => {
         onChanged={() => {}}
         onFocusAnchor={() => {}}
       onClose={() => {}}
+        onStartComment={() => {}}
         focusRequest={{ id: 't1', nonce: 2 }}
       />,
     )
@@ -149,6 +206,7 @@ describe('ReviewRail — reveal-by-nonce', () => {
         onChanged={() => {}}
         onFocusAnchor={() => {}}
       onClose={() => {}}
+        onStartComment={() => {}}
         focusRequest={{ id: 't1', nonce: 1 }}
       />,
     )
@@ -172,6 +230,7 @@ describe('ReviewRail — reveal-by-nonce', () => {
         onChanged={() => {}}
         onFocusAnchor={() => {}}
       onClose={() => {}}
+        onStartComment={() => {}}
         focusRequest={{ id: 't2', nonce: 2 }}
       />,
     )
@@ -204,6 +263,7 @@ describe('ReviewRail — reveal-by-nonce', () => {
         onChanged={() => {}}
         onFocusAnchor={() => {}}
       onClose={() => {}}
+        onStartComment={() => {}}
         focusRequest={{ id: 't1', nonce: 1 }}
       />,
     )

--- a/packages/web/src/components/review/ReviewRail.tsx
+++ b/packages/web/src/components/review/ReviewRail.tsx
@@ -53,9 +53,11 @@ export function ReviewRail({
   // not just `id` — see shouldReveal — so the SAME thread can be re-requested (e.g. clicking the
   // same highlight twice) and still reveal.
   focusRequest?: RevealRequest | null
-  // Set only for content with no DOM to select in (the audio view) — offers a plain "Add
-  // comment" trigger that opens the composer with a bare page anchor, no text/element pending.
-  onStartComment?: () => void
+  // Opens the composer on a bare page anchor — no text/element pending. REQUIRED, for every
+  // content type (#112): its optionality used to BE the gate that limited page comments to the
+  // audio view, so the type is what keeps it ungated. Text selection still composes in the
+  // popover; this is the "about the page as a whole" path.
+  onStartComment: () => void
   // Set only for the audio view — lets the composer's timestamp button read the player's
   // current position (via a ref, at click time) without any state/effect wiring.
   getCurrentTime?: () => number
@@ -142,9 +144,15 @@ export function ReviewRail({
         </Button>
       </header>
 
-      {/* The rail composes PAGE comments only (audio's "Add comment"). A text selection composes in
-          the popover over the content, and element comments no longer exist as a creation path — so
-          there is no anchor preview to draw here, only the composer. */}
+      {/* The rail composes PAGE comments only ("Add comment"). A text selection composes in the
+          popover over the content, and element comments no longer exist as a creation path — so
+          there is no anchor preview to draw here, only the composer.
+
+          A BUTTON, not an always-mounted textarea (#112): `composing` here and the popover's own
+          composer are independent states (viewer.tsx:86,94) — nothing clears one when the other
+          opens — so a permanently-open textarea would make "two live drafts, no rule for which
+          wins" the DEFAULT state on every text selection, and would spend ~100px of a 55vh mobile
+          bottom sheet on every reader who came only to read. */}
       {composing ? (
         <div className="border-b bg-muted/40 p-3">
           <Composer
@@ -160,14 +168,12 @@ export function ReviewRail({
           />
         </div>
       ) : (
-        onStartComment && (
-          <div className="border-b p-3">
-            <Button type="button" variant="outline" size="sm" className="w-full" onClick={onStartComment}>
-              <MessageSquarePlus className="size-3.5" />
-              Add comment
-            </Button>
-          </div>
-        )
+        <div className="border-b p-3">
+          <Button type="button" variant="outline" size="sm" className="w-full" onClick={onStartComment}>
+            <MessageSquarePlus className="size-3.5" />
+            Add comment
+          </Button>
+        </div>
       )}
 
       <div className="flex gap-1 px-4 py-2">
@@ -187,13 +193,16 @@ export function ReviewRail({
       </div>
 
       <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto px-4 pb-4">
+        {/* Both creation paths get named (#112). Keyed on getCurrentTime, which is the one prop
+            that is still genuinely audio-only — the audio view has no DOM to select text in, so
+            offering it a "select text" path would be a lie. */}
         {active.length === 0 && !composing && (
           <p className="px-1 py-8 text-center text-muted-foreground text-sm">
             {filter !== 'open'
               ? 'No resolved threads.'
-              : onStartComment
+              : getCurrentTime
                 ? 'Add a comment above — optionally with a timestamp.'
-                : 'Select text to comment.'}
+                : 'Add a comment above, or select text on the page to anchor one.'}
           </p>
         )}
         {active.map((t) => (

--- a/packages/web/src/components/review/ThreadCard.tsx
+++ b/packages/web/src/components/review/ThreadCard.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Check, Mic, RotateCcw, Trash2 } from 'lucide-react'
+import { Check, FileText, Mic, RotateCcw, Trash2 } from 'lucide-react'
 import { toast } from 'sonner'
 import { ApiError } from '@/lib/api'
 import { comments, type CommentItem, type CommentReaction, type Thread } from '@/lib/comments'
@@ -96,7 +96,14 @@ export function ThreadCard({
             “{thread.quote}”
           </button>
         ) : (
-          <span className="text-muted-foreground text-xs">Page comment</span>
+          // No quote and no element: a PAGE thread, about the file as a whole. It paints nothing on
+          // the page (paintAnchors, lib/comments.ts) and has nothing to focus, so this is a static
+          // marker, not a button — but it's chip-weight like AnchorChip so the card doesn't read as
+          // an anchorless orphan beside anchored ones (#112).
+          <span className="inline-flex items-center gap-1 rounded bg-muted px-1.5 py-0.5 font-medium text-muted-foreground text-xs">
+            <FileText className="size-3" />
+            Page
+          </span>
         )}
       </div>
 

--- a/packages/web/src/lib/comments.test.ts
+++ b/packages/web/src/lib/comments.test.ts
@@ -13,6 +13,15 @@ describe('pendingToInput — pending anchor → NewThreadInput', () => {
     })
   })
 
+  // #112: a page pending is no longer audio-only — an HTML page can be commented on as a whole,
+  // without picking an arbitrary sentence to hang the comment off. The map is the same either way;
+  // this pins the HTML case so the payload can't quietly grow a quote for it.
+  test('a page pending from an HTML page → anchorType page with NO quote key', () => {
+    const input = pendingToInput('index.html', 'this chart is wrong', { kind: 'page' })
+    expect(input).toEqual({ filePath: 'index.html', body: 'this chart is wrong', anchorType: 'page' })
+    expect(input).not.toHaveProperty('quote')
+  })
+
   test('a page pending (audio view — no DOM to anchor to) → a bare page payload, no quote/element', () => {
     expect(pendingToInput('song.mp3', 'love this bridge', { kind: 'page' })).toEqual({
       filePath: 'song.mp3',

--- a/packages/web/src/routes/viewer.test.tsx
+++ b/packages/web/src/routes/viewer.test.tsx
@@ -235,6 +235,44 @@ describe('viewer wiring — adding a comment opens the rail', () => {
   })
 })
 
+// #112 — the whole bug was one wiring line here: `onStartComment={isAudio ? startPageComment :
+// undefined}`, which handed the rail its page-comment trigger only on the audio view. SITE in this
+// file is an HTML page (index.html), so this is the non-audio case the gate excluded, driven
+// through the real rail and the real composer. Nothing below would survive re-adding the isAudio
+// gate: the button simply wouldn't render.
+describe('viewer wiring — a page comment can be written from a non-audio view (#112)', () => {
+  test('the rail\'s "Add comment" creates a page-anchored thread — anchorType page, no quote', async () => {
+    const create = spyOn(comments, 'create').mockResolvedValue(mkThread({ id: 'p1', anchorType: 'page', quote: null }))
+    const list = spyOn(comments, 'list').mockResolvedValue(THREADS)
+    const mentionable = spyOn(comments, 'mentionable').mockResolvedValue([])
+    try {
+      const { container } = renderViewer('/sp/site?review=1')
+      await waitFor(() => expect(container.querySelector('iframe')).not.toBeNull())
+      const { iframe, send } = armIframe(container)
+      loadIframe(iframe)
+      act(() => send({ type: 'glance:ready', filePath: 'index.html' })) // gives submitThread its filePath
+
+      // No text selection anywhere in this test — that is the point of a page comment.
+      fireEvent.click(await screen.findByRole('button', { name: 'Add comment' }))
+      fireEvent.change(screen.getByRole('textbox'), { target: { value: 'this chart is wrong' } })
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: 'Comment' }))
+      })
+
+      expect(create).toHaveBeenCalledTimes(1)
+      const input = create.mock.calls[0]![1]
+      expect(input).toEqual({ filePath: 'index.html', body: 'this chart is wrong', anchorType: 'page' })
+      // Explicit, not implied by toEqual: a page thread must carry NO quote at all — sending an
+      // empty-string quote would make the server treat it as a text anchor it can never re-find.
+      expect(input).not.toHaveProperty('quote')
+    } finally {
+      create.mockRestore()
+      list.mockRestore()
+      mentionable.mockRestore()
+    }
+  })
+})
+
 describe('viewer wiring — rail toggle (C2b: the rail is just a panel, not a review-mode gate)', () => {
   // C2b's mutation-check found `toggleRail = () => setRailOpen(true)` (never closes) and
   // `onClose={() => {}}` both survive the whole suite green: ViewerTopBar.test.tsx only asserts the

--- a/packages/web/src/routes/viewer.tsx
+++ b/packages/web/src/routes/viewer.tsx
@@ -90,7 +90,10 @@ function Viewer() {
   const onDirtyChange = useCallback((d: boolean) => {
     dirtyRef.current = d
   }, [])
-  // The rail composer, now only ever the page (audio) anchor — element creation is gone (slice C2a).
+  // The rail composer, now only ever the page anchor — element creation is gone (slice C2a). Note
+  // this is INDEPENDENT of `popover` above: neither clears the other, so both can be open at once.
+  // That is why the rail offers a page comment behind a button rather than an always-open textarea
+  // (#112) — an always-open one would make two live drafts the norm, not the exception.
   const [composing, setComposing] = useState<PendingAnchor | null>(null)
   const [sidebarOpen, setSidebarOpen] = useState(false)
   const [cmdOpen, setCmdOpen] = useState(false)
@@ -303,8 +306,10 @@ function Viewer() {
 
   useEffect(paint, [paint])
 
-  // Audio view: no DOM to select text/elements in, so the rail's "Add comment" button starts a
-  // bare page-anchored composer directly (no selection step).
+  // The rail's "Add comment" button starts a bare page-anchored composer directly (no selection
+  // step) — for every content type, not just audio (#112). Audio NEEDS it (there is no DOM to
+  // select in); everywhere else it is how you say something about the page as a whole rather than
+  // about one arbitrary sentence. Text selection still composes in the popover, untouched.
   const startPageComment = useCallback(() => setComposing({ kind: 'page' }), [])
 
   // Read on demand (an event handler, not a subscription) — never causes a re-render, so the
@@ -566,7 +571,7 @@ function Viewer() {
             onChanged={() => filePath && refresh(filePath)}
             onFocusAnchor={scrollAnchor}
             onClose={closeRail}
-            onStartComment={isAudio ? startPageComment : undefined}
+            onStartComment={startPageComment}
             getCurrentTime={isAudio ? getCurrentTime : undefined}
             // Highlight clicks take over from the deep link once one has happened (see revealThread):
             // the link is one-shot at mount and carries a constant nonce, while a click re-requests


### PR DESCRIPTION
Closes #112.

You could only comment on a page by selecting text first, so saying something about the page as a whole — "this chart is wrong", "ship it", "who owns this?" — meant hanging the comment off an arbitrary sentence.

`anchorType: 'page'` was already wired end to end (schema, create route, `pendingToInput`, `startPageComment`, the rail trigger). One line in `viewer.tsx` handed the rail its trigger only when `isAudio`, because the audio view has no DOM to select in. That gate is the whole bug.

## The UX decision: a button, not an always-open textarea

The issue offered two options — reuse the existing "Add comment" button, or mount a textarea permanently at the top of the rail. The button wins, and not just because it's cheaper:

- **The rail composer and the popover composer are independent states.** `composing` and `popover.composer` are separate; nothing clears one when the other opens. Two composers can already be open at once. Behind a button that's a rare state you reach deliberately; with an always-open textarea it becomes the **default** — every text selection opens a second composer beside an already-open one, two live drafts, no rule for which wins.
- **The rail is a bottom sheet on mobile** (`max-h-[55vh]`). An always-mounted textarea spends a fixed slice of it on every page view, including for everyone who came to read rather than write.

So "simplest" and "best UX" land on the same option here, which isn't always true. The cost is one click before you can type — mitigated by the composer autofocusing.

## What changed

1. **Ungated the trigger.** `onStartComment` is passed for every content type. It is now a **required** prop: its optionality *was* the gate, so the type is what keeps it ungated, and the conditional render goes with it. `getCurrentTime` stays audio-only — the timestamp button is genuinely audio-specific.
2. **Empty-state copy names both paths** — "Add a comment above, or select text on the page to anchor one." Keyed on `getCurrentTime`, since audio has no DOM to select in and shouldn't be offered a path it doesn't have.
3. **Page threads read as anchored.** The no-quote fallback in `ThreadCard` was already a plain "Page comment" span; it's now a chip at the same weight as the element `AnchorChip`, so a page thread doesn't look like an orphan beside anchored ones. Static, not a button — a page thread paints nothing and has nothing to focus.

Not touched: `paintAnchors` still emits nothing for page threads. There's no DOM range to draw, and a page comment living in the rail only is correct.

## Tests

- `viewer.test.tsx` — a page comment written from a **non-audio** view (no selection anywhere in the test) sends `anchorType: 'page'` with **no** `quote` key. Re-adding the `isAudio` gate fails this test specifically: the button doesn't render.
- `ReviewRail.test.tsx` — the trigger is offered with no audio player present and fires; both empty-state copies.
- `comments.test.ts` — an HTML-page case on the `pendingToInput` seam.

## Gates

- `bun test` — web **323 pass / 0 fail** (318 before, +5 new); api **1088 pass / 0 fail**.
- `bunx tsc --noEmit` in `packages/web` — clean.

## One thing left alone

On a non-audio view `filePath` arrives via the iframe's `glance:ready` message, so clicking "Add comment" and submitting before the frame reports ready hits the existing "This page is still loading" toast and keeps the draft. Pre-existing behaviour, now reachable on HTML where it previously wasn't. Disabling the trigger until `loaded` would remove it — left out as scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MQGvQ6moUhT5ZU78sMajVb