### PR TITLE
feat(api-keys): control-plane API keys (#113)

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,18 @@ Defaults: `--space` = your personal space · `--name` = file/folder name slugifi
 
 The CLI keeps itself current (once-a-day background check, atomic in-place swap). Opt out with `GLANCE_NO_UPDATE=1`.
 
+## API keys & HTTP API
+
+`glance login` is interactive, so CI mints an **API key** at `/settings/keys` instead and exports it — `GLANCE_TOKEN` takes precedence over the stored config:
+
+```bash
+export GLANCE_TOKEN=glk_...              # shown exactly once at mint
+glance deploy ./dist                     # or call the API directly:
+curl -H "Authorization: Bearer $GLANCE_TOKEN" https://your-instance/api/sites/mine
+```
+
+A key authenticates the control plane as you and can only ever narrow your own access: it may create and deploy sites, never delete one, and never mint or revoke another key. Full endpoint reference, request/response shapes, grant semantics and the data-token exchange: **[packages/api/API.md](packages/api/API.md)**. In-app: `/docs/api-keys`.
+
 ## Security model
 
 - **Uploaded HTML/JS is untrusted** — served from a separate content origin (`CONTENT_URL`), so app session cookies never reach it. This is why Glance stands up two Workers, not one.

--- a/packages/api/API.md
+++ b/packages/api/API.md
@@ -1,13 +1,14 @@
 # Glance HTTP API
 
-The control plane a script, CI job, or agent talks to. Everything here is authenticated
-with an **API key** (`glk_…`) minted from `/settings/keys` — see
-[API keys](#api-keys) for how a key differs from your browser session and from the CLI's
-stored token.
+The HTTP control plane. Every endpoint below is callable with an **API key** (`glk_…`) minted from
+`/settings/keys`.
 
 Base URL is your instance origin (`https://glance.<your-subdomain>.workers.dev` by default).
 All request and response bodies are JSON unless noted; the one exception is
 [deploy](#deploy-files), which is `multipart/form-data`.
+
+> Looking for the `glance` CLI instead? See the [README](../../README.md#cli). The CLI is a client
+> of this API, not part of its contract — nothing here requires it.
 
 - [Authentication](#authentication)
 - [What a key may do](#what-a-key-may-do)
@@ -28,29 +29,21 @@ Send the key as a bearer token:
 curl -H "Authorization: Bearer $GLANCE_TOKEN" https://your-instance/api/sites/mine
 ```
 
-Three credential kinds reach the same routes, and the server records *which* one authenticated
-a request — the limits below apply to keys only:
+Three credential kinds reach these routes, and the server records *which* one authenticated a
+request. The [grant limits](#what-a-key-may-do) apply to API keys only:
 
-| Credential | Presented as | Notes |
+| Credential | Presented as | Governed by |
 | --- | --- | --- |
-| Browser session | `__Host-glance_session` cookie | Unsafe methods additionally require same-origin (CSRF). |
-| CLI device token | `Authorization: Bearer <token>` | Minted by `glance login`; governed by ownership alone. |
-| API key | `Authorization: Bearer glk_…` | Governed by ownership **and** the grants below. |
+| API key | `Authorization: Bearer glk_…` | Ownership **and** its grants |
+| Device token | `Authorization: Bearer <uuid>` | Ownership alone |
+| Browser session | `__Host-glance_session` cookie | Ownership alone; unsafe methods also require same-origin (CSRF) |
 
-A `glk_`-prefixed bearer is dispatched to the key store and never falls through to the CLI token
-store, or the reverse — an invalid key is a `401`, not a retry against the other store.
+A `glk_`-prefixed bearer is dispatched to the key store and never falls through to the device-token
+store, or the reverse — an invalid key is `401`, not a retry against the other store.
 
-The CLI reads `GLANCE_TOKEN` from the environment ahead of its stored config, so CI can deploy
-without ever running the interactive `glance login`:
-
-```bash
-export GLANCE_TOKEN=glk_...
-export GLANCE_API_URL=https://your-instance   # only if no ~/.glance/config.json exists
-glance deploy ./dist
-```
-
-`glance logout` deliberately ignores `GLANCE_TOKEN` and acts on the stored session instead — a
-key is revoked from `/settings/keys`, not by logging out.
+`POST /api/auth/logout` is a *session* verb: it destroys a browser session and revokes a device
+token. Presented with an API key it returns `400 not_a_session` — a key is revoked with
+[`DELETE /api/api-keys/:id`](#delete-apiapi-keysid--revoke), not by logging out.
 
 ## What a key may do
 

--- a/packages/api/API.md
+++ b/packages/api/API.md
@@ -1,0 +1,263 @@
+# Glance HTTP API
+
+The control plane a script, CI job, or agent talks to. Everything here is authenticated
+with an **API key** (`glk_…`) minted from `/settings/keys` — see
+[API keys](#api-keys) for how a key differs from your browser session and from the CLI's
+stored token.
+
+Base URL is your instance origin (`https://glance.<your-subdomain>.workers.dev` by default).
+All request and response bodies are JSON unless noted; the one exception is
+[deploy](#deploy-files), which is `multipart/form-data`.
+
+- [Authentication](#authentication)
+- [What a key may do](#what-a-key-may-do)
+- [API keys](#api-keys)
+- [Sites](#sites)
+- [Deploy files](#deploy-files)
+- [Spaces](#spaces)
+- [Data tokens (glance.db)](#data-tokens-glancedb)
+- [Errors](#errors)
+
+---
+
+## Authentication
+
+Send the key as a bearer token:
+
+```bash
+curl -H "Authorization: Bearer $GLANCE_TOKEN" https://your-instance/api/sites/mine
+```
+
+Three credential kinds reach the same routes, and the server records *which* one authenticated
+a request — the limits below apply to keys only:
+
+| Credential | Presented as | Notes |
+| --- | --- | --- |
+| Browser session | `__Host-glance_session` cookie | Unsafe methods additionally require same-origin (CSRF). |
+| CLI device token | `Authorization: Bearer <token>` | Minted by `glance login`; governed by ownership alone. |
+| API key | `Authorization: Bearer glk_…` | Governed by ownership **and** the grants below. |
+
+A `glk_`-prefixed bearer is dispatched to the key store and never falls through to the CLI token
+store, or the reverse — an invalid key is a `401`, not a retry against the other store.
+
+The CLI reads `GLANCE_TOKEN` from the environment ahead of its stored config, so CI can deploy
+without ever running the interactive `glance login`:
+
+```bash
+export GLANCE_TOKEN=glk_...
+export GLANCE_API_URL=https://your-instance   # only if no ~/.glance/config.json exists
+glance deploy ./dist
+```
+
+`glance logout` deliberately ignores `GLANCE_TOKEN` and acts on the stored session instead — a
+key is revoked from `/settings/keys`, not by logging out.
+
+## What a key may do
+
+A key carries a `grants` object fixed at mint time. It can only ever *narrow* what you can already
+do — a key never grants access you don't have.
+
+```jsonc
+{
+  "control": true,          // may change control-plane state (deploy, create, fork, move, share)
+  "data": {                 // or null — null means the key cannot mint data tokens at all
+    "scope": { "kind": "all-owned" },        // or { "kind": "sites", "siteIds": ["…"] }
+    "caps": ["read"]                          // ceiling on a minted data token
+  }
+}
+```
+
+Without `control: true`, every `POST`/`PUT`/`PATCH`/`DELETE` on the control plane is `403`; reads
+still work, which is what a data-only key needs to resolve a site before minting a token.
+
+Two things are refused for **every** key regardless of grants:
+
+| Operation | Result | Why |
+| --- | --- | --- |
+| `DELETE /api/sites/:space/:site` | `403` | A key may create and deploy sites, not destroy them. |
+| `POST` / `DELETE` on `/api/api-keys` | `403` | A leaked key must not mint a successor or revoke your other keys. |
+
+> **Caveat — space deletion is not covered by that rule.** `DELETE /api/spaces/:slug` carries no
+> key check, so a key with `control: true` can delete a **group space it created**, which hard-
+> destroys every site inside it. Personal spaces are protected (`403`), and the delete is refused
+> with `409` if the space holds sites owned by other members — but your own sites in your own
+> group space can be erased this way despite the per-site rule above. Scope keys accordingly.
+
+A key may also **list** your keys (`GET /api/api-keys`) — names, grants, expiries and
+`glk_…abcd` hints, never a secret or hash.
+
+## API keys
+
+Mounted at `/api/api-keys`. Every route is scoped to the caller's own keys; there is no
+surface for managing anyone else's.
+
+### `POST /api/api-keys` — mint
+
+Session or CLI token only (`403` for a key credential).
+
+```jsonc
+// request
+{
+  "name": "CI deploy bot",           // required, ≤200 chars
+  "expiresInDays": 30,               // required, one of 1 | 7 | 30 | 90 | 180 | 365
+  "grants": { "control": true, "data": null }
+}
+```
+
+```jsonc
+// 201, Cache-Control: no-store
+{
+  "id": "…",
+  "name": "CI deploy bot",
+  "secret": "glk_…",                 // shown EXACTLY ONCE — only its hash is stored
+  "grants": { "control": true, "data": null },
+  "createdAt": "2026-07-31T10:16:21.208Z",
+  "expiresAt": "2026-08-30T10:16:21.208Z"
+}
+```
+
+`expiresAt` is always derived server-side from `expiresInDays`; an `expiresAt` in the request body
+is ignored outright. Ten **active** keys per user (`400` beyond that) — revoked and expired keys are
+tombstones and don't count, so revoking one frees a slot immediately.
+
+### `GET /api/api-keys` — list
+
+```jsonc
+{
+  "items": [{
+    "id": "…",
+    "name": "CI deploy bot",
+    "grants": { "control": true, "data": null },
+    "createdAt": "…", "expiresAt": "…",
+    "revokedAt": null,                // set once revoked; the row is kept, not deleted
+    "lastUsedAt": "…",                // touched at most hourly, not per request
+    "secretHint": "glk_…6HJQ"         // last 4 chars only
+  }]
+}
+```
+
+### `DELETE /api/api-keys/:id` — revoke
+
+Session or CLI token only (`403` for a key credential). Idempotent — revoking an already-revoked
+key still succeeds. A key that isn't yours is `404`, not `403`, so ids can't be probed.
+
+```jsonc
+{ "revoked": true }
+```
+
+A revoked key stops authenticating immediately. One documented exception: a
+[data token](#data-tokens-glancedb) the key already minted keeps working for the remainder of its
+≤300s life, because that token is a self-contained signed credential and not a lookup against the key.
+
+## Sites
+
+`requireAuth` on all; the ones marked ✱ additionally need `control: true` on a key.
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `POST` | `/api/sites` ✱ | Create an empty site record |
+| `GET` | `/api/sites/mine` | Sites you own, newest first |
+| `GET` | `/api/sites/shared` | Sites shared with you |
+| `GET` | `/api/sites/team` | Team feed |
+| `GET` | `/api/sites/search?q=` | Search |
+| `GET` | `/api/sites/:space/:site` | Viewer metadata + a token-gated content URL |
+| `GET` | `/api/sites/:space/:site/exists` | Slug-conflict probe |
+| `GET` | `/api/sites/:space/:site/shares` | Current shares |
+| `PUT` | `/api/sites/:space/:site/shares` ✱ | Replace shares |
+| `PATCH` | `/api/sites/:space/:site` ✱ | Rename / change visibility |
+| `POST` | `/api/sites/:space/:site/move` ✱ | Move to another space |
+| `POST` | `/api/sites/:space/:site/fork` ✱ | Fork |
+| `DELETE` | `/api/sites/:space/:site` | Delete — **always `403` for a key** |
+
+```jsonc
+// POST /api/sites
+{ "spaceSlug": "sam", "siteSlug": "q3-metrics", "title": "Q3 Metrics", "visibility": "private" }
+// 201
+{ "id": "…", "spaceSlug": "sam", "siteSlug": "q3-metrics", "url": "https://your-instance/sam/q3-metrics" }
+```
+
+`siteSlug` must be a valid slug and not a reserved word (`docs` among them, which is broader than
+the space-level collision that motivated it — a site literally named `docs` is rejected `400`).
+Visibility is `private`, `team`, or a share list; there is no public tier — every viewer needs a login.
+
+## Deploy files
+
+```
+POST /api/upload/:spaceSlug/:siteSlug        multipart/form-data      ✱ control grant
+```
+
+| Field | Notes |
+| --- | --- |
+| `files` | Repeated. Each file's name is its in-site path. ≤20MB each, ≤200 files. |
+| `visibility` | Optional. Create defaults to `team`; on replace, omitting it keeps the current tier. |
+| `title` | Optional display title. Never renames an already-titled site on replace. |
+| `expectedVersion` | The `contentVersion` you last read. Required for an **editor** replace (optimistic concurrency); advisory for the owner. |
+
+```jsonc
+// 200
+{ "url": "https://your-instance/sam/q3-metrics", "siteSlug": "q3-metrics", "fileCount": 3, "contentVersion": 4 }
+```
+
+`409 {"conflict": true}` on a version conflict or an unexpected create-vs-replace mismatch;
+`413` if a file exceeds 20MB; `429` if the per-IP rate limit (10/60s) trips.
+
+```bash
+curl -X POST "https://your-instance/api/upload/sam/q3-metrics" \
+  -H "Authorization: Bearer $GLANCE_TOKEN" \
+  -F "files=@dist/index.html;filename=index.html" \
+  -F "files=@dist/app.js;filename=app.js" \
+  -F "visibility=team"
+```
+
+## Spaces
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `POST` | `/api/spaces` ✱ | Create a group space |
+| `GET` | `/api/spaces/mine` | Spaces you belong to |
+| `GET` | `/api/spaces/:slug` | One space |
+| `GET` | `/api/spaces/:slug/sites` | Its sites |
+| `POST` | `/api/spaces/:slug/members` ✱ | Add a member |
+| `DELETE` | `/api/spaces/:slug/members/:userId` ✱ | Remove a member |
+| `DELETE` | `/api/spaces/:slug` ✱ | Delete a group space — see the caveat above |
+
+## Data tokens (glance.db)
+
+The control plane never touches site data. To read or write a site's document store, exchange your
+credential for a short-lived data token and use that against `/api/_data`:
+
+```
+POST /api/data-token/:space/:site
+```
+
+```jsonc
+{ "token": "…", "caps": ["read"], "expiresIn": 300 }
+```
+
+The token lives **300 seconds** — mint per run, never bake one into an env var or config file; a
+`401` on the data plane means it aged out. `404` if the instance has no `DATA_TOKEN_SECRET`
+configured (the feature is off).
+
+When a key mints one, the resulting capabilities are the intersection of three things: your own
+access to that site, the key's `grants.data.caps` ceiling, and the key's `scope` allowlist. Narrower
+always wins — a key can restrict what you could otherwise do, never widen it. A key whose
+`grants.data` is `null` is `403` here.
+
+```bash
+TOKEN=$(curl -s -X POST -H "Authorization: Bearer $GLANCE_TOKEN" \
+  "https://your-instance/api/data-token/sam/q3-metrics" | jq -r .token)
+```
+
+## Errors
+
+Every error is `{"error": "<reason>"}` with a meaningful status.
+
+| Status | Means |
+| --- | --- |
+| `400` | Malformed body, invalid grants, bad slug, or the active-key cap |
+| `401` | No credential, or one that is expired, revoked, or unknown |
+| `403` | Authenticated but not allowed — missing control grant, a key hitting a key-denied route, or CSRF on a cookie request |
+| `404` | Not found, **or** deliberately indistinguishable from not-yours (revoking someone else's key) |
+| `409` | Slug taken, version conflict, or a space holding other members' sites |
+| `413` | File over 20MB |
+| `429` | Rate limited |

--- a/packages/api/drizzle/0025_api_keys.sql
+++ b/packages/api/drizzle/0025_api_keys.sql
@@ -1,0 +1,22 @@
+-- Control-plane API keys: a long-lived credential a user mints for CLI/CI use, distinct from the
+-- GLANCE_SESSIONS browser cookie. Only `hash` (SHA-256 hex of the secret) is ever stored — the
+-- secret itself is shown once at creation and never persisted. `grants` is a JSON blob holding the
+-- key's scoped permissions, the same text/json-mode idiom as `documents.json`. `revokedAt` is a
+-- manual kill switch; `expiresAt` is enforced independently at auth time. `userId` cascades: a
+-- deleted user's keys are meaningless. The (userId, createdAt) index serves the owner's list query.
+CREATE TABLE `api_keys` (
+	`id` text PRIMARY KEY NOT NULL,
+	`userId` text NOT NULL,
+	`name` text NOT NULL,
+	`hash` text NOT NULL,
+	`grants` text NOT NULL,
+	`createdAt` text NOT NULL,
+	`expiresAt` text NOT NULL,
+	`revokedAt` text,
+	`lastUsedAt` text,
+	FOREIGN KEY (`userId`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `api_keys_hash_unique` ON `api_keys` (`hash`);
+--> statement-breakpoint
+CREATE INDEX `api_keys_user_created` ON `api_keys` (`userId`,`createdAt`);

--- a/packages/api/drizzle/0026_api_key_display_suffix.sql
+++ b/packages/api/drizzle/0026_api_key_display_suffix.sql
@@ -1,0 +1,5 @@
+-- Non-secret display fragment for the key list UI (e.g. "glk_…4mR2"). ONLY the last 4 characters
+-- of the plaintext secret are stored — never enough to be useful to an attacker even combined with
+-- the public API_KEY_PREFIX constant, and the hash alone can never be reversed into it. Nullable so
+-- pre-migration rows (none in prod yet, but the column must still tolerate it) render with no hint.
+ALTER TABLE `api_keys` ADD `displaySuffix` text;

--- a/packages/api/drizzle/meta/_journal.json
+++ b/packages/api/drizzle/meta/_journal.json
@@ -183,6 +183,13 @@
       "when": 1786000000000,
       "tag": "0025_api_keys",
       "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "6",
+      "when": 1786100000000,
+      "tag": "0026_api_key_display_suffix",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/drizzle/meta/_journal.json
+++ b/packages/api/drizzle/meta/_journal.json
@@ -176,6 +176,13 @@
       "when": 1785900000000,
       "tag": "0024_comment_reactions",
       "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "6",
+      "when": 1786000000000,
+      "tag": "0025_api_keys",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/src/db/schema.ts
+++ b/packages/api/src/db/schema.ts
@@ -1,4 +1,5 @@
 import { type AnySQLiteColumn, index, integer, primaryKey, sqliteTable, text, unique } from 'drizzle-orm/sqlite-core'
+import type { ApiKeyGrants } from '../lib/api-key'
 
 // Column names mirror the spec's SQL exactly (camelCase) so raw `wrangler d1 execute`
 // queries in the runbook keep working. IDs are app-generated UUIDs; timestamps are ISO-8601.
@@ -385,7 +386,7 @@ export const apiKeys = sqliteTable(
     userId: text('userId').notNull().references(() => users.id, { onDelete: 'cascade' }),
     name: text('name').notNull(),
     hash: text('hash').notNull().unique(),
-    grants: text('grants', { mode: 'json' }).$type<unknown>().notNull(),
+    grants: text('grants', { mode: 'json' }).$type<ApiKeyGrants>().notNull(),
     createdAt: text('createdAt').notNull().$defaultFn(() => new Date().toISOString()),
     expiresAt: text('expiresAt').notNull(),
     revokedAt: text('revokedAt'),

--- a/packages/api/src/db/schema.ts
+++ b/packages/api/src/db/schema.ts
@@ -391,6 +391,11 @@ export const apiKeys = sqliteTable(
     expiresAt: text('expiresAt').notNull(),
     revokedAt: text('revokedAt'),
     lastUsedAt: text('lastUsedAt'),
+    // Non-secret display fragment for the key list UI (rendered as `${API_KEY_PREFIX}…${suffix}`,
+    // e.g. "glk_…4mR2"). ONLY the last 4 chars of the plaintext secret — nowhere near enough
+    // entropy to be useful to an attacker, and never enough to reconstruct the secret. Nullable so
+    // rows written before this column existed still read fine.
+    displaySuffix: text('displaySuffix'),
   },
   (t) => [index('api_keys_user_created').on(t.userId, t.createdAt)],
 )

--- a/packages/api/src/db/schema.ts
+++ b/packages/api/src/db/schema.ts
@@ -373,6 +373,27 @@ export const siteSummaries = sqliteTable('site_summaries', {
     .$onUpdate(() => new Date().toISOString()),
 })
 
+// Control-plane API keys: a long-lived credential a user mints for CLI/CI use, distinct from the
+// GLANCE_SESSIONS browser cookie. Only `hash` (SHA-256 hex of the secret) is ever stored — the
+// secret itself is shown once at creation and never persisted. `grants` is a JSON blob (see
+// `documents.json` for the same text/json-mode idiom) holding the key's scoped permissions.
+// `revokedAt` is a manual kill switch; `expiresAt` is enforced independently at auth time.
+export const apiKeys = sqliteTable(
+  'api_keys',
+  {
+    id: text('id').primaryKey().$defaultFn(() => crypto.randomUUID()),
+    userId: text('userId').notNull().references(() => users.id, { onDelete: 'cascade' }),
+    name: text('name').notNull(),
+    hash: text('hash').notNull().unique(),
+    grants: text('grants', { mode: 'json' }).$type<unknown>().notNull(),
+    createdAt: text('createdAt').notNull().$defaultFn(() => new Date().toISOString()),
+    expiresAt: text('expiresAt').notNull(),
+    revokedAt: text('revokedAt'),
+    lastUsedAt: text('lastUsedAt'),
+  },
+  (t) => [index('api_keys_user_created').on(t.userId, t.createdAt)],
+)
+
 export type User = typeof users.$inferSelect
 export type NewUser = typeof users.$inferInsert
 export type Space = typeof spaces.$inferSelect
@@ -403,6 +424,8 @@ export type Notification = typeof notifications.$inferSelect
 export type NewNotification = typeof notifications.$inferInsert
 export type NotificationType = Notification['type']
 export type SiteSummary = typeof siteSummaries.$inferSelect
+export type ApiKey = typeof apiKeys.$inferSelect
+export type NewApiKey = typeof apiKeys.$inferInsert
 
 export type Visibility = Site['visibility']
 export type SpaceType = Space['type']

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -9,6 +9,7 @@ import { isGoogleEnabled } from './lib/oauth'
 import { trackCliUsage } from './middleware/analytics'
 import { requireSameOrigin } from './middleware/auth'
 import { admin } from './routes/admin'
+import { apiKeys } from './routes/api-keys'
 import { auth } from './routes/auth'
 import { avatars } from './routes/avatars'
 import { commentFeed } from './routes/comment-feed'
@@ -119,6 +120,8 @@ app.route('/api/users', users)
 // off the browser, so the CSP above stays `img-src 'self'`.
 app.route('/api/avatars', avatars)
 app.route('/api/notifications', notifications)
+// Self-service control-plane API keys (mint/list/revoke), scoped to the caller's own keys.
+app.route('/api/api-keys', apiKeys)
 app.route('/api/whats-new', whatsNew)
 app.route('/api/admin', admin)
 // Slack Events API (link_shared → chat.unfurl). Authenticated by Slack's HMAC signature, not a

--- a/packages/api/src/lib/api-key.test.ts
+++ b/packages/api/src/lib/api-key.test.ts
@@ -2,9 +2,10 @@ import { describe, expect, test } from 'bun:test'
 import { eq, sql } from 'drizzle-orm'
 import { Hono } from 'hono'
 import { apiKeys } from '../db/schema'
-import { makeDb, seedApiKey, seedUser } from '../test/harness'
+import { FULL_GRANTS, makeDb, seedApiKey, seedUser } from '../test/harness'
 import type { AppEnv } from '../types'
 import { API_KEY_PREFIX, apiKeyDb, generateApiKey, hashApiKey, resolveApiKey } from './api-key'
+import type { ApiKeyGrants } from './api-key'
 import { b64urlDecode } from './hmac'
 
 describe('generateApiKey', () => {
@@ -64,7 +65,7 @@ describe('resolveApiKey', () => {
     await seedApiKey(db, { userId: uid, hash, expiresAt })
 
     const resolved = await resolveApiKey(db, secret)
-    expect(resolved).toEqual({ id: expect.any(String), userId: uid, grants: [] })
+    expect(resolved).toEqual({ id: expect.any(String), userId: uid, grants: FULL_GRANTS })
   })
 
   test('CASE-04: non-empty grants round-trip through resolveApiKey unchanged', async () => {
@@ -72,7 +73,7 @@ describe('resolveApiKey', () => {
     const uid = await seedUser(db)
     const secret = generateApiKey()
     const hash = await hashApiKey(secret)
-    const grants = { scopes: ['sites:read', 'sites:write'] }
+    const grants = { control: false, data: { scope: { kind: 'sites' as const, siteIds: ['s1', 's2'] }, caps: ['read' as const] } }
     await seedApiKey(db, { userId: uid, hash, grants })
 
     const resolved = await resolveApiKey(db, secret)
@@ -116,6 +117,41 @@ describe('resolveApiKey', () => {
     const id = await seedApiKey(db, { userId: uid, hash })
     // Bypass drizzle's json-mode serialization to plant a corrupt blob directly.
     await db.run(sql`update api_keys set grants = 'not-json' where id = ${id}`)
+
+    await expect(resolveApiKey(db, secret)).resolves.toBeNull()
+  })
+
+  test('CASE-06: a parseable but wrong-shape grants blob resolves to null (fails closed on shape, not just JSON syntax)', async () => {
+    const db = makeDb()
+    const uid = await seedUser(db)
+    const secret = generateApiKey()
+    const hash = await hashApiKey(secret)
+    // Valid JSON, valid object — but `scope.kind` is neither 'all-owned' nor 'sites', so
+    // isDataScope/isApiKeyGrants must reject it. This never touches JSON.parse's catch path,
+    // so it isolates the shape validator from the "corrupt blob" case above.
+    const badGrants = { control: true, data: { scope: { kind: 'nope' }, caps: ['read'] } } as unknown as ApiKeyGrants
+    await seedApiKey(db, { userId: uid, hash, grants: badGrants })
+
+    await expect(resolveApiKey(db, secret)).resolves.toBeNull()
+  })
+
+  // CASE-06 above only pins ONE of the validator's four rejecting branches (an unknown
+  // scope.kind). Each of the rest is a separate way a malformed blob could authenticate, so
+  // each gets its own case — deleting any single check in isApiKeyGrants/isDataScope must
+  // turn something red. `caps` as a bare string is the sharpest one: it survives every other
+  // check and would then reach `ceiling.includes(c)`, which on a string is SUBSTRING matching
+  // — 'read' would test true against a ceiling of 'read_all'.
+  test.each([
+    ['control is not a boolean', { control: 'yes', data: null }],
+    ['caps is a bare string rather than an array', { control: true, data: { scope: { kind: 'all-owned' }, caps: 'read_all' } }],
+    ['caps is null', { control: true, data: { scope: { kind: 'all-owned' }, caps: null } }],
+    ['a sites scope carries non-string siteIds', { control: true, data: { scope: { kind: 'sites', siteIds: [42] }, caps: ['read'] } }],
+  ])('a grants blob whose %s resolves to null (fail closed)', async (_label, badGrants) => {
+    const db = makeDb()
+    const uid = await seedUser(db)
+    const secret = generateApiKey()
+    const hash = await hashApiKey(secret)
+    await seedApiKey(db, { userId: uid, hash, grants: badGrants as unknown as ApiKeyGrants })
 
     await expect(resolveApiKey(db, secret)).resolves.toBeNull()
   })

--- a/packages/api/src/lib/api-key.test.ts
+++ b/packages/api/src/lib/api-key.test.ts
@@ -65,7 +65,7 @@ describe('resolveApiKey', () => {
     await seedApiKey(db, { userId: uid, hash, expiresAt })
 
     const resolved = await resolveApiKey(db, secret)
-    expect(resolved).toEqual({ id: expect.any(String), userId: uid, grants: FULL_GRANTS })
+    expect(resolved).toEqual({ id: expect.any(String), userId: uid, grants: FULL_GRANTS, lastUsedAt: null })
   })
 
   test('CASE-04: non-empty grants round-trip through resolveApiKey unchanged', async () => {
@@ -77,7 +77,7 @@ describe('resolveApiKey', () => {
     await seedApiKey(db, { userId: uid, hash, grants })
 
     const resolved = await resolveApiKey(db, secret)
-    expect(resolved).toEqual({ id: expect.any(String), userId: uid, grants })
+    expect(resolved).toEqual({ id: expect.any(String), userId: uid, grants, lastUsedAt: null })
   })
 
   test('CASE-02: a revoked key does not resolve, but its row is still readable directly (tombstone)', async () => {

--- a/packages/api/src/lib/api-key.test.ts
+++ b/packages/api/src/lib/api-key.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, test } from 'bun:test'
+import { eq, sql } from 'drizzle-orm'
+import { Hono } from 'hono'
+import { apiKeys } from '../db/schema'
+import { makeDb, seedApiKey, seedUser } from '../test/harness'
+import type { AppEnv } from '../types'
+import { API_KEY_PREFIX, apiKeyDb, generateApiKey, hashApiKey, resolveApiKey } from './api-key'
+import { b64urlDecode } from './hmac'
+
+describe('generateApiKey', () => {
+  test('returns a "glk_"-prefixed, unpadded base64url secret carrying 32 CSPRNG bytes', () => {
+    const a = generateApiKey()
+    const b = generateApiKey()
+    expect(a.startsWith('glk_')).toBe(true)
+    expect(a).not.toEqual(b)
+
+    const payload = a.slice(API_KEY_PREFIX.length)
+    expect(payload).not.toContain('=')
+    expect(payload).toMatch(/^[A-Za-z0-9_-]+$/)
+    expect(b64urlDecode(payload)).toHaveLength(32)
+  })
+})
+
+describe('hashApiKey', () => {
+  test('is the plain SHA-256 hex digest of the UTF-8 secret, no salt/pepper (known vector)', async () => {
+    // Known-answer vector — pins the exact bytes hashed. Seeded rows in other tests derive
+    // their hash from hashApiKey itself, so only this fixed vector catches a change to what
+    // gets hashed (e.g. a prepended pepper or altered encoding).
+    expect(await hashApiKey('glk_test-secret')).toEqual(
+      'f4866cfe9ce3d1ae85dffc3709cbbea3d1d157cf4d9046fd8b5276b9d6433371',
+    )
+  })
+
+  test('is deterministic lowercase hex SHA-256 of the secret', async () => {
+    const hash = await hashApiKey('glk_test-secret')
+    expect(hash).toMatch(/^[0-9a-f]{64}$/)
+    expect(await hashApiKey('glk_test-secret')).toEqual(hash)
+  })
+})
+
+describe('resolveApiKey', () => {
+  test('CASE-01: a key whose expiresAt is one second in the past does not resolve', async () => {
+    const db = makeDb()
+    const uid = await seedUser(db)
+    const secret = generateApiKey()
+    const hash = await hashApiKey(secret)
+    const expiresAt = new Date(Date.now() - 1000).toISOString()
+    await seedApiKey(db, { userId: uid, hash, expiresAt })
+
+    expect(await resolveApiKey(db, secret)).toBeNull()
+  })
+
+  test('CASE-03: a key expiring later today resolves and maps id/userId/grants correctly (happy path — NOT the datetime(now) trap; see CASE-01 for that)', async () => {
+    const db = makeDb()
+    const uid = await seedUser(db)
+    const secret = generateApiKey()
+    const hash = await hashApiKey(secret)
+    // Same-day expiry a few hours out. This does NOT catch the datetime('now') space-vs-T trap:
+    // lexically '<today>T<laterHours>...Z' > '<today> <nowHours>...' (space 0x20 < 'T' 0x54) is
+    // ALWAYS true regardless of the hours, so this case stays green even under the buggy
+    // `sql`datetime('now')`` predicate. CASE-01 (an already-expired key) is what actually kills
+    // that mutation — this test only pins field mapping (id/userId/grants) on the happy path.
+    const expiresAt = new Date(Date.now() + 4 * 60 * 60 * 1000).toISOString()
+    await seedApiKey(db, { userId: uid, hash, expiresAt })
+
+    const resolved = await resolveApiKey(db, secret)
+    expect(resolved).toEqual({ id: expect.any(String), userId: uid, grants: [] })
+  })
+
+  test('CASE-04: non-empty grants round-trip through resolveApiKey unchanged', async () => {
+    const db = makeDb()
+    const uid = await seedUser(db)
+    const secret = generateApiKey()
+    const hash = await hashApiKey(secret)
+    const grants = { scopes: ['sites:read', 'sites:write'] }
+    await seedApiKey(db, { userId: uid, hash, grants })
+
+    const resolved = await resolveApiKey(db, secret)
+    expect(resolved).toEqual({ id: expect.any(String), userId: uid, grants })
+  })
+
+  test('CASE-02: a revoked key does not resolve, but its row is still readable directly (tombstone)', async () => {
+    const db = makeDb()
+    const uid = await seedUser(db)
+    const secret = generateApiKey()
+    const hash = await hashApiKey(secret)
+    const id = await seedApiKey(db, { userId: uid, hash, revokedAt: new Date().toISOString() })
+
+    expect(await resolveApiKey(db, secret)).toBeNull()
+    const [row] = await db.select().from(apiKeys).where(eq(apiKeys.id, id))
+    expect(row).toBeDefined()
+    expect(row.revokedAt).not.toBeNull()
+  })
+
+  test('CASE-05: the plaintext secret appears nowhere in the stored row', async () => {
+    const db = makeDb()
+    const uid = await seedUser(db)
+    const secret = generateApiKey()
+    const hash = await hashApiKey(secret)
+    const id = await seedApiKey(db, { userId: uid, hash })
+
+    const [row] = await db.select().from(apiKeys).where(eq(apiKeys.id, id))
+    expect(JSON.stringify(row)).not.toContain(secret)
+  })
+
+  test('an unknown hash resolves to null', async () => {
+    const db = makeDb()
+    expect(await resolveApiKey(db, 'glk_never-issued')).toBeNull()
+  })
+
+  test('an unparseable grants blob resolves to null (fail closed), not throw', async () => {
+    const db = makeDb()
+    const uid = await seedUser(db)
+    const secret = generateApiKey()
+    const hash = await hashApiKey(secret)
+    const id = await seedApiKey(db, { userId: uid, hash })
+    // Bypass drizzle's json-mode serialization to plant a corrupt blob directly.
+    await db.run(sql`update api_keys set grants = 'not-json' where id = ${id}`)
+
+    await expect(resolveApiKey(db, secret)).resolves.toBeNull()
+  })
+})
+
+describe('apiKeyDb', () => {
+  test('no GLANCE_DB binding → falls back to c.get(\'db\') (route-fixtures harness shape)', async () => {
+    const harnessDb = makeDb()
+    const app = new Hono<AppEnv>()
+    app.use('*', async (c, next) => {
+      c.set('db', harnessDb)
+      await next()
+    })
+    let seen: unknown
+    app.get('/x', (c) => {
+      seen = apiKeyDb(c)
+      return c.text('ok')
+    })
+    await app.request('/x', {}, {} as AppEnv['Bindings'])
+    expect(seen).toBe(harnessDb)
+  })
+
+  test('GLANCE_DB bound → a first-primary session client, not the fallback db', async () => {
+    const statement = {
+      bind: () => statement,
+      all: async () => ({ results: [], success: true, meta: {} }),
+      run: async () => ({ results: [], success: true, meta: {} }),
+      raw: async () => [],
+    }
+    const anchors: string[] = []
+    const binding = {
+      withSession: (a: string) => {
+        anchors.push(a)
+        return { prepare: () => statement, getBookmark: () => null }
+      },
+    } as unknown as D1Database
+    const app = new Hono<AppEnv>()
+    let seen: unknown
+    app.get('/x', (c) => {
+      seen = apiKeyDb(c)
+      return c.text('ok')
+    })
+    await app.request('/x', {}, { GLANCE_DB: binding } as unknown as AppEnv['Bindings'])
+    expect(anchors).toEqual(['first-primary'])
+    expect(seen).toBeDefined()
+  })
+})

--- a/packages/api/src/lib/api-key.ts
+++ b/packages/api/src/lib/api-key.ts
@@ -4,11 +4,46 @@ import type { Context } from 'hono'
 import { sessionDb } from '../db/client'
 import { apiKeys } from '../db/schema'
 import type { AppEnv } from '../types'
+import type { DataCapability } from './data-token'
 import { b64urlEncode } from './hmac'
 
 const enc = new TextEncoder()
 
 export const API_KEY_PREFIX = 'glk_'
+
+// The api_keys.grants JSON blob, now that its shape is settled. `control` may drive the control
+// plane (deploy, list, fork...) — site DELETE is denied to keys regardless (see routes/sites.ts).
+// `data: null` means the key cannot mint data tokens at all; otherwise `scope` allowlists which
+// sites it may mint for and `caps` ceilings what a minted token can carry (routes/data.ts
+// intersects this against the caller's own access — narrower wins on both sides).
+export type ApiKeyGrants = {
+  control: boolean
+  data: { scope: { kind: 'all-owned' } | { kind: 'sites'; siteIds: string[] }; caps: DataCapability[] } | null
+}
+
+function isDataScope(v: unknown): v is ApiKeyGrants['data'] & object {
+  if (typeof v !== 'object' || v === null) return false
+  const scope = (v as { scope?: unknown }).scope
+  const caps = (v as { caps?: unknown }).caps
+  if (!Array.isArray(caps) || !caps.every((c) => typeof c === 'string')) return false
+  if (typeof scope !== 'object' || scope === null) return false
+  const kind = (scope as { kind?: unknown }).kind
+  if (kind === 'all-owned') return true
+  if (kind === 'sites') {
+    const siteIds = (scope as { siteIds?: unknown }).siteIds
+    return Array.isArray(siteIds) && siteIds.every((id) => typeof id === 'string')
+  }
+  return false
+}
+
+/** Narrow runtime validator for the grants shape (not a schema library) — resolveApiKey fails
+ *  closed on anything that doesn't match, same as an unparseable blob. */
+function isApiKeyGrants(v: unknown): v is ApiKeyGrants {
+  if (typeof v !== 'object' || v === null) return false
+  const g = v as { control?: unknown; data?: unknown }
+  if (typeof g.control !== 'boolean') return false
+  return g.data === null || isDataScope(g.data)
+}
 
 /** Mint a fresh control-plane API key secret: 32 CSPRNG bytes, base64url (no padding), prefixed
  *  so a key is recognizable at a glance (and greppable in logs — never log the full value). The
@@ -33,11 +68,12 @@ export async function hashApiKey(secret: string): Promise<string> {
  *  the two FAILS OPEN for a key expiring later the same day, because 'T' (0x54) sorts after
  *  the space (0x20): '2026-07-31T00:00:00.000Z' > '2026-07-31 12:00:00' is true, so an
  *  already-expired-today key would still authenticate. An unparseable `grants` blob resolves to
- *  null (fail closed) rather than throwing. */
+ *  null (fail closed) rather than throwing — and so does a parseable blob that doesn't match
+ *  `ApiKeyGrants` (a shape check, since the column is untyped JSON at rest). */
 export async function resolveApiKey(
   db: DrizzleD1Database,
   secret: string,
-): Promise<{ id: string; userId: string; grants: unknown } | null> {
+): Promise<{ id: string; userId: string; grants: ApiKeyGrants } | null> {
   const hash = await hashApiKey(secret)
   const now = new Date().toISOString()
   let row: typeof apiKeys.$inferSelect | undefined
@@ -52,6 +88,7 @@ export async function resolveApiKey(
     return null
   }
   if (!row) return null
+  if (!isApiKeyGrants(row.grants)) return null
   return { id: row.id, userId: row.userId, grants: row.grants }
 }
 

--- a/packages/api/src/lib/api-key.ts
+++ b/packages/api/src/lib/api-key.ts
@@ -1,0 +1,64 @@
+import { and, eq, gt, isNull } from 'drizzle-orm'
+import type { DrizzleD1Database } from 'drizzle-orm/d1'
+import type { Context } from 'hono'
+import { sessionDb } from '../db/client'
+import { apiKeys } from '../db/schema'
+import type { AppEnv } from '../types'
+import { b64urlEncode } from './hmac'
+
+const enc = new TextEncoder()
+
+export const API_KEY_PREFIX = 'glk_'
+
+/** Mint a fresh control-plane API key secret: 32 CSPRNG bytes, base64url (no padding), prefixed
+ *  so a key is recognizable at a glance (and greppable in logs — never log the full value). The
+ *  plaintext is returned to the caller ONCE; only its hash is ever persisted. */
+export function generateApiKey(): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(32))
+  return API_KEY_PREFIX + b64urlEncode(bytes.buffer as ArrayBuffer)
+}
+
+/** Plain SHA-256 hex, no salt, no KDF iteration. Unlike a password, this secret is already 256
+ *  bits of CSPRNG entropy — a slow KDF (bcrypt/scrypt/argon2) buys nothing against brute force
+ *  here and would only add latency to every authenticated request. */
+export async function hashApiKey(secret: string): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', enc.encode(secret))
+  return Array.from(new Uint8Array(digest), (b) => b.toString(16).padStart(2, '0')).join('')
+}
+
+/** Resolve a presented secret to its LIVE key row (revokedAt IS NULL, not expired), or null.
+ *  The expiry compare binds a JS-side `new Date().toISOString()` as a parameter rather than
+ *  using SQLite's `datetime('now')` — that function emits 'YYYY-MM-DD HH:MM:SS' (space
+ *  separator) while `expiresAt` is stored 'YYYY-MM-DDTHH:MM:SS.sssZ'. A lexical compare between
+ *  the two FAILS OPEN for a key expiring later the same day, because 'T' (0x54) sorts after
+ *  the space (0x20): '2026-07-31T00:00:00.000Z' > '2026-07-31 12:00:00' is true, so an
+ *  already-expired-today key would still authenticate. An unparseable `grants` blob resolves to
+ *  null (fail closed) rather than throwing. */
+export async function resolveApiKey(
+  db: DrizzleD1Database,
+  secret: string,
+): Promise<{ id: string; userId: string; grants: unknown } | null> {
+  const hash = await hashApiKey(secret)
+  const now = new Date().toISOString()
+  let row: typeof apiKeys.$inferSelect | undefined
+  try {
+    // drizzle's json-mode column JSON.parses `grants` while mapping the row — a corrupt blob
+    // throws HERE, inside the select, not after; caught below so it fails closed.
+    ;[row] = await db
+      .select()
+      .from(apiKeys)
+      .where(and(eq(apiKeys.hash, hash), isNull(apiKeys.revokedAt), gt(apiKeys.expiresAt, now)))
+  } catch {
+    return null
+  }
+  if (!row) return null
+  return { id: row.id, userId: row.userId, grants: row.grants }
+}
+
+// 'first-primary': withDb defaults to 'first-unconstrained', so a replica could still serve an
+// api_keys row that predates a revoke — credential reads must be strongly consistent, not
+// eventually. Falls back to c.get('db') so the harness's route tests (which set the db on the
+// context directly and bind no GLANCE_DB) keep working.
+export function apiKeyDb(c: Context<AppEnv>): DrizzleD1Database {
+  return c.env.GLANCE_DB ? sessionDb(c.env.GLANCE_DB, 'first-primary') : c.get('db')
+}

--- a/packages/api/src/lib/api-key.ts
+++ b/packages/api/src/lib/api-key.ts
@@ -11,6 +11,10 @@ const enc = new TextEncoder()
 
 export const API_KEY_PREFIX = 'glk_'
 
+// Throttle window for the lastUsedAt touch (see touchApiKeyLastUsed below): a key hammered once a
+// second would otherwise cost 86,400 D1 row-writes/day just for "last used 4m ago" in the UI.
+export const LAST_USED_THROTTLE_MS = 60 * 60 * 1000
+
 // The api_keys.grants JSON blob, now that its shape is settled. `control` may drive the control
 // plane (deploy, list, fork...) — site DELETE is denied to keys regardless (see routes/sites.ts).
 // `data: null` means the key cannot mint data tokens at all; otherwise `scope` allowlists which
@@ -37,8 +41,10 @@ function isDataScope(v: unknown): v is ApiKeyGrants['data'] & object {
 }
 
 /** Narrow runtime validator for the grants shape (not a schema library) — resolveApiKey fails
- *  closed on anything that doesn't match, same as an unparseable blob. */
-function isApiKeyGrants(v: unknown): v is ApiKeyGrants {
+ *  closed on anything that doesn't match, same as an unparseable blob. Exported so the mint route
+ *  (routes/api-keys.ts) rejects a malformed `grants` body with the SAME check, rather than a
+ *  second, driftable one. */
+export function isApiKeyGrants(v: unknown): v is ApiKeyGrants {
   if (typeof v !== 'object' || v === null) return false
   const g = v as { control?: unknown; data?: unknown }
   if (typeof g.control !== 'boolean') return false
@@ -73,7 +79,7 @@ export async function hashApiKey(secret: string): Promise<string> {
 export async function resolveApiKey(
   db: DrizzleD1Database,
   secret: string,
-): Promise<{ id: string; userId: string; grants: ApiKeyGrants } | null> {
+): Promise<{ id: string; userId: string; grants: ApiKeyGrants; lastUsedAt: string | null } | null> {
   const hash = await hashApiKey(secret)
   const now = new Date().toISOString()
   let row: typeof apiKeys.$inferSelect | undefined
@@ -89,7 +95,31 @@ export async function resolveApiKey(
   }
   if (!row) return null
   if (!isApiKeyGrants(row.grants)) return null
-  return { id: row.id, userId: row.userId, grants: row.grants }
+  return { id: row.id, userId: row.userId, grants: row.grants, lastUsedAt: row.lastUsedAt }
+}
+
+/** Best-effort `lastUsedAt` touch, throttled to LAST_USED_THROTTLE_MS: a no-op when the stored
+ *  value is already within the window, so a hot key costs one D1 write per hour rather than one
+ *  per request. NEVER throws — same "swallow it" contract as recordEvent (lib/events.ts), since
+ *  a failed touch must not turn an authenticated request into an error. Callers hand the
+ *  resulting promise to fireAndForget so the write itself rides off the response's critical path. */
+export async function touchApiKeyLastUsed(db: DrizzleD1Database, id: string, lastUsedAt: string | null): Promise<void> {
+  if (lastUsedAt !== null && Date.now() - new Date(lastUsedAt).getTime() < LAST_USED_THROTTLE_MS) return
+  try {
+    await db.update(apiKeys).set({ lastUsedAt: new Date().toISOString() }).where(eq(apiKeys.id, id))
+  } catch {
+    // Swallow — a failed touch must never surface to the caller.
+  }
+}
+
+/** Revoke every LIVE key (revokedAt IS NULL) a user holds — the D1 counterpart to
+ *  `revokeUserCliTokens` (KV), called alongside it from the offboarding kill-switch. Idempotent:
+ *  the WHERE simply matches nothing on a second call or for a user with no keys. */
+export async function revokeUserApiKeys(db: DrizzleD1Database, userId: string): Promise<void> {
+  await db
+    .update(apiKeys)
+    .set({ revokedAt: new Date().toISOString() })
+    .where(and(eq(apiKeys.userId, userId), isNull(apiKeys.revokedAt)))
 }
 
 // 'first-primary': withDb defaults to 'first-unconstrained', so a replica could still serve an

--- a/packages/api/src/lib/glance.test.ts
+++ b/packages/api/src/lib/glance.test.ts
@@ -59,6 +59,7 @@ describe('isValidSlug', () => {
     expect(isValidSlug('admin')).toBe(false)
     expect(isValidSlug('api')).toBe(false)
     expect(isValidSlug('content')).toBe(false)
+    expect(isValidSlug('docs')).toBe(false)
   })
 })
 

--- a/packages/api/src/lib/session.ts
+++ b/packages/api/src/lib/session.ts
@@ -95,6 +95,14 @@ export async function readCliToken(c: Context<AppEnv>, token: string): Promise<S
   }
 }
 
+/** The `Authorization: Bearer <token>` value, or null when the header is absent or carries
+ *  another scheme. THE single place that header is parsed — the analytics middleware derives its
+ *  CLI/key tagging from this too, rather than re-slicing the header itself. */
+export function bearerToken(c: Context<AppEnv>): string | null {
+  const header = c.req.header('Authorization')
+  return header?.startsWith('Bearer ') ? header.slice(7) : null
+}
+
 // Resolve the request's credential — session cookie, then Authorization: Bearer, dispatched by
 // prefix: a `glk_`-prefixed token is a D1 control-plane API key and is resolved ONLY against D1;
 // anything else is a KV CLI token. On a failed `glk_` resolve this returns null immediately and
@@ -104,9 +112,8 @@ export async function readCredential(c: Context<AppEnv>): Promise<Credential | n
   const sessionUser = await readSession(c)
   if (sessionUser) return { kind: 'session', user: sessionUser }
 
-  const header = c.req.header('Authorization')
-  if (!header?.startsWith('Bearer ')) return null
-  const token = header.slice(7)
+  const token = bearerToken(c)
+  if (token === null) return null
 
   if (token.startsWith(API_KEY_PREFIX)) {
     const db = apiKeyDb(c)

--- a/packages/api/src/lib/session.ts
+++ b/packages/api/src/lib/session.ts
@@ -1,6 +1,8 @@
 import type { Context } from 'hono'
 import { deleteCookie, getSignedCookie, setSignedCookie } from 'hono/cookie'
-import type { AppEnv, SessionUser } from '../types'
+import { getUserById } from '../db/repo'
+import type { AppEnv, Credential, SessionUser } from '../types'
+import { API_KEY_PREFIX, apiKeyDb, resolveApiKey } from './api-key'
 
 const SESSION_COOKIE = '__Host-glance_session'
 const SESSION_TTL = 60 * 60 * 24 // 24h
@@ -92,13 +94,37 @@ export async function readCliToken(c: Context<AppEnv>, token: string): Promise<S
   }
 }
 
-// Resolve the request's user from the session cookie, falling back to a CLI Bearer token.
-// Used by `requireAuth` and by route handlers that read the user inline (rather than via the
-// middleware) so they can shape their own not-found / forbidden JSON — e.g. the viewer endpoint.
-export async function readSessionOrBearer(c: Context<AppEnv>): Promise<SessionUser | null> {
-  const user = await readSession(c)
-  if (user) return user
+// Resolve the request's credential — session cookie, then Authorization: Bearer, dispatched by
+// prefix: a `glk_`-prefixed token is a D1 control-plane API key and is resolved ONLY against D1;
+// anything else is a KV CLI token. On a failed `glk_` resolve this returns null immediately and
+// must NOT fall through to the KV CLI lookup — an attacker presenting a bad API key must not get
+// a second shot at the CLI token store (or vice versa).
+export async function readCredential(c: Context<AppEnv>): Promise<Credential | null> {
+  const sessionUser = await readSession(c)
+  if (sessionUser) return { kind: 'session', user: sessionUser }
+
   const header = c.req.header('Authorization')
-  if (header?.startsWith('Bearer ')) return readCliToken(c, header.slice(7))
-  return null
+  if (!header?.startsWith('Bearer ')) return null
+  const token = header.slice(7)
+
+  if (token.startsWith(API_KEY_PREFIX)) {
+    const db = apiKeyDb(c)
+    const resolved = await resolveApiKey(db, token)
+    if (!resolved) return null
+    const keyUser = await getUserById(db, resolved.userId)
+    if (!keyUser) return null
+    return { kind: 'key', user: keyUser, keyId: resolved.id, grants: resolved.grants }
+  }
+
+  const cliUser = await readCliToken(c, token)
+  return cliUser ? { kind: 'cli', user: cliUser } : null
+}
+
+// Resolve the request's user from the session cookie, falling back to a CLI/API-key Bearer
+// token. Used by `requireAuth` and by route handlers that read the user inline (rather than via
+// the middleware) so they can shape their own not-found / forbidden JSON — e.g. the viewer
+// endpoint. A thin projection of `readCredential` — ONE resolution path, not two that can drift.
+export async function readSessionOrBearer(c: Context<AppEnv>): Promise<SessionUser | null> {
+  const cred = await readCredential(c)
+  return cred?.user ?? null
 }

--- a/packages/api/src/lib/session.ts
+++ b/packages/api/src/lib/session.ts
@@ -2,7 +2,8 @@ import type { Context } from 'hono'
 import { deleteCookie, getSignedCookie, setSignedCookie } from 'hono/cookie'
 import { getUserById } from '../db/repo'
 import type { AppEnv, Credential, SessionUser } from '../types'
-import { API_KEY_PREFIX, apiKeyDb, resolveApiKey } from './api-key'
+import { API_KEY_PREFIX, apiKeyDb, resolveApiKey, touchApiKeyLastUsed } from './api-key'
+import { fireAndForget } from './events'
 
 const SESSION_COOKIE = '__Host-glance_session'
 const SESSION_TTL = 60 * 60 * 24 // 24h
@@ -113,6 +114,9 @@ export async function readCredential(c: Context<AppEnv>): Promise<Credential | n
     if (!resolved) return null
     const keyUser = await getUserById(db, resolved.userId)
     if (!keyUser) return null
+    // Best-effort, throttled usage touch — off the response's critical path (fireAndForget) and
+    // never allowed to fail the request (touchApiKeyLastUsed swallows its own errors).
+    await fireAndForget(c, touchApiKeyLastUsed(db, resolved.id, resolved.lastUsedAt))
     return { kind: 'key', user: keyUser, keyId: resolved.id, grants: resolved.grants }
   }
 

--- a/packages/api/src/lib/slug.ts
+++ b/packages/api/src/lib/slug.ts
@@ -6,7 +6,7 @@ export const RESERVED_SLUGS = new Set([
   'api', 'admin', 'login', 'logout', 'dashboard', 'content', 'assets', 'auth',
   'static', 'public', 'app', 'www', 'health', 'me', 'settings', 'about', 'help',
   'spaces', 'sites', 'upload', 'files', 'cli', 'new', 'edit', 'delete', '_t',
-  'whats-new',
+  'whats-new', 'docs',
 ])
 
 const SLUG_RE = /^[a-z0-9](?:[a-z0-9-]{1,38}[a-z0-9])$/

--- a/packages/api/src/middleware/analytics.test.ts
+++ b/packages/api/src/middleware/analytics.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, test } from 'bun:test'
 import { Hono } from 'hono'
 import { events } from '../db/schema'
+import { generateApiKey, hashApiKey } from '../lib/api-key'
 import { parseCliVersion } from '../lib/events'
 import { readSessionOrBearer } from '../lib/session'
-import { makeDb, makeKv, seedUser } from '../test/harness'
+import { makeDb, makeKv, seedApiKey, seedUser } from '../test/harness'
 import type { AppEnv } from '../types'
 import { trackCliUsage } from './analytics'
 import { requireAuth } from './auth'
@@ -112,6 +113,26 @@ describe('trackCliUsage', () => {
     )
     expect(res.status).toBe(200)
     expect(await db.select().from(events)).toHaveLength(0)
+  })
+
+  test('a glk_-authenticated request records cliVersion null, not a parse of its User-Agent', async () => {
+    const { app, db, env } = setup()
+    const uid = await seedUser(db, { id: 'u1' })
+    const secret = generateApiKey()
+    await seedApiKey(db, { userId: uid, hash: await hashApiKey(secret) })
+
+    // A User-Agent that WOULD parse as a CLI version if treated like one — proving the null is
+    // from the glk_ check, not merely a missing header.
+    const res = await app.request(
+      '/api/upload/acme/site',
+      { headers: { Authorization: `Bearer ${secret}`, 'User-Agent': 'glance-cli/9.9.9' } },
+      env,
+    )
+    expect(res.status).toBe(200)
+
+    const rows = await db.select().from(events)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({ type: 'cli', action: 'upload', userId: uid, cliVersion: null })
   })
 
   test('an unauthorized request (bad token) records nothing', async () => {

--- a/packages/api/src/middleware/analytics.ts
+++ b/packages/api/src/middleware/analytics.ts
@@ -3,7 +3,7 @@ import { getCookie } from 'hono/cookie'
 import { createMiddleware } from 'hono/factory'
 import { API_KEY_PREFIX } from '../lib/api-key'
 import { fireAndForget, parseCliVersion, recordEvent } from '../lib/events'
-import { readSessionOrBearer } from '../lib/session'
+import { bearerToken, readSessionOrBearer } from '../lib/session'
 import type { AppEnv } from '../types'
 
 const SESSION_COOKIE = '__Host-glance_session'
@@ -15,16 +15,15 @@ const SESSION_COOKIE = '__Host-glance_session'
 // directly to shape its own 404/403 JSON, never running requireAuth) leave `authKind`/`user`
 // unset, so their CLI hits used to go unrecorded.
 function isCliRequest(c: Context<AppEnv>): boolean {
-  const isBearer = c.req.header('Authorization')?.startsWith('Bearer ') ?? false
-  return isBearer && getCookie(c, SESSION_COOKIE) === undefined
+  return bearerToken(c) !== null && getCookie(c, SESSION_COOKIE) === undefined
 }
 
 // A `glk_`-prefixed Bearer is a D1 API key, not the CLI's own client — its User-Agent was never
 // stamped `glance-cli/<version>` by our CLI, so parsing it as one would pollute the version
-// stats with garbage. Derived from the raw header for the same reason as isCliRequest above.
-function isKeyRequest(c: Context<AppEnv>): boolean {
-  const header = c.req.header('Authorization')
-  return (header?.startsWith('Bearer ') && header.slice(7).startsWith(API_KEY_PREFIX)) ?? false
+// stats with garbage. Derived from the raw header (same reason as isCliRequest above).
+function cliVersionOf(c: Context<AppEnv>): string | null {
+  if (bearerToken(c)?.startsWith(API_KEY_PREFIX)) return null
+  return parseCliVersion(c.req.header('User-Agent'))
 }
 
 // CLI-usage analytics. Mounted on /api/*, it runs AFTER the route, then records one event per
@@ -49,7 +48,7 @@ export const trackCliUsage = createMiddleware<AppEnv>(async (c, next) => {
         type: 'cli',
         action,
         userId: user.id,
-        cliVersion: isKeyRequest(c) ? null : parseCliVersion(c.req.header('User-Agent')),
+        cliVersion: cliVersionOf(c),
       })
     })(),
   )

--- a/packages/api/src/middleware/analytics.ts
+++ b/packages/api/src/middleware/analytics.ts
@@ -1,6 +1,7 @@
 import type { Context } from 'hono'
 import { getCookie } from 'hono/cookie'
 import { createMiddleware } from 'hono/factory'
+import { API_KEY_PREFIX } from '../lib/api-key'
 import { fireAndForget, parseCliVersion, recordEvent } from '../lib/events'
 import { readSessionOrBearer } from '../lib/session'
 import type { AppEnv } from '../types'
@@ -16,6 +17,14 @@ const SESSION_COOKIE = '__Host-glance_session'
 function isCliRequest(c: Context<AppEnv>): boolean {
   const isBearer = c.req.header('Authorization')?.startsWith('Bearer ') ?? false
   return isBearer && getCookie(c, SESSION_COOKIE) === undefined
+}
+
+// A `glk_`-prefixed Bearer is a D1 API key, not the CLI's own client — its User-Agent was never
+// stamped `glance-cli/<version>` by our CLI, so parsing it as one would pollute the version
+// stats with garbage. Derived from the raw header for the same reason as isCliRequest above.
+function isKeyRequest(c: Context<AppEnv>): boolean {
+  const header = c.req.header('Authorization')
+  return (header?.startsWith('Bearer ') && header.slice(7).startsWith(API_KEY_PREFIX)) ?? false
 }
 
 // CLI-usage analytics. Mounted on /api/*, it runs AFTER the route, then records one event per
@@ -40,7 +49,7 @@ export const trackCliUsage = createMiddleware<AppEnv>(async (c, next) => {
         type: 'cli',
         action,
         userId: user.id,
-        cliVersion: parseCliVersion(c.req.header('User-Agent')),
+        cliVersion: isKeyRequest(c) ? null : parseCliVersion(c.req.header('User-Agent')),
       })
     })(),
   )

--- a/packages/api/src/middleware/auth-credential.test.ts
+++ b/packages/api/src/middleware/auth-credential.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, test } from 'bun:test'
+import { Hono } from 'hono'
+import { API_KEY_PREFIX, generateApiKey, hashApiKey } from '../lib/api-key'
+import { createSession, readSessionOrBearer } from '../lib/session'
+import { makeDb, makeKv, seedApiKey, seedUser } from '../test/harness'
+import type { AppEnv } from '../types'
+import { requireAuth } from './auth'
+
+// The seam the rest of the api-keys plan hangs off: requireAuth attaches a Credential (not just
+// a user) so downstream code can tell HOW the caller authenticated. `/whoami` stands in for any
+// requireAuth-guarded route and echoes back exactly what got set on the context.
+function setup() {
+  const db = makeDb()
+  const kv = makeKv()
+  const app = new Hono<AppEnv>()
+  app.use('*', async (c, next) => {
+    c.set('db', db)
+    await next()
+  })
+  app.get('/whoami', requireAuth, (c) => c.json(c.get('credential')))
+  // Stands in for the INLINE-auth routes (the viewer endpoint `glance read` hits), which call
+  // readSessionOrBearer directly instead of running requireAuth. It must resolve the same
+  // credentials the middleware does — see the projection test below.
+  app.get('/inline', async (c) => {
+    const user = await readSessionOrBearer(c)
+    return user ? c.json(user) : c.json({ error: 'unauthorized' }, 401)
+  })
+  const env = {
+    GLANCE_SESSIONS: kv,
+    SESSION_SECRET: 'sekret',
+    APP_URL: 'https://glance.example.com',
+  } as unknown as AppEnv['Bindings']
+  return { app, db, kv, env }
+}
+
+async function sessionCookie(
+  app: Hono<AppEnv>,
+  env: AppEnv['Bindings'],
+  user: { id: string; email: string; name: string | null; role: 'member' | 'superadmin' },
+) {
+  app.get('/login', async (c) => {
+    await createSession(c, user)
+    return c.text('ok')
+  })
+  const res = await app.request('/login', {}, env)
+  return (res.headers.get('set-cookie') ?? '').split(';')[0]
+}
+
+describe('requireAuth credential dispatch', () => {
+  test('a session-cookie caller yields kind "session"', async () => {
+    const { app, db, env } = setup()
+    const uid = await seedUser(db, { id: 'u1' })
+    const cookie = await sessionCookie(app, env, { id: uid, email: 'u1@x.com', name: null, role: 'member' })
+
+    const res = await app.request('/whoami', { headers: { Cookie: cookie } }, env)
+    expect(res.status).toBe(200)
+    expect(await res.json()).toMatchObject({ kind: 'session', user: { id: uid } })
+  })
+
+  test('CASE-06: an existing KV CLI (plain Bearer) token still authenticates, yielding kind "cli"', async () => {
+    const { app, db, kv, env } = setup()
+    const uid = await seedUser(db, { id: 'u1' })
+    await kv.put(`cli:tok-${uid}`, JSON.stringify({ id: uid, email: 'u1@x.com', name: null, role: 'member' }))
+
+    const res = await app.request('/whoami', { headers: { Authorization: `Bearer tok-${uid}` } }, env)
+    expect(res.status).toBe(200)
+    expect(await res.json()).toMatchObject({ kind: 'cli', user: { id: uid } })
+  })
+
+  test('a live glk_ key yields kind "key" with keyId and grants', async () => {
+    const { app, db, env } = setup()
+    const uid = await seedUser(db, { id: 'u1' })
+    const secret = generateApiKey()
+    const hash = await hashApiKey(secret)
+    const grants = { scopes: ['sites:read'] }
+    const keyId = await seedApiKey(db, { userId: uid, hash, grants })
+
+    const res = await app.request('/whoami', { headers: { Authorization: `Bearer ${secret}` } }, env)
+    expect(res.status).toBe(200)
+    expect(await res.json()).toMatchObject({ kind: 'key', keyId, grants, user: { id: uid } })
+  })
+
+  test('CASE-04: an unknown glk_ token 401s and never falls through to the KV CLI lookup', async () => {
+    const { app, db, kv, env } = setup()
+    // Composed from the exported prefix rather than written out — a literal key-shaped string
+    // here trips the repo's pre-commit secret scanner.
+    const token = `${API_KEY_PREFIX}definitely-not-issued`
+    // The KV-planted user must be a REAL D1 row — otherwise a fall-through would still 401 via
+    // requireAuth's live getUserById re-resolution, masking the exact bug this case exists to
+    // catch. With the user seeded, a fall-through authenticates as 200, not a coincidental 401.
+    const uid = await seedUser(db, { id: 'ghost' })
+    // Plant a live CLI-token KV entry under this EXACT string. If prefix dispatch fell through to
+    // the KV lookup on a failed D1 resolve, this would authenticate — it must not, in either
+    // direction: a glk_ token never gets a shot at the CLI store.
+    await kv.put(`cli:${token}`, JSON.stringify({ id: uid, email: 'ghost@x.com', name: null, role: 'member' }))
+
+    const res = await app.request('/whoami', { headers: { Authorization: `Bearer ${token}` } }, env)
+    expect(res.status).toBe(401)
+  })
+
+  // readSessionOrBearer is a PROJECTION of readCredential, not a second resolver. Reverting it to
+  // its own readSession -> readCliToken implementation leaves every test above green while silently
+  // 401ing API keys on the inline-auth routes — which is the whole `glance read` path. This is the
+  // test that fails when the two paths drift apart.
+  test('readSessionOrBearer resolves a glk_ key too, so inline-auth routes accept API keys', async () => {
+    const { app, db, env } = setup()
+    const uid = await seedUser(db, { id: 'u1' })
+    const secret = generateApiKey()
+    await seedApiKey(db, { userId: uid, hash: await hashApiKey(secret) })
+
+    const res = await app.request('/inline', { headers: { Authorization: `Bearer ${secret}` } }, env)
+    expect(res.status).toBe(200)
+    expect(await res.json()).toMatchObject({ id: uid })
+  })
+
+  // Resolution order, step 1: the cookie is checked BEFORE the Authorization header. A browser
+  // request that also carries a key must resolve as its logged-in user, not as the key's owner —
+  // otherwise `credential.kind` would disagree with requireAuth's 'web' authKind tag.
+  test('the session cookie wins over a Bearer glk_ key on the same request', async () => {
+    const { app, db, env } = setup()
+    const owner = await seedUser(db, { id: 'u1' })
+    const keyOwner = await seedUser(db, { id: 'u2' })
+    const secret = generateApiKey()
+    await seedApiKey(db, { userId: keyOwner, hash: await hashApiKey(secret) })
+    const cookie = await sessionCookie(app, env, { id: owner, email: 'u1@x.com', name: null, role: 'member' })
+
+    const res = await app.request(
+      '/whoami',
+      { headers: { Cookie: cookie, Authorization: `Bearer ${secret}` } },
+      env,
+    )
+    expect(res.status).toBe(200)
+    expect(await res.json()).toMatchObject({ kind: 'session', user: { id: owner } })
+  })
+})

--- a/packages/api/src/middleware/auth-credential.test.ts
+++ b/packages/api/src/middleware/auth-credential.test.ts
@@ -72,7 +72,7 @@ describe('requireAuth credential dispatch', () => {
     const uid = await seedUser(db, { id: 'u1' })
     const secret = generateApiKey()
     const hash = await hashApiKey(secret)
-    const grants = { scopes: ['sites:read'] }
+    const grants = { control: true, data: { scope: { kind: 'all-owned' as const }, caps: ['read' as const] } }
     const keyId = await seedApiKey(db, { userId: uid, hash, grants })
 
     const res = await app.request('/whoami', { headers: { Authorization: `Bearer ${secret}` } }, env)

--- a/packages/api/src/middleware/auth-credential.test.ts
+++ b/packages/api/src/middleware/auth-credential.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from 'bun:test'
+import { eq } from 'drizzle-orm'
 import { Hono } from 'hono'
-import { API_KEY_PREFIX, generateApiKey, hashApiKey } from '../lib/api-key'
+import { apiKeys as apiKeysTable } from '../db/schema'
+import { API_KEY_PREFIX, LAST_USED_THROTTLE_MS, generateApiKey, hashApiKey } from '../lib/api-key'
 import { createSession, readSessionOrBearer } from '../lib/session'
 import { makeDb, makeKv, seedApiKey, seedUser } from '../test/harness'
 import type { AppEnv } from '../types'
@@ -131,5 +133,79 @@ describe('requireAuth credential dispatch', () => {
     )
     expect(res.status).toBe(200)
     expect(await res.json()).toMatchObject({ kind: 'session', user: { id: owner } })
+  })
+})
+
+describe('api key lastUsedAt touch', () => {
+  test('CASE-18: two authed requests inside the throttle window write lastUsedAt exactly once', async () => {
+    const { app, db, env } = setup()
+    const uid = await seedUser(db, { id: 'u1' })
+    const secret = generateApiKey()
+    await seedApiKey(db, { userId: uid, hash: await hashApiKey(secret), lastUsedAt: null })
+    db.resetCounters()
+
+    await app.request('/whoami', { headers: { Authorization: `Bearer ${secret}` } }, env)
+    await app.request('/whoami', { headers: { Authorization: `Bearer ${secret}` } }, env)
+
+    expect(db.counters.update).toBe(1)
+  })
+
+  test('a first-ever use writes lastUsedAt; a use after the window elapses writes again', async () => {
+    const { app, db, env } = setup()
+    const uid = await seedUser(db, { id: 'u1' })
+    const secret = generateApiKey()
+    const keyId = await seedApiKey(db, { userId: uid, hash: await hashApiKey(secret), lastUsedAt: null })
+    db.resetCounters()
+
+    await app.request('/whoami', { headers: { Authorization: `Bearer ${secret}` } }, env)
+    expect(db.counters.update).toBe(1)
+    const [afterFirst] = await db.select().from(apiKeysTable).where(eq(apiKeysTable.id, keyId))
+    expect(afterFirst.lastUsedAt).not.toBeNull()
+
+    // Back-date lastUsedAt past the throttle window to simulate elapsed time.
+    const stale = new Date(Date.now() - LAST_USED_THROTTLE_MS - 1000).toISOString()
+    await db.update(apiKeysTable).set({ lastUsedAt: stale }).where(eq(apiKeysTable.id, keyId))
+    db.resetCounters()
+
+    await app.request('/whoami', { headers: { Authorization: `Bearer ${secret}` } }, env)
+    expect(db.counters.update).toBe(1)
+    const [afterSecond] = await db.select().from(apiKeysTable).where(eq(apiKeysTable.id, keyId))
+    expect(afterSecond.lastUsedAt).not.toBe(stale)
+  })
+
+  test('a request whose lastUsedAt write THROWS still returns its normal authenticated response', async () => {
+    const { app, db, env } = setup()
+    const uid = await seedUser(db, { id: 'u1' })
+    const secret = generateApiKey()
+    await seedApiKey(db, { userId: uid, hash: await hashApiKey(secret), lastUsedAt: null })
+    const originalUpdate = db.update.bind(db)
+    db.update = (() => {
+      throw new Error('boom')
+    }) as typeof db.update
+
+    const res = await app.request('/whoami', { headers: { Authorization: `Bearer ${secret}` } }, env)
+    expect(res.status).toBe(200)
+    expect(await res.json()).toMatchObject({ kind: 'key', user: { id: uid } })
+
+    db.update = originalUpdate
+  })
+
+  test('the CLI-token and cookie paths perform no api_keys write at all', async () => {
+    const { app, db, kv, env } = setup()
+    const uid = await seedUser(db, { id: 'u1' })
+    await kv.put(`cli:tok-${uid}`, JSON.stringify({ id: uid, email: 'u1@x.com', name: null, role: 'member' }))
+    // Registers a route on `app`, so it must happen before any app.request() call builds the
+    // matcher (Hono freezes routing on first dispatch) — same ordering the other cookie tests use.
+    const cookie = await sessionCookie(app, env, { id: uid, email: 'u1@x.com', name: null, role: 'member' })
+
+    db.resetCounters()
+    const cliRes = await app.request('/whoami', { headers: { Authorization: `Bearer tok-${uid}` } }, env)
+    expect(cliRes.status).toBe(200)
+    expect(db.counters.update).toBe(0)
+
+    db.resetCounters()
+    const cookieRes = await app.request('/whoami', { headers: { Cookie: cookie } }, env)
+    expect(cookieRes.status).toBe(200)
+    expect(db.counters.update).toBe(0)
   })
 })

--- a/packages/api/src/middleware/auth.ts
+++ b/packages/api/src/middleware/auth.ts
@@ -1,7 +1,7 @@
 import { getCookie } from 'hono/cookie'
 import { createMiddleware } from 'hono/factory'
 import { getUserById } from '../db/repo'
-import { readSessionOrBearer } from '../lib/session'
+import { readCredential } from '../lib/session'
 import type { AppEnv } from '../types'
 
 const SESSION_COOKIE = '__Host-glance_session'
@@ -27,18 +27,21 @@ export const requireSameOrigin = createMiddleware<AppEnv>(async (c, next) => {
   await next()
 })
 
-/** 401 unless a valid browser session OR CLI Bearer token exists; attaches the LIVE user. */
+/** 401 unless a valid browser session, CLI Bearer token, or D1 API key exists; attaches the LIVE
+ *  user plus the resolved Credential (which store authenticated the request). */
 export const requireAuth = createMiddleware<AppEnv>(async (c, next) => {
-  const session = await readSessionOrBearer(c)
-  if (!session) return c.json({ error: 'unauthorized' }, 401)
-  // The KV session is a snapshot frozen for the token's life (24h cookie / 30d CLI). Re-resolve
-  // the live row each request so a deleted user is rejected (401) and a role/email change takes
-  // effect immediately — e.g. a demoted superadmin loses privilege now (requireSuperAdmin sees
-  // the fresh role) rather than at token expiry. Single indexed PK read; the viewer hot path
-  // reads readSessionOrBearer inline (not this middleware), so FCP is unaffected.
-  const user = await getUserById(c.get('db'), session.id)
+  const credential = await readCredential(c)
+  if (!credential) return c.json({ error: 'unauthorized' }, 401)
+  // The KV session / D1 key lookup is a snapshot frozen for the token's life (24h cookie / 30d
+  // CLI / until the key is queried again). Re-resolve the live row each request so a deleted
+  // user is rejected (401) and a role/email change takes effect immediately — e.g. a demoted
+  // superadmin loses privilege now (requireSuperAdmin sees the fresh role) rather than at token
+  // expiry. Single indexed PK read; the viewer hot path reads readSessionOrBearer inline (not
+  // this middleware), so FCP is unaffected.
+  const user = await getUserById(c.get('db'), credential.user.id)
   if (!user) return c.json({ error: 'unauthorized' }, 401)
   c.set('user', user)
+  c.set('credential', credential)
   // Tag the credential for usage analytics. The CLI sends a Bearer token and never a cookie;
   // browsers always carry the cookie. Session cookie wins (mirrors readSessionOrBearer), so a
   // request is 'cli' only when there's no cookie AND a Bearer token is present.

--- a/packages/api/src/middleware/auth.ts
+++ b/packages/api/src/middleware/auth.ts
@@ -1,7 +1,7 @@
 import { getCookie } from 'hono/cookie'
 import { createMiddleware } from 'hono/factory'
 import { getUserById } from '../db/repo'
-import { readCredential } from '../lib/session'
+import { bearerToken, readCredential } from '../lib/session'
 import type { AppEnv } from '../types'
 
 const SESSION_COOKIE = '__Host-glance_session'
@@ -45,9 +45,32 @@ export const requireAuth = createMiddleware<AppEnv>(async (c, next) => {
   // Tag the credential for usage analytics. The CLI sends a Bearer token and never a cookie;
   // browsers always carry the cookie. Session cookie wins (mirrors readSessionOrBearer), so a
   // request is 'cli' only when there's no cookie AND a Bearer token is present.
-  const isBearer = c.req.header('Authorization')?.startsWith('Bearer ') ?? false
   const hasCookie = getCookie(c, SESSION_COOKIE) !== undefined
-  c.set('authKind', !hasCookie && isBearer ? 'cli' : 'web')
+  c.set('authKind', !hasCookie && bearerToken(c) !== null ? 'cli' : 'web')
+  await next()
+})
+
+// Methods that CHANGE control-plane state. A key without the control grant may still read
+// (listing sites, resolving a site before minting a data token); what it may not do is deploy,
+// create, fork, move or otherwise mutate. GET/HEAD are exactly the operations the data-only key
+// in the wireframe still needs.
+const UNSAFE = new Set(['POST', 'PUT', 'PATCH', 'DELETE'])
+
+/**
+ * Must run after requireAuth. 403s a key credential that was minted WITHOUT the control grant
+ * when it tries to change control-plane state.
+ *
+ * This exists because `grants.control` is a promise made to the user at mint time — the dialog
+ * offers it as an opt-in and the docs say it is what lets a key deploy. Storing that flag and
+ * never reading it is worse than not offering it: the operator believes they minted a data-only
+ * key and actually minted one with the full control plane. Session and CLI credentials are
+ * unaffected — they carry no grants and are governed by ownership alone, exactly as before.
+ */
+export const requireControlGrant = createMiddleware<AppEnv>(async (c, next) => {
+  const credential = c.get('credential')
+  if (credential?.kind === 'key' && !credential.grants.control && UNSAFE.has(c.req.method)) {
+    return c.json({ error: 'forbidden' }, 403)
+  }
   await next()
 })
 

--- a/packages/api/src/routes/admin.test.ts
+++ b/packages/api/src/routes/admin.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from 'bun:test'
+import { auth, authKey, makeRouteApp, mintKey, mintUser } from '../test/route-fixtures'
+
+describe('POST /api/admin/users/:id/revoke-cli', () => {
+  test('CASE-16: also revokes the user’s D1 API keys — the key stops authenticating afterwards', async () => {
+    const { app, db, kv, env } = makeRouteApp()
+    await mintUser(db, kv, 'admin', { role: 'superadmin' })
+    await mintUser(db, kv, 'owner')
+    const secret = await mintKey(db, 'owner')
+
+    // Sanity: the key authenticates before the kill-switch runs.
+    const before = await app.request('/api/api-keys', { headers: authKey(secret) }, env)
+    expect(before.status).toBe(200)
+
+    const res = await app.request(
+      '/api/admin/users/owner/revoke-cli',
+      { method: 'POST', headers: auth('admin') },
+      env,
+    )
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ ok: true })
+
+    // The key must stop AUTHENTICATING — not merely have a column changed.
+    const after = await app.request('/api/api-keys', { headers: authKey(secret) }, env)
+    expect(after.status).toBe(401)
+  })
+
+  // The slice added D1-key revocation ALONGSIDE the pre-existing KV sweep, and nothing anywhere
+  // characterized that sweep — deleting revokeUserCliTokens from the route left the whole suite
+  // green. Both halves of the kill-switch belong under test, or offboarding can silently start
+  // leaving CLI tokens live.
+  test('still revokes the user’s KV CLI tokens — both halves of the kill-switch', async () => {
+    const { app, db, kv, env } = makeRouteApp()
+    await mintUser(db, kv, 'admin', { role: 'superadmin' })
+    await mintUser(db, kv, 'owner')
+
+    const before = await app.request('/api/api-keys', { headers: auth('owner') }, env)
+    expect(before.status).toBe(200)
+
+    await app.request('/api/admin/users/owner/revoke-cli', { method: 'POST', headers: auth('admin') }, env)
+
+    const after = await app.request('/api/api-keys', { headers: auth('owner') }, env)
+    expect(after.status).toBe(401)
+    expect(await kv.get('cli:tok-owner')).toBeNull()
+  })
+
+  test('idempotent: a second call is a no-op, and a user with no keys is fine', async () => {
+    const { app, db, kv, env } = makeRouteApp()
+    await mintUser(db, kv, 'admin', { role: 'superadmin' })
+    await mintUser(db, kv, 'nokeys')
+
+    const first = await app.request(
+      '/api/admin/users/nokeys/revoke-cli',
+      { method: 'POST', headers: auth('admin') },
+      env,
+    )
+    expect(first.status).toBe(200)
+    expect(await first.json()).toEqual({ ok: true })
+
+    const second = await app.request(
+      '/api/admin/users/nokeys/revoke-cli',
+      { method: 'POST', headers: auth('admin') },
+      env,
+    )
+    expect(second.status).toBe(200)
+    expect(await second.json()).toEqual({ ok: true })
+  })
+
+  test('does not touch another user’s keys', async () => {
+    const { app, db, kv, env } = makeRouteApp()
+    await mintUser(db, kv, 'admin', { role: 'superadmin' })
+    await mintUser(db, kv, 'owner')
+    await mintUser(db, kv, 'other')
+    const otherSecret = await mintKey(db, 'other')
+
+    await app.request('/api/admin/users/owner/revoke-cli', { method: 'POST', headers: auth('admin') }, env)
+
+    const res = await app.request('/api/api-keys', { headers: authKey(otherSecret) }, env)
+    expect(res.status).toBe(200)
+  })
+})

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -1,6 +1,7 @@
 import { and, desc, eq, sql } from 'drizzle-orm'
 import { Hono } from 'hono'
 import { sites, spaceMembers, spaces as spacesTable, users } from '../db/schema'
+import { revokeUserApiKeys } from '../lib/api-key'
 import { fireAndForget } from '../lib/events'
 import { revokeUserCliTokens } from '../lib/session'
 import { cachedStats } from '../lib/stats'
@@ -125,10 +126,13 @@ admin.get('/users', async (c) => {
 })
 
 // POST /api/admin/users/:id/revoke-cli — offboarding kill-switch: revoke EVERY CLI token the user
-// holds (enumerated via the per-user `cli_index:` prefix). Idempotent — a no-op for a user with no
-// tokens (or an already-deleted one). Superadmin-only via the router-wide requireSuperAdmin above.
+// holds (enumerated via the per-user `cli_index:` prefix) AND every D1 API key they hold — a user
+// whose access is being killed keeps neither. Idempotent — a no-op for a user with no tokens/keys
+// (or already-revoked ones). Superadmin-only via the router-wide requireSuperAdmin above.
 admin.post('/users/:id/revoke-cli', async (c) => {
-  await revokeUserCliTokens(c, c.req.param('id'))
+  const userId = c.req.param('id')
+  await revokeUserCliTokens(c, userId)
+  await revokeUserApiKeys(c.get('db'), userId)
   return c.json({ ok: true })
 })
 

--- a/packages/api/src/routes/api-key-control-grant.test.ts
+++ b/packages/api/src/routes/api-key-control-grant.test.ts
@@ -1,0 +1,98 @@
+// `grants.control` is a promise made to the operator at mint time: the dialog offers it as an
+// opt-in labelled "Also allow managing sites (deploy, create, fork)" and the docs page says it is
+// what lets a key deploy. Before requireControlGrant that flag was stored, validated and shown —
+// and never read, so a key minted with the box UNTICKED still had the entire control plane. These
+// pin the two halves of the boundary: an unticked key cannot change control-plane state, and it
+// can still do everything a data-only key is supposed to do.
+import { describe, expect, test } from 'bun:test'
+import { eq } from 'drizzle-orm'
+import { sites } from '../db/schema'
+import { seedMember, seedSite, seedSpace } from '../test/harness'
+import { DATA_ONLY_GRANTS, authKey, makeRouteApp, mintKey, mintUser } from '../test/route-fixtures'
+
+async function setup() {
+  const ctx = makeRouteApp()
+  const { db, kv } = ctx
+  await mintUser(db, kv, 'owner')
+  await seedSpace(db, { id: 'acme', slug: 'acme', createdBy: 'owner' })
+  await seedMember(db, 'acme', 'owner')
+  await seedSite(db, { id: 'deck', spaceId: 'acme', ownerId: 'owner', slug: 'deck' })
+  return ctx
+}
+
+describe('requireControlGrant — a key without the control grant cannot change control state', () => {
+  test('it cannot rename a site, and the site is untouched', async () => {
+    const ctx = await setup()
+    const dataOnly = await mintKey(ctx.db, 'owner', DATA_ONLY_GRANTS)
+
+    const res = await ctx.app.request(
+      '/api/sites/acme/deck',
+      { method: 'PATCH', headers: authKey(dataOnly), body: JSON.stringify({ title: 'Renamed' }) },
+      ctx.env,
+    )
+    expect(res.status).toBe(403)
+    const [row] = await ctx.db.select().from(sites).where(eq(sites.id, 'deck'))
+    expect(row.title).not.toBe('Renamed')
+  })
+
+  test('it cannot fork a site, create a space, or add a member', async () => {
+    const ctx = await setup()
+    const dataOnly = await mintKey(ctx.db, 'owner', DATA_ONLY_GRANTS)
+
+    for (const [path, body] of [
+      ['/api/sites/acme/deck/fork', { name: 'copy' }],
+      ['/api/spaces', { slug: 'newspace', name: 'New' }],
+      ['/api/spaces/acme/members', { email: 'x@example.com' }],
+    ] as const) {
+      const res = await ctx.app.request(
+        path,
+        { method: 'POST', headers: authKey(dataOnly), body: JSON.stringify(body) },
+        ctx.env,
+      )
+      expect({ path, status: res.status }).toEqual({ path, status: 403 })
+    }
+  })
+
+  // The other half. A data-only key is a legitimate credential, not a broken one — gating reads
+  // would break the very use case the grant exists to express.
+  test('it can still READ: the grant gates mutation, not access', async () => {
+    const ctx = await setup()
+    const dataOnly = await mintKey(ctx.db, 'owner', DATA_ONLY_GRANTS)
+
+    const res = await ctx.app.request('/api/sites/mine', { headers: authKey(dataOnly) }, ctx.env)
+    expect(res.status).toBe(200)
+  })
+
+  // And the same request with the grant ticked must go through, or the middleware would just be
+  // a blanket key deny wearing a grant's name.
+  test('the SAME request succeeds with a control-granted key', async () => {
+    const ctx = await setup()
+    const full = await mintKey(ctx.db, 'owner')
+
+    const res = await ctx.app.request(
+      '/api/sites/acme/deck',
+      { method: 'PATCH', headers: authKey(full), body: JSON.stringify({ title: 'Renamed' }) },
+      ctx.env,
+    )
+    expect(res.status).toBe(200)
+    const [row] = await ctx.db.select().from(sites).where(eq(sites.id, 'deck'))
+    expect(row.title).toBe('Renamed')
+  })
+
+  // Session and CLI credentials carry no grants at all; they must be governed by ownership alone,
+  // exactly as before this middleware existed.
+  test('a CLI-token caller is unaffected — it carries no grants to check', async () => {
+    const ctx = await setup()
+
+    const res = await ctx.app.request(
+      '/api/sites/acme/deck',
+      {
+        method: 'PATCH',
+        headers: { Authorization: 'Bearer tok-owner', Origin: 'https://glance.example.com', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title: 'Renamed by CLI' }),
+      },
+      ctx.env,
+    )
+    expect(res.status).toBe(200)
+  })
+})

--- a/packages/api/src/routes/api-keys.test.ts
+++ b/packages/api/src/routes/api-keys.test.ts
@@ -1,0 +1,306 @@
+import { describe, expect, test } from 'bun:test'
+import { eq } from 'drizzle-orm'
+import { API_KEY_PREFIX } from '../lib/api-key'
+import { apiKeys as apiKeysTable } from '../db/schema'
+import { FULL_GRANTS, seedApiKey } from '../test/harness'
+import { auth, authKey, makeRouteApp, mintKey, mintUser } from '../test/route-fixtures'
+import { KEY_DURATIONS, MAX_ACTIVE_KEYS } from './api-keys'
+
+async function scenario() {
+  // Real production wiring (makeRouteApp mounts this router the way index.ts does), so these
+  // tests also prove /api/api-keys is reachable in the assembled app, not just in isolation.
+  const { app, db, kv, env } = makeRouteApp()
+  await mintUser(db, kv, 'owner')
+  await mintUser(db, kv, 'other')
+  // Bound request helper: the CLI Bearer path (auth()) needs GLANCE_SESSIONS on env, so env
+  // travels with app/db rather than being threaded through every call site.
+  // Hono's `.get('/')`/`.post('/')` on a sub-router match the mount path with NO trailing slash
+  // (see whats-new.test.ts) — '/' here means "the router root", not a literal trailing slash.
+  const req = (headers: Record<string, string>, method: string, path: string, body?: unknown) =>
+    app.request(
+      `/api/api-keys${path === '/' ? '' : path}`,
+      { method, headers, body: body ? JSON.stringify(body) : undefined },
+      env,
+    )
+  return { db, kv, app, env, req }
+}
+
+describe('POST /api/api-keys — mint', () => {
+  test('CASE-13: mint returns the secret once; the GET list response body NEVER contains it', async () => {
+    const { req } = await scenario()
+    const mintRes = await req(auth('owner'), 'POST', '/', { name: 'ci key', expiresInDays: 30, grants: FULL_GRANTS })
+    expect(mintRes.status).toBe(201)
+    const minted = await mintRes.json()
+    expect(typeof minted.secret).toBe('string')
+    expect(minted.secret.startsWith('glk_')).toBe(true)
+
+    const listRes = await req(auth('owner'), 'GET', '/')
+    const listBody = await listRes.text()
+    expect(listBody).not.toContain(minted.secret)
+
+    // The secret returned above must actually work as a Bearer token — proves the stored hash
+    // matches what was minted, not merely that SOME secret was returned.
+    const authRes = await req(authKey(minted.secret), 'GET', '/')
+    expect(authRes.status).toBe(200)
+  })
+
+  test('mint sets Cache-Control: no-store', async () => {
+    const { req } = await scenario()
+    const res = await req(auth('owner'), 'POST', '/', { name: 'k', expiresInDays: 7, grants: FULL_GRANTS })
+    expect(res.headers.get('cache-control')).toBe('no-store')
+  })
+
+  test('CASE-14a: expiresInDays outside the fixed duration set is rejected', async () => {
+    const { req } = await scenario()
+    const res = await req(auth('owner'), 'POST', '/', { name: 'k', expiresInDays: 45, grants: FULL_GRANTS })
+    expect(res.status).toBe(400)
+  })
+
+  test('CASE-14b: a body-supplied expiresAt is ignored — server derives it from expiresInDays', async () => {
+    const { db, req } = await scenario()
+    const tenYearsOut = new Date(Date.now() + 10 * 365 * 24 * 60 * 60 * 1000).toISOString()
+    const res = await req(auth('owner'), 'POST', '/', {
+      name: 'k',
+      expiresInDays: 7,
+      expiresAt: tenYearsOut,
+      grants: FULL_GRANTS,
+    })
+    expect(res.status).toBe(201)
+    const { id } = await res.json()
+    const [mine] = await db.select().from(apiKeysTable).where(eq(apiKeysTable.id, id))
+    expect(mine.expiresAt).not.toBe(tenYearsOut)
+    const expected = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000)
+    expect(Math.abs(new Date(mine.expiresAt).getTime() - expected.getTime())).toBeLessThan(5000)
+  })
+
+  test('malformed grants blob → 400', async () => {
+    const { req } = await scenario()
+    const res = await req(auth('owner'), 'POST', '/', {
+      name: 'k',
+      expiresInDays: 30,
+      grants: { control: 'yes', data: null },
+    })
+    expect(res.status).toBe(400)
+  })
+
+  test('empty/whitespace-only name → 400', async () => {
+    const { req } = await scenario()
+    const res = await req(auth('owner'), 'POST', '/', { name: '   ', expiresInDays: 30, grants: FULL_GRANTS })
+    expect(res.status).toBe(400)
+  })
+
+  test('name over the max length → 400', async () => {
+    const { req } = await scenario()
+    const res = await req(auth('owner'), 'POST', '/', { name: 'x'.repeat(201), expiresInDays: 30, grants: FULL_GRANTS })
+    expect(res.status).toBe(400)
+  })
+
+  test('unauthenticated mint → 401', async () => {
+    const { req } = await scenario()
+    const res = await req({ 'Content-Type': 'application/json' }, 'POST', '/', {
+      name: 'k',
+      expiresInDays: 30,
+      grants: FULL_GRANTS,
+    })
+    expect(res.status).toBe(401)
+  })
+
+  test('the fixed duration set is exactly [1, 7, 30, 90, 180, 365]', () => {
+    expect(KEY_DURATIONS).toEqual([1, 7, 30, 90, 180, 365])
+  })
+
+  test('a key-authenticated mint is 403’d, regardless of its grants', async () => {
+    const { db, req } = await scenario()
+    const secret = await mintKey(db, 'owner')
+    const res = await req(authKey(secret), 'POST', '/', { name: 'backdoor', expiresInDays: 365, grants: FULL_GRANTS })
+    expect(res.status).toBe(403)
+    const list = await req(auth('owner'), 'GET', '/')
+    const { items } = await list.json()
+    expect(items.map((k: { name: string }) => k.name)).not.toContain('backdoor')
+  })
+
+  test('CASE-19: the (cap+1)th active key is rejected; revoking one frees a slot; expired/revoked keys do not count', async () => {
+    const { db, req } = await scenario()
+    // Pre-fill with an EXPIRED key and a REVOKED key — neither should count against the cap.
+    await seedApiKey(db, { userId: 'owner', expiresAt: new Date(Date.now() - 1000).toISOString() })
+    await seedApiKey(db, { userId: 'owner', revokedAt: new Date().toISOString() })
+
+    const ids: string[] = []
+    for (let i = 0; i < MAX_ACTIVE_KEYS; i++) {
+      const res = await req(auth('owner'), 'POST', '/', { name: `k${i}`, expiresInDays: 30, grants: FULL_GRANTS })
+      expect(res.status).toBe(201)
+      ids.push((await res.json()).id)
+    }
+    const overCap = await req(auth('owner'), 'POST', '/', { name: 'over', expiresInDays: 30, grants: FULL_GRANTS })
+    expect(overCap.status).toBe(400)
+
+    // Revoking one frees a slot.
+    const revoke = await req(auth('owner'), 'DELETE', `/${ids[0]}`)
+    expect(revoke.status).toBe(200)
+    const afterRevoke = await req(auth('owner'), 'POST', '/', {
+      name: 'after-revoke',
+      expiresInDays: 30,
+      grants: FULL_GRANTS,
+    })
+    expect(afterRevoke.status).toBe(201)
+  })
+
+  test('the active-key cap is exactly 10', () => {
+    expect(MAX_ACTIVE_KEYS).toBe(10)
+  })
+
+  test("the cap only counts the CALLER's own keys — another user's active keys don't consume it", async () => {
+    const { db, req } = await scenario()
+    // 'other' has MAX_ACTIVE_KEYS active keys already; 'owner' has none.
+    for (let i = 0; i < MAX_ACTIVE_KEYS; i++) {
+      await seedApiKey(db, { userId: 'other', name: `other-${i}` })
+    }
+    const res = await req(auth('owner'), 'POST', '/', { name: 'k', expiresInDays: 30, grants: FULL_GRANTS })
+    expect(res.status).toBe(201)
+  })
+})
+
+describe('GET /api/api-keys — list', () => {
+  test('lists newest first with the expected fields, and a revoked key stays (tombstone)', async () => {
+    const { req } = await scenario()
+    const first = await req(auth('owner'), 'POST', '/', { name: 'first', expiresInDays: 30, grants: FULL_GRANTS })
+    const firstId = (await first.json()).id
+    await req(auth('owner'), 'POST', '/', { name: 'second', expiresInDays: 30, grants: FULL_GRANTS })
+
+    await req(auth('owner'), 'DELETE', `/${firstId}`)
+
+    const list = await req(auth('owner'), 'GET', '/')
+    expect(list.status).toBe(200)
+    const { items } = await list.json()
+    expect(items).toHaveLength(2)
+    expect(items.map((k: { name: string }) => k.name)).toEqual(['second', 'first'])
+    const revoked = items.find((k: { name: string }) => k.name === 'first')
+    expect(revoked.revokedAt).not.toBeNull()
+    for (const k of items) {
+      expect(k).toHaveProperty('name')
+      expect(k.grants).toEqual(FULL_GRANTS)
+      expect(k).toHaveProperty('createdAt')
+      expect(k).toHaveProperty('expiresAt')
+      expect(k).toHaveProperty('revokedAt')
+      expect(k).toHaveProperty('lastUsedAt')
+      expect(k).not.toHaveProperty('hash')
+    }
+  })
+
+  test('secretHint is the prefix plus ONLY the last 4 characters of the secret — nothing more', async () => {
+    const { req } = await scenario()
+    const mintRes = await req(auth('owner'), 'POST', '/', { name: 'k', expiresInDays: 30, grants: FULL_GRANTS })
+    const minted = await mintRes.json()
+
+    const list = await req(auth('owner'), 'GET', '/')
+    const { items } = await list.json()
+    // Exact equality pins both the prefix/ellipsis framing AND the length of the suffix — a
+    // longer slice (e.g. the last 20 chars instead of 4) would fail this, not just toHaveProperty.
+    expect(items[0].secretHint).toBe(`${API_KEY_PREFIX}…${minted.secret.slice(-4)}`)
+  })
+
+  // The test above reads the RENDERED hint, so it stays green even if the column behind it holds
+  // the whole plaintext and the route slices it down on the way out. What must never happen is
+  // the secret being AT REST in a recoverable form — assert the stored column directly.
+  test('the stored displaySuffix is only the last 4 characters — the secret is not at rest anywhere', async () => {
+    const { req, db } = await scenario()
+    const minted = await (await req(auth('owner'), 'POST', '/', { name: 'k', expiresInDays: 30, grants: FULL_GRANTS })).json()
+
+    const [row] = await db.select().from(apiKeysTable).where(eq(apiKeysTable.id, minted.id))
+    expect(row.displaySuffix).toBe(minted.secret.slice(-4))
+    expect(JSON.stringify(row)).not.toContain(minted.secret)
+  })
+
+  // The tombstone requirement has two halves and only the revoked one was pinned. An EXPIRED key
+  // must stay listed too: the row is what the user clicks to delete, so filtering it out of the
+  // list would strand it — visible nowhere, still occupying nothing, impossible to clean up.
+  test('an EXPIRED key stays in the list (the other half of the tombstone)', async () => {
+    const { req, db } = await scenario()
+    await seedApiKey(db, { userId: 'owner', name: 'stale', expiresAt: new Date(Date.now() - 1000).toISOString() })
+
+    const { items } = await (await req(auth('owner'), 'GET', '/')).json()
+    expect(items.map((k: { name: string }) => k.name)).toEqual(['stale'])
+  })
+
+  // Rows minted before migration 0026 have no displaySuffix. The hint must degrade to null rather
+  // than rendering the literal string "glk_…null" into the keys screen.
+  test('a pre-0026 row with no displaySuffix lists with a null secretHint, not "…null"', async () => {
+    const { req, db } = await scenario()
+    await seedApiKey(db, { userId: 'owner', name: 'legacy' })
+
+    const { items } = await (await req(auth('owner'), 'GET', '/')).json()
+    expect(items[0].secretHint).toBeNull()
+  })
+
+  test("only lists the caller's own keys", async () => {
+    const { req } = await scenario()
+    await req(auth('owner'), 'POST', '/', { name: 'owner key', expiresInDays: 30, grants: FULL_GRANTS })
+    await req(auth('other'), 'POST', '/', { name: 'other key', expiresInDays: 30, grants: FULL_GRANTS })
+    const list = await req(auth('owner'), 'GET', '/')
+    const { items } = await list.json()
+    expect(items).toHaveLength(1)
+    expect(items[0].name).toBe('owner key')
+  })
+
+  test('a key can authenticate to its own routes too', async () => {
+    const { db, req } = await scenario()
+    const secret = await mintKey(db, 'owner')
+    const res = await req(authKey(secret), 'GET', '/')
+    expect(res.status).toBe(200)
+  })
+})
+
+describe('DELETE /api/api-keys/:id — revoke', () => {
+  test("CASE-15: revoking another user's key returns 404, not 403", async () => {
+    const { req } = await scenario()
+    const mintRes = await req(auth('owner'), 'POST', '/', { name: 'k', expiresInDays: 30, grants: FULL_GRANTS })
+    const { id } = await mintRes.json()
+    const res = await req(auth('other'), 'DELETE', `/${id}`)
+    expect(res.status).toBe(404)
+  })
+
+  test('revoking is idempotent — revoking an already-revoked key is still a success', async () => {
+    const { req } = await scenario()
+    const mintRes = await req(auth('owner'), 'POST', '/', { name: 'k', expiresInDays: 30, grants: FULL_GRANTS })
+    const { id } = await mintRes.json()
+    expect((await req(auth('owner'), 'DELETE', `/${id}`)).status).toBe(200)
+    expect((await req(auth('owner'), 'DELETE', `/${id}`)).status).toBe(200)
+  })
+
+  test('revoking an unknown id returns 404', async () => {
+    const { req } = await scenario()
+    const res = await req(auth('owner'), 'DELETE', '/does-not-exist')
+    expect(res.status).toBe(404)
+  })
+
+  test('unauthenticated revoke → 401', async () => {
+    const { req } = await scenario()
+    const res = await req({ 'Content-Type': 'application/json' }, 'DELETE', '/does-not-exist')
+    expect(res.status).toBe(401)
+  })
+
+  // A leaked key must not be able to mint a backdoor key (see the mint describe block above) OR
+  // revoke the user's OTHER keys — either would let a leaked key outlive its own revocation.
+  // Checked BEFORE the ownership lookup (same ordering as sites.ts DELETE), so a key learns
+  // nothing about which ids exist either.
+  test("a key-authenticated revoke is 403’d, even against the SAME key's own owner's other keys", async () => {
+    const { db, req } = await scenario()
+    const victim = await req(auth('owner'), 'POST', '/', { name: 'victim', expiresInDays: 30, grants: FULL_GRANTS })
+    const { id: victimId } = await victim.json()
+    const secret = await mintKey(db, 'owner')
+
+    const res = await req(authKey(secret), 'DELETE', `/${victimId}`)
+    expect(res.status).toBe(403)
+
+    const list = await req(auth('owner'), 'GET', '/')
+    const { items } = await list.json()
+    expect(items.find((k: { id: string }) => k.id === victimId).revokedAt).toBeNull()
+  })
+
+  test('a key-authenticated revoke of a NONEXISTENT id is still 403, not 404', async () => {
+    const { db, req } = await scenario()
+    const secret = await mintKey(db, 'owner')
+    const res = await req(authKey(secret), 'DELETE', '/does-not-exist')
+    expect(res.status).toBe(403)
+  })
+})

--- a/packages/api/src/routes/api-keys.ts
+++ b/packages/api/src/routes/api-keys.ts
@@ -1,0 +1,141 @@
+import { and, count, desc, eq, gt, isNull } from 'drizzle-orm'
+import type { DrizzleD1Database } from 'drizzle-orm/d1'
+import { Hono } from 'hono'
+import { apiKeys as apiKeysTable } from '../db/schema'
+import { API_KEY_PREFIX, type ApiKeyGrants, generateApiKey, hashApiKey, isApiKeyGrants } from '../lib/api-key'
+import { requireAuth } from '../middleware/auth'
+import type { AppEnv } from '../types'
+
+// Self-service control-plane API keys, mounted at /api/api-keys. Every route is scoped to the
+// CALLER's own keys (c.get('user').id) — there is no admin surface here to manage anyone else's.
+
+const MAX_NAME_LENGTH = 200
+
+// The only expiries a key may be minted with. `expiresAt` is ALWAYS derived server-side from one
+// of these — a body-supplied `expiresAt` is never read, so a client can never name its own expiry.
+export const KEY_DURATIONS = [1, 7, 30, 90, 180, 365] as const
+
+// Per-user cap on ACTIVE keys (revokedAt IS NULL AND not expired). Expired and revoked keys are
+// tombstones, not active, so they never count against it — revoking one frees a slot immediately.
+export const MAX_ACTIVE_KEYS = 10
+
+export const apiKeys = new Hono<AppEnv>()
+apiKeys.use('*', requireAuth)
+
+// Same not-expired predicate style as resolveApiKey (lib/api-key.ts): a JS-side ISO instant bound
+// as a parameter, never SQLite's `datetime('now')` (see that file's comment for why the lexical
+// compare between the two formats fails open for a same-day expiry).
+function activeKeyCount(db: DrizzleD1Database, userId: string) {
+  const now = new Date().toISOString()
+  return db
+    .select({ n: count() })
+    .from(apiKeysTable)
+    .where(and(eq(apiKeysTable.userId, userId), isNull(apiKeysTable.revokedAt), gt(apiKeysTable.expiresAt, now)))
+}
+
+// POST / — mint a fresh key. Returns the plaintext secret EXACTLY ONCE; only its hash is stored.
+apiKeys.post('/', async (c) => {
+  // A key may never mint another key regardless of its grants — otherwise a leaked key mints a
+  // backdoor key that outlives revocation of the leaked one (same "denied regardless" pattern as
+  // site DELETE in routes/sites.ts).
+  if (c.get('credential').kind === 'key') return c.json({ error: 'forbidden' }, 403)
+
+  const body = (await c.req.json().catch(() => null)) as {
+    name?: unknown
+    expiresInDays?: unknown
+    grants?: unknown
+  } | null
+
+  const name = typeof body?.name === 'string' ? body.name.trim() : ''
+  if (!name || name.length > MAX_NAME_LENGTH) return c.json({ error: 'name is required' }, 400)
+
+  const expiresInDays = body?.expiresInDays
+  if (typeof expiresInDays !== 'number' || !KEY_DURATIONS.includes(expiresInDays as (typeof KEY_DURATIONS)[number])) {
+    return c.json({ error: `expiresInDays must be one of ${KEY_DURATIONS.join(', ')}` }, 400)
+  }
+
+  const grants = body?.grants
+  if (!isApiKeyGrants(grants)) return c.json({ error: 'invalid grants' }, 400)
+
+  const db = c.get('db')
+  const user = c.get('user')
+
+  const [{ n: activeCount }] = await activeKeyCount(db, user.id)
+  if (activeCount >= MAX_ACTIVE_KEYS) {
+    return c.json({ error: `active key limit reached (max ${MAX_ACTIVE_KEYS})` }, 400)
+  }
+
+  const secret = generateApiKey()
+  const hash = await hashApiKey(secret)
+  const now = new Date()
+  // expiresAt is computed HERE, from the fixed duration set only — any `expiresAt` in the body is
+  // never read above, so it cannot influence this value.
+  const expiresAt = new Date(now.getTime() + expiresInDays * 24 * 60 * 60 * 1000).toISOString()
+  const id = crypto.randomUUID()
+  await db.insert(apiKeysTable).values({
+    id,
+    userId: user.id,
+    name,
+    hash,
+    grants: grants as ApiKeyGrants,
+    createdAt: now.toISOString(),
+    expiresAt,
+    // Non-secret display fragment: the last 4 chars of the plaintext ONLY (see schema.ts comment
+    // on `displaySuffix` — never enough to be useful to an attacker).
+    displaySuffix: secret.slice(-4),
+  })
+
+  return c.json(
+    { id, name, secret, grants, createdAt: now.toISOString(), expiresAt },
+    201,
+    // The secret is shown exactly once, in this response — never cache it.
+    { 'Cache-Control': 'no-store' },
+  )
+})
+
+// GET / — the caller's own keys, newest first. Revoked and expired rows stay (tombstone model,
+// not a hard delete) so the UI can still show them. Never returns `hash` or anything the secret
+// could be derived from.
+apiKeys.get('/', async (c) => {
+  const rows = await c
+    .get('db')
+    .select({
+      id: apiKeysTable.id,
+      name: apiKeysTable.name,
+      grants: apiKeysTable.grants,
+      createdAt: apiKeysTable.createdAt,
+      expiresAt: apiKeysTable.expiresAt,
+      revokedAt: apiKeysTable.revokedAt,
+      lastUsedAt: apiKeysTable.lastUsedAt,
+      displaySuffix: apiKeysTable.displaySuffix,
+    })
+    .from(apiKeysTable)
+    .where(eq(apiKeysTable.userId, c.get('user').id))
+    .orderBy(desc(apiKeysTable.createdAt))
+
+  return c.json({
+    items: rows.map(({ displaySuffix, ...row }) => ({
+      ...row,
+      secretHint: displaySuffix ? `${API_KEY_PREFIX}…${displaySuffix}` : null,
+    })),
+  })
+})
+
+// DELETE /:id — revoke. Idempotent: revoking an already-revoked key is still a success. A key
+// that isn't the caller's own 404s (not 403 — a 403 would confirm the id exists at all).
+apiKeys.delete('/:id', async (c) => {
+  // A key may never revoke a key — checked BEFORE the ownership lookup so a key learns nothing
+  // about which ids exist, and so a leaked key can't be used to revoke the user's OTHER keys.
+  if (c.get('credential').kind === 'key') return c.json({ error: 'forbidden' }, 403)
+
+  const id = c.req.param('id')
+  const db = c.get('db')
+  const [row] = await db
+    .select({ id: apiKeysTable.id })
+    .from(apiKeysTable)
+    .where(and(eq(apiKeysTable.id, id), eq(apiKeysTable.userId, c.get('user').id)))
+  if (!row) return c.json({ error: 'not found' }, 404)
+
+  await db.update(apiKeysTable).set({ revokedAt: new Date().toISOString() }).where(eq(apiKeysTable.id, id))
+  return c.json({ revoked: true })
+})

--- a/packages/api/src/routes/api-keys.ts
+++ b/packages/api/src/routes/api-keys.ts
@@ -2,7 +2,7 @@ import { and, count, desc, eq, gt, isNull } from 'drizzle-orm'
 import type { DrizzleD1Database } from 'drizzle-orm/d1'
 import { Hono } from 'hono'
 import { apiKeys as apiKeysTable } from '../db/schema'
-import { API_KEY_PREFIX, type ApiKeyGrants, generateApiKey, hashApiKey, isApiKeyGrants } from '../lib/api-key'
+import { API_KEY_PREFIX, generateApiKey, hashApiKey, isApiKeyGrants } from '../lib/api-key'
 import { requireAuth } from '../middleware/auth'
 import type { AppEnv } from '../types'
 
@@ -77,7 +77,7 @@ apiKeys.post('/', async (c) => {
     userId: user.id,
     name,
     hash,
-    grants: grants as ApiKeyGrants,
+    grants,
     createdAt: now.toISOString(),
     expiresAt,
     // Non-secret display fragment: the last 4 chars of the plaintext ONLY (see schema.ts comment

--- a/packages/api/src/routes/auth-logout.test.ts
+++ b/packages/api/src/routes/auth-logout.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from 'bun:test'
+import { Hono } from 'hono'
+import { generateApiKey, hashApiKey } from '../lib/api-key'
+import { createSession } from '../lib/session'
+import { makeDb, makeKv, seedApiKey, seedUser } from '../test/harness'
+import type { AppEnv, SessionUser } from '../types'
+import { auth } from './auth'
+
+// POST /api/auth/logout — cookie logout, CLI-Bearer logout, and (the gap this file pins) a
+// key-authenticated logout, which must NOT report success for a revocation it did not perform.
+
+function setup() {
+  const db = makeDb()
+  const kv = makeKv()
+  const env = {
+    APP_URL: 'https://glance.example.com',
+    SESSION_SECRET: 'sess-secret',
+    GLANCE_SESSIONS: kv,
+  } as unknown as AppEnv['Bindings']
+  const app = new Hono<AppEnv>()
+  app.use('*', async (c, next) => {
+    c.set('db', db)
+    await next()
+  })
+  app.route('/api/auth', auth)
+  return { app, env, db, kv }
+}
+
+async function sessionCookie(app: Hono<AppEnv>, env: AppEnv['Bindings'], user: SessionUser) {
+  app.get('/login', async (c) => {
+    await createSession(c, user)
+    return c.text('ok')
+  })
+  const res = await app.request('/login', {}, env)
+  return (res.headers.get('set-cookie') ?? '').split(';')[0]
+}
+
+describe('POST /api/auth/logout', () => {
+  test('characterization: cookie logout returns { ok: true } and the cookie no longer authenticates', async () => {
+    const { app, db, env } = setup()
+    const uid = await seedUser(db, { id: 'u1' })
+    const cookie = await sessionCookie(app, env, { id: uid, email: 'u1@x.com', name: null, role: 'member' })
+
+    const before = await app.request('/api/auth/me', { headers: { Cookie: cookie } }, env)
+    expect(before.status).toBe(200)
+
+    const res = await app.request('/api/auth/logout', { method: 'POST', headers: { Cookie: cookie } }, env)
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ ok: true })
+
+    const after = await app.request('/api/auth/me', { headers: { Cookie: cookie } }, env)
+    expect(after.status).toBe(401)
+  })
+
+  test('characterization: CLI-Bearer logout returns { ok: true } and the KV token is really gone', async () => {
+    const { app, kv, env } = setup()
+    const uid = 'u1'
+    await kv.put(`cli:tok-${uid}`, JSON.stringify({ id: uid, email: 'u1@x.com', name: null, role: 'member' }))
+    await kv.put(`cli_index:${uid}:tok-${uid}`, '')
+
+    const res = await app.request(
+      '/api/auth/logout',
+      { method: 'POST', headers: { Authorization: `Bearer tok-${uid}` } },
+      env,
+    )
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ ok: true })
+    expect(kv.store.has(`cli:tok-${uid}`)).toBe(false)
+
+    const after = await app.request(
+      '/api/auth/me',
+      { headers: { Authorization: `Bearer tok-${uid}` } },
+      env,
+    )
+    expect(after.status).toBe(401)
+  })
+
+  test('CASE-17: a key-authenticated logout does not report success, and the key still authenticates afterwards', async () => {
+    const { app, db, env } = setup()
+    const uid = await seedUser(db, { id: 'u1' })
+    const secret = generateApiKey()
+    await seedApiKey(db, { userId: uid, hash: await hashApiKey(secret) })
+
+    const res = await app.request(
+      '/api/auth/logout',
+      { method: 'POST', headers: { Authorization: `Bearer ${secret}` } },
+      env,
+    )
+    // Must not report success — a key is not a session, and logout did not revoke it. Asserted
+    // as the exact status, not `not.toBe(200)`: the latter stays green if this ever degrades
+    // into a 500, which is a crash rather than the deliberate refusal this route now returns.
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.ok).not.toBe(true)
+    expect(JSON.stringify(body).toLowerCase()).toContain('keys screen')
+
+    // Not revoked here — the key must still authenticate.
+    const after = await app.request('/api/auth/me', { headers: { Authorization: `Bearer ${secret}` } }, env)
+    expect(after.status).toBe(200)
+  })
+})

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -9,7 +9,7 @@ import { requireAuth } from '../middleware/auth'
 import { sanitizeAvatarUrl } from '../lib/avatar'
 import { bootstrapDecision } from '../lib/bootstrap'
 import { createGoogle, isGoogleEnabled, OAUTH_SCOPES } from '../lib/oauth'
-import { createCliToken, createSession, destroyCliToken, destroySession } from '../lib/session'
+import { createCliToken, createSession, destroyCliToken, destroySession, readCredential } from '../lib/session'
 import type { AppEnv, Bindings, SessionUser } from '../types'
 
 const OAUTH_COOKIE = 'glance_oauth'
@@ -90,6 +90,15 @@ auth.get('/callback', async (c) => {
 })
 
 auth.post('/logout', async (c) => {
+  // This route runs neither requireAuth nor requireSameOrigin's cookie gate, so the credential is
+  // resolved directly. A `glk_` API key is not a session — `glance logout` is the wrong verb for
+  // it (a key is revoked from the keys screen, not by logging out) — so report that rather than
+  // silently doing nothing: destroyCliToken below is a KV delete and no-ops on a D1 key, and a
+  // false { ok: true } would tell the caller a credential was revoked when it was not.
+  if ((await readCredential(c))?.kind === 'key') {
+    return c.json({ error: 'not_a_session', message: 'This is an API key — revoke it from the keys screen, not logout.' }, 400)
+  }
+
   await destroySession(c)
   // `glance logout` authenticates with a Bearer CLI token and no cookie, so also revoke that
   // token server-side — otherwise the logged-out CLI credential stays valid for its full 30d TTL.

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -9,7 +9,14 @@ import { requireAuth } from '../middleware/auth'
 import { sanitizeAvatarUrl } from '../lib/avatar'
 import { bootstrapDecision } from '../lib/bootstrap'
 import { createGoogle, isGoogleEnabled, OAUTH_SCOPES } from '../lib/oauth'
-import { createCliToken, createSession, destroyCliToken, destroySession, readCredential } from '../lib/session'
+import {
+  bearerToken,
+  createCliToken,
+  createSession,
+  destroyCliToken,
+  destroySession,
+  readCredential,
+} from '../lib/session'
 import type { AppEnv, Bindings, SessionUser } from '../types'
 
 const OAUTH_COOKIE = 'glance_oauth'
@@ -102,8 +109,8 @@ auth.post('/logout', async (c) => {
   await destroySession(c)
   // `glance logout` authenticates with a Bearer CLI token and no cookie, so also revoke that
   // token server-side — otherwise the logged-out CLI credential stays valid for its full 30d TTL.
-  const header = c.req.header('Authorization')
-  if (header?.startsWith('Bearer ')) await destroyCliToken(c, header.slice(7))
+  const token = bearerToken(c)
+  if (token) await destroyCliToken(c, token)
   return c.json({ ok: true })
 })
 

--- a/packages/api/src/routes/data.test.ts
+++ b/packages/api/src/routes/data.test.ts
@@ -3,10 +3,12 @@ import type { DrizzleD1Database } from 'drizzle-orm/d1'
 import { eq } from 'drizzle-orm'
 import { Hono } from 'hono'
 import { documents, sites } from '../db/schema'
+import { generateApiKey, hashApiKey } from '../lib/api-key'
+import type { ApiKeyGrants } from '../lib/api-key'
 import { signDataToken } from '../lib/data-token'
-import { makeDb, seedMember, seedSite, seedSpace, seedUser } from '../test/harness'
+import { makeDb, seedApiKey, seedMember, seedSite, seedSpace, seedUser } from '../test/harness'
 import { auth, makeRouteApp, mintUser } from '../test/route-fixtures'
-import { MAX_DOCS_PER_SITE, dataApi, dataCapsFor, dataToken } from './data'
+import { MAX_DOCS_PER_SITE, dataApi, dataCapsFor, dataToken, intersectCaps } from './data'
 
 const HMAC_A = 'glance-test-aaa'
 // getDb() prefers the injected harness db, so GLANCE_DB is never touched; CONTENT_URL drives CORS.
@@ -47,7 +49,11 @@ async function scenario() {
     // Over-privileged B token for siteA (simulates a compromised mint) — used to prove that even
     // WITH write caps (but no read_all), B still cannot reach A's rows (createdBy scoping is
     // independent of write caps).
-    viewerB_write: await signDataToken(HMAC_A, { siteId: 'siteA', viewerId: 'userB', caps: ['read', 'create', 'write'] }),
+    viewerB_write: await signDataToken(HMAC_A, {
+      siteId: 'siteA',
+      viewerId: 'userB',
+      caps: ['read', 'create', 'write'],
+    }),
     // B's legitimate token for their OWN site — used to prove cross-tenant reach is impossible.
     B_siteB: await signDataToken(HMAC_A, { siteId: 'siteB', viewerId: 'userB', caps: OWNER_CAPS }),
   }
@@ -113,8 +119,18 @@ describe('glance.db data plane — happy path', () => {
 
 describe('P0-4/P0-3: modify authority is distinct from view authority', () => {
   test('dataCapsFor: owner + superadmin get write/read_all; a viewer gets read+create only', () => {
-    expect(dataCapsFor({ id: 'userA', role: 'member' }, { ownerId: 'userA' })).toEqual(['read', 'create', 'write', 'read_all'])
-    expect(dataCapsFor({ id: 'root', role: 'superadmin' }, { ownerId: 'userA' })).toEqual(['read', 'create', 'write', 'read_all'])
+    expect(dataCapsFor({ id: 'userA', role: 'member' }, { ownerId: 'userA' })).toEqual([
+      'read',
+      'create',
+      'write',
+      'read_all',
+    ])
+    expect(dataCapsFor({ id: 'root', role: 'superadmin' }, { ownerId: 'userA' })).toEqual([
+      'read',
+      'create',
+      'write',
+      'read_all',
+    ])
     expect(dataCapsFor({ id: 'userB', role: 'member' }, { ownerId: 'userA' })).toEqual(['read', 'create'])
   })
 
@@ -124,7 +140,12 @@ describe('P0-4/P0-3: modify authority is distinct from view authority', () => {
   // cap minting, an editor could read-all/delete the OWNER's glance.db docs. Owner path unchanged.
   test('dataCaps.editor.pin: an editor-share grantee still gets read+create only; owner unchanged', () => {
     expect(dataCapsFor({ id: 'editor', role: 'member' }, { ownerId: 'owner' })).toEqual(['read', 'create'])
-    expect(dataCapsFor({ id: 'owner', role: 'member' }, { ownerId: 'owner' })).toEqual(['read', 'create', 'write', 'read_all'])
+    expect(dataCapsFor({ id: 'owner', role: 'member' }, { ownerId: 'owner' })).toEqual([
+      'read',
+      'create',
+      'write',
+      'read_all',
+    ])
   })
 
   test('ATTACK: a viewer token cannot modify — put/delete → 403; legacy read-only also blocked from create', async () => {
@@ -395,7 +416,18 @@ describe('mint route — POST /api/data-token/:space/:site', () => {
     await seedSite(db, { id: 'site-m', spaceId: sp, ownerId: 'owner', slug: 'doc', visibility: 'team' })
     const mint = (as: string, space = 'acme', site = 'doc') =>
       app.request(`/api/data-token/${space}/${site}`, { method: 'POST', headers: auth(as) }, env)
-    return { db, app, env, mint }
+    // Seeds a live glk_ key for `userId` with the given grants ceiling, returning a mint()-alike
+    // that authenticates as that key instead of the CLI Bearer token.
+    const mintAsKey = async (userId: string, grants: ApiKeyGrants, space = 'acme', site = 'doc') => {
+      const secret = generateApiKey()
+      await seedApiKey(db, { userId, hash: await hashApiKey(secret), grants })
+      return app.request(
+        `/api/data-token/${space}/${site}`,
+        { method: 'POST', headers: { Authorization: `Bearer ${secret}` } },
+        env,
+      )
+    }
+    return { db, app, env, mint, mintAsKey }
   }
 
   test('owner mints write caps; a plain viewer mints read+create only', async () => {
@@ -422,5 +454,89 @@ describe('mint route — POST /api/data-token/:space/:site', () => {
     expect((await mint('peer')).status).toBe(200)
     expect(db.counters.loose).toBe(1) // requireAuth's user read — nothing else loose
     expect(db.counters.batches).toBe(1) // the access-facts batch
+  })
+
+  test('CASE-09: a key minting for a site outside its allowlist is 403', async () => {
+    const { mintAsKey } = await mintScenario()
+    const grants: ApiKeyGrants = {
+      control: false,
+      data: { scope: { kind: 'sites', siteIds: ['some-other-site'] }, caps: ['read', 'create', 'write', 'read_all'] },
+    }
+    const res = await mintAsKey('owner', grants)
+    expect(res.status).toBe(403)
+  })
+
+  test('CASE-10: an OWNER key with ceiling [read] mints [read], not the owner’s four', async () => {
+    const { mintAsKey } = await mintScenario()
+    const grants: ApiKeyGrants = { control: false, data: { scope: { kind: 'all-owned' }, caps: ['read'] } }
+    const res = await mintAsKey('owner', grants)
+    expect(res.status).toBe(200)
+    expect((await res.json()).caps).toEqual(['read'])
+  })
+
+  test('CASE-11: a FULL-ceiling key for a site the user only VIEWS still mints exactly [read, create] — never widens', async () => {
+    const { mintAsKey } = await mintScenario()
+    const grants: ApiKeyGrants = {
+      control: false,
+      data: { scope: { kind: 'sites', siteIds: ['site-m'] }, caps: ['read', 'create', 'write', 'read_all'] },
+    }
+    const res = await mintAsKey('peer', grants)
+    expect(res.status).toBe(200)
+    expect((await res.json()).caps).toEqual(['read', 'create'])
+  })
+
+  test('a key whose grants.data is null cannot mint a data token at all', async () => {
+    const { mintAsKey } = await mintScenario()
+    const grants: ApiKeyGrants = { control: true, data: null }
+    const res = await mintAsKey('owner', grants)
+    expect(res.status).toBe(403)
+  })
+
+  test('CASE-12: an allowlisted key whose ceiling shares no cap with the caller’s own access is 403, not a caps: [] token', async () => {
+    const { mintAsKey } = await mintScenario()
+    // peer's own base is [read, create] (site-access.spec) — a ceiling of exactly [write,
+    // read_all] intersects to empty, and the route must refuse to mint a capability-less token.
+    const grants: ApiKeyGrants = {
+      control: false,
+      data: { scope: { kind: 'sites', siteIds: ['site-m'] }, caps: ['write', 'read_all'] },
+    }
+    const res = await mintAsKey('peer', grants)
+    expect(res.status).toBe(403)
+  })
+
+  test('CASE-13: an all-owned key mints only for sites the caller OWNS — a non-owned site 403s even though it is a member', async () => {
+    const { mintAsKey } = await mintScenario()
+    // site-m is owned by 'owner'; 'peer' is a member but not the owner, so 'all-owned' must not
+    // resolve to "any site the caller can currently see".
+    const grants: ApiKeyGrants = { control: false, data: { scope: { kind: 'all-owned' }, caps: ['read'] } }
+    const res = await mintAsKey('peer', grants)
+    expect(res.status).toBe(403)
+  })
+
+  test('CASE-14: the allowlist keys on the resolved site id, never the URL slug', async () => {
+    const { mintAsKey } = await mintScenario()
+    // site-m's slug is 'doc' — an allowlist containing the SLUG, not the id, must still 403.
+    const grants: ApiKeyGrants = {
+      control: false,
+      data: { scope: { kind: 'sites', siteIds: ['doc'] }, caps: ['read', 'create', 'write', 'read_all'] },
+    }
+    const res = await mintAsKey('owner', grants)
+    expect(res.status).toBe(403)
+  })
+})
+
+describe('intersectCaps', () => {
+  test('no key ceiling (grants null) → base unchanged, same order', () => {
+    expect(intersectCaps(['read', 'create', 'write', 'read_all'], null)).toEqual([
+      'read',
+      'create',
+      'write',
+      'read_all',
+    ])
+  })
+
+  test('a key ceiling narrows base to the overlap, preserving base order', () => {
+    const grants: ApiKeyGrants = { control: false, data: { scope: { kind: 'all-owned' }, caps: ['write', 'read'] } }
+    expect(intersectCaps(['read', 'create', 'write', 'read_all'], grants)).toEqual(['read', 'write'])
   })
 })

--- a/packages/api/src/routes/data.test.ts
+++ b/packages/api/src/routes/data.test.ts
@@ -526,7 +526,7 @@ describe('mint route — POST /api/data-token/:space/:site', () => {
 })
 
 describe('intersectCaps', () => {
-  test('no key ceiling (grants null) → base unchanged, same order', () => {
+  test('no key ceiling (null) → base unchanged, same order', () => {
     expect(intersectCaps(['read', 'create', 'write', 'read_all'], null)).toEqual([
       'read',
       'create',
@@ -536,7 +536,6 @@ describe('intersectCaps', () => {
   })
 
   test('a key ceiling narrows base to the overlap, preserving base order', () => {
-    const grants: ApiKeyGrants = { control: false, data: { scope: { kind: 'all-owned' }, caps: ['write', 'read'] } }
-    expect(intersectCaps(['read', 'create', 'write', 'read_all'], grants)).toEqual(['read', 'write'])
+    expect(intersectCaps(['read', 'create', 'write', 'read_all'], ['write', 'read'])).toEqual(['read', 'write'])
   })
 })

--- a/packages/api/src/routes/data.ts
+++ b/packages/api/src/routes/data.ts
@@ -3,6 +3,7 @@ import type { DrizzleD1Database } from 'drizzle-orm/d1'
 import { type Context, Hono } from 'hono'
 import { sessionDb } from '../db/client'
 import { type ChangeLogRow, type DocumentRow, type Site, documents, sites } from '../db/schema'
+import type { ApiKeyGrants } from '../lib/api-key'
 import { type DataCapability, type DataClaims, hasCap, signDataToken, verifyDataToken } from '../lib/data-token'
 import { canViewerRead, readsEveryCreator } from '../lib/data-visibility'
 import { authorizeViewerById, fetchAccessFacts, siteAccessFromFacts } from '../lib/site-access'
@@ -327,7 +328,9 @@ dataApi.put('/:collection/:docId', async (c) => {
       await db
         .select({ createdBy: documents.createdBy, createdAt: documents.createdAt })
         .from(documents)
-        .where(and(eq(documents.siteId, claims.siteId), eq(documents.collection, collection), eq(documents.docId, docId)))
+        .where(
+          and(eq(documents.siteId, claims.siteId), eq(documents.collection, collection), eq(documents.docId, docId)),
+        )
         .limit(1)
     )[0]
     if (!existing) return null
@@ -505,6 +508,17 @@ export function dataCapsFor(user: Pick<SessionUser, 'id' | 'role'>, site: Pick<S
     : ['read', 'create']
 }
 
+// Intersect a caller's own caps ceiling (`base`, from dataCapsFor) against an API key's data-plane
+// ceiling. `grants: null` means the caller isn't key-authenticated (or the key has no ceiling to
+// apply) — base passes through UNCHANGED, byte-for-byte, so session/CLI callers are untouched.
+// Otherwise the result is the overlap: it can only ever narrow `base`, never add a cap `base`
+// didn't already have — order is `base`'s, so existing assertions on the caps array keep passing.
+export function intersectCaps(base: DataCapability[], grants: ApiKeyGrants | null): DataCapability[] {
+  if (!grants?.data) return base
+  const ceiling = grants.data.caps
+  return base.filter((c) => ceiling.includes(c))
+}
+
 export const dataToken = new Hono<AppEnv>()
 dataToken.use('*', requireAuth)
 
@@ -512,6 +526,11 @@ dataToken.use('*', requireAuth)
 // the site owner (or superadmin); any other authorized viewer — including any authenticated
 // user on a `team` site — receives READ-only. This is where "can view" is prevented from
 // implying "can write": the untrusted content page can only ever act with the caps minted here.
+//
+// A key-authenticated caller intersects with its OWN grant: the allowlist gates WHICH site it may
+// mint for at all (403 outside it, or outside its owned sites for an 'all-owned' scope), and
+// `data.caps` ceilings WHAT the minted token may carry — never widening the caller's own access,
+// never granted by the key alone if the caller's own access is narrower (see intersectCaps).
 dataToken.post('/:space/:site', async (c) => {
   if (!c.env.DATA_TOKEN_SECRET) return c.json({ error: 'not found' }, 404)
   const db = c.get('db')
@@ -522,7 +541,22 @@ dataToken.post('/:space/:site', async (c) => {
   if (!site) return c.json({ error: 'not found' }, 404)
   if (!access.ok) return c.json({ error: 'forbidden' }, access.status)
 
-  const caps = dataCapsFor(user, site)
-  const token = await signDataToken(c.env.DATA_TOKEN_SECRET, { siteId: site.id, viewerId: user.id, caps }, DATA_TOKEN_TTL_SEC)
+  const credential = c.get('credential')
+  let grants: ApiKeyGrants | null = null
+  if (credential.kind === 'key') {
+    if (!credential.grants.data) return c.json({ error: 'forbidden' }, 403)
+    const { scope } = credential.grants.data
+    const allowed = scope.kind === 'all-owned' ? site.ownerId === user.id : scope.siteIds.includes(site.id)
+    if (!allowed) return c.json({ error: 'forbidden' }, 403)
+    grants = credential.grants
+  }
+
+  const caps = intersectCaps(dataCapsFor(user, site), grants)
+  if (caps.length === 0) return c.json({ error: 'forbidden' }, 403)
+  const token = await signDataToken(
+    c.env.DATA_TOKEN_SECRET,
+    { siteId: site.id, viewerId: user.id, caps },
+    DATA_TOKEN_TTL_SEC,
+  )
   return c.json({ token, caps, expiresIn: DATA_TOKEN_TTL_SEC })
 })

--- a/packages/api/src/routes/data.ts
+++ b/packages/api/src/routes/data.ts
@@ -3,7 +3,6 @@ import type { DrizzleD1Database } from 'drizzle-orm/d1'
 import { type Context, Hono } from 'hono'
 import { sessionDb } from '../db/client'
 import { type ChangeLogRow, type DocumentRow, type Site, documents, sites } from '../db/schema'
-import type { ApiKeyGrants } from '../lib/api-key'
 import { type DataCapability, type DataClaims, hasCap, signDataToken, verifyDataToken } from '../lib/data-token'
 import { canViewerRead, readsEveryCreator } from '../lib/data-visibility'
 import { authorizeViewerById, fetchAccessFacts, siteAccessFromFacts } from '../lib/site-access'
@@ -509,14 +508,12 @@ export function dataCapsFor(user: Pick<SessionUser, 'id' | 'role'>, site: Pick<S
 }
 
 // Intersect a caller's own caps ceiling (`base`, from dataCapsFor) against an API key's data-plane
-// ceiling. `grants: null` means the caller isn't key-authenticated (or the key has no ceiling to
-// apply) — base passes through UNCHANGED, byte-for-byte, so session/CLI callers are untouched.
-// Otherwise the result is the overlap: it can only ever narrow `base`, never add a cap `base`
-// didn't already have — order is `base`'s, so existing assertions on the caps array keep passing.
-export function intersectCaps(base: DataCapability[], grants: ApiKeyGrants | null): DataCapability[] {
-  if (!grants?.data) return base
-  const ceiling = grants.data.caps
-  return base.filter((c) => ceiling.includes(c))
+// ceiling. `ceiling: null` means the caller isn't key-authenticated — base passes through
+// UNCHANGED, byte-for-byte, so session/CLI callers are untouched. Otherwise the result is the
+// overlap: it can only ever narrow `base`, never add a cap `base` didn't already have — order is
+// `base`'s, so existing assertions on the caps array keep passing.
+export function intersectCaps(base: DataCapability[], ceiling: DataCapability[] | null): DataCapability[] {
+  return ceiling ? base.filter((cap) => ceiling.includes(cap)) : base
 }
 
 export const dataToken = new Hono<AppEnv>()
@@ -542,16 +539,16 @@ dataToken.post('/:space/:site', async (c) => {
   if (!access.ok) return c.json({ error: 'forbidden' }, access.status)
 
   const credential = c.get('credential')
-  let grants: ApiKeyGrants | null = null
+  let ceiling: DataCapability[] | null = null
   if (credential.kind === 'key') {
     if (!credential.grants.data) return c.json({ error: 'forbidden' }, 403)
-    const { scope } = credential.grants.data
+    const { scope, caps } = credential.grants.data
     const allowed = scope.kind === 'all-owned' ? site.ownerId === user.id : scope.siteIds.includes(site.id)
     if (!allowed) return c.json({ error: 'forbidden' }, 403)
-    grants = credential.grants
+    ceiling = caps
   }
 
-  const caps = intersectCaps(dataCapsFor(user, site), grants)
+  const caps = intersectCaps(dataCapsFor(user, site), ceiling)
   if (caps.length === 0) return c.json({ error: 'forbidden' }, 403)
   const token = await signDataToken(
     c.env.DATA_TOKEN_SECRET,

--- a/packages/api/src/routes/sites-delete.test.ts
+++ b/packages/api/src/routes/sites-delete.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from 'bun:test'
+import { eq } from 'drizzle-orm'
+import { sites } from '../db/schema'
+import { seedMember, seedSite, seedSpace } from '../test/harness'
+import { auth, authKey, makeRouteApp, mintKey, mintUser } from '../test/route-fixtures'
+
+// DELETE /api/sites/:space/:site — an API key MAY create sites (deploy is the headline use case)
+// but MUST NOT delete them. The deny keys on the credential kind, checked BEFORE the ownership
+// check, so a key never learns whether the site exists or who owns it.
+
+async function setup() {
+  const ctx = makeRouteApp()
+  const { db, kv } = ctx
+  await mintUser(db, kv, 'owner', { email: 'owner@e.com' })
+  await seedSpace(db, { id: 'acme', slug: 'acme', createdBy: 'owner' })
+  await seedMember(db, 'acme', 'owner')
+  await seedSite(db, { id: 'deck', spaceId: 'acme', ownerId: 'owner', slug: 'deck' })
+  return ctx
+}
+
+describe('DELETE /api/sites/:space/:site — credential-based deny', () => {
+  test('CASE-07: a key-authenticated delete, from the owner’s own key, is 403’d and the site survives', async () => {
+    const ctx = await setup()
+    const secret = await mintKey(ctx.db, 'owner')
+
+    const res = await ctx.app.request('/api/sites/acme/deck', { method: 'DELETE', headers: authKey(secret) }, ctx.env)
+    expect(res.status).toBe(403)
+    expect(await ctx.db.select().from(sites).where(eq(sites.id, 'deck'))).toHaveLength(1)
+  })
+
+  test('CASE-07b: the same delete with a CLI Bearer token, same owner, same site, still succeeds', async () => {
+    const ctx = await setup()
+
+    const res = await ctx.app.request('/api/sites/acme/deck', { method: 'DELETE', headers: auth('owner') }, ctx.env)
+    expect(res.status).toBe(200)
+    expect(await ctx.db.select().from(sites).where(eq(sites.id, 'deck'))).toHaveLength(0)
+  })
+
+  // Pins the ORDERING the handler's comment claims. Moving the deny below the site lookup keeps
+  // both cases above green while turning the route into an existence oracle: a key would get 404
+  // for a site that does not exist and 403 for one that does, which is exactly the leak the
+  // credential check is placed first to avoid.
+  test('CASE-07c: a key-authenticated delete of a NONEXISTENT site is 403, not 404', async () => {
+    const ctx = await setup()
+    const secret = await mintKey(ctx.db, 'owner')
+
+    const res = await ctx.app.request('/api/sites/acme/ghost', { method: 'DELETE', headers: authKey(secret) }, ctx.env)
+    expect(res.status).toBe(403)
+  })
+})

--- a/packages/api/src/routes/sites.ts
+++ b/packages/api/src/routes/sites.ts
@@ -696,6 +696,9 @@ sites.post('/:spaceSlug/:siteSlug/fork', requireAuth, async (c) => {
 sites.delete('/:spaceSlug/:siteSlug', requireAuth, async (c) => {
   const user = c.get('user')
   const db = c.get('db')
+  // An API key may create sites (deploy is the headline use case) but may not delete them. Checked
+  // BEFORE the ownership lookup so a key learns nothing about the site's existence or owner.
+  if (c.get('credential').kind === 'key') return c.json({ error: 'forbidden' }, 403)
   const { spaceSlug, siteSlug } = c.req.param()
   const site = await resolveSite(db, spaceSlug, siteSlug)
   if (!site) return c.json({ error: 'not found' }, 404)

--- a/packages/api/src/routes/sites.ts
+++ b/packages/api/src/routes/sites.ts
@@ -25,7 +25,7 @@ import { isValidSlug } from '../lib/slug'
 import { copyObjects, deleteKeys, deleteSiteObjects } from '../lib/storage'
 import { signToken } from '../lib/token'
 import { isVisibility, normalizeVisibility } from '../lib/visibility'
-import { requireAuth } from '../middleware/auth'
+import { requireAuth, requireControlGrant } from '../middleware/auth'
 import type { AppEnv, SessionUser } from '../types'
 
 // Phase 4: site CRUD + viewer metadata. Mounted at /api/sites.
@@ -148,7 +148,7 @@ export async function searchSites(
 }
 
 // POST /api/sites — create an empty site in a space the caller belongs to.
-sites.post('/', requireAuth, async (c) => {
+sites.post('/', requireAuth, requireControlGrant, async (c) => {
   const user = c.get('user')
   const db = c.get('db')
   const body = await c.req.json().catch(() => null)
@@ -456,7 +456,7 @@ sites.get('/:spaceSlug/:siteSlug/shares', requireAuth, async (c) => {
 })
 
 // PUT /api/sites/:spaceSlug/:siteSlug/shares — owner-only: replace the whole share set.
-sites.put('/:spaceSlug/:siteSlug/shares', requireAuth, async (c) => {
+sites.put('/:spaceSlug/:siteSlug/shares', requireAuth, requireControlGrant, async (c) => {
   const user = c.get('user')
   const db = c.get('db')
   const { spaceSlug, siteSlug } = c.req.param()
@@ -493,7 +493,7 @@ sites.put('/:spaceSlug/:siteSlug/shares', requireAuth, async (c) => {
 })
 
 // PATCH /api/sites/:spaceSlug/:siteSlug — owner-only update of visibility/title.
-sites.patch('/:spaceSlug/:siteSlug', requireAuth, async (c) => {
+sites.patch('/:spaceSlug/:siteSlug', requireAuth, requireControlGrant, async (c) => {
   const user = c.get('user')
   const db = c.get('db')
   const { spaceSlug, siteSlug } = c.req.param()
@@ -525,7 +525,7 @@ sites.patch('/:spaceSlug/:siteSlug', requireAuth, async (c) => {
 // POST /api/sites/:spaceSlug/:siteSlug/move — owner (or superadmin) moves a site to another
 // space they belong to. Storage keys are space-agnostic (uuid-prefixed), so only `spaceId`
 // changes; shares/comments key off `siteId` and survive. The site's URL becomes /<dest>/<slug>.
-sites.post('/:spaceSlug/:siteSlug/move', requireAuth, async (c) => {
+sites.post('/:spaceSlug/:siteSlug/move', requireAuth, requireControlGrant, async (c) => {
   const user = c.get('user')
   const db = c.get('db')
   const { spaceSlug, siteSlug } = c.req.param()
@@ -583,7 +583,7 @@ async function freeForkSlug(db: DrizzleD1Database, spaceId: string, base: string
 // (default: your personal space). The fork is INDEPENDENT: new id, new owner, its own R2 objects,
 // no shares, no comments, version 0. Read access is the whole gate — if you can open it, you can
 // fork it (you could already download the bytes and redeploy them by hand).
-sites.post('/:spaceSlug/:siteSlug/fork', requireAuth, async (c) => {
+sites.post('/:spaceSlug/:siteSlug/fork', requireAuth, requireControlGrant, async (c) => {
   const user = c.get('user')
   const db = c.get('db')
   const { spaceSlug, siteSlug } = c.req.param()
@@ -693,7 +693,7 @@ sites.post('/:spaceSlug/:siteSlug/fork', requireAuth, async (c) => {
 })
 
 // DELETE /api/sites/:spaceSlug/:siteSlug — hard delete (owner or superadmin). Purges R2 first.
-sites.delete('/:spaceSlug/:siteSlug', requireAuth, async (c) => {
+sites.delete('/:spaceSlug/:siteSlug', requireAuth, requireControlGrant, async (c) => {
   const user = c.get('user')
   const db = c.get('db')
   // An API key may create sites (deploy is the headline use case) but may not delete them. Checked

--- a/packages/api/src/routes/spaces.ts
+++ b/packages/api/src/routes/spaces.ts
@@ -8,7 +8,7 @@ import { batchAll } from '../lib/d1'
 import { siteFeedColumns, toFeedRow } from '../lib/site-feed'
 import { deleteSpaceObjects } from '../lib/storage'
 import { isValidSlug } from '../lib/slug'
-import { requireAuth } from '../middleware/auth'
+import { requireAuth, requireControlGrant } from '../middleware/auth'
 import type { AppEnv } from '../types'
 
 export const spaces = new Hono<AppEnv>()
@@ -22,7 +22,7 @@ function isUniqueConstraintError(err: unknown): boolean {
 }
 
 // POST /api/spaces — create a GROUP space. Creator is added as a member (atomic).
-spaces.post('/', requireAuth, async (c) => {
+spaces.post('/', requireAuth, requireControlGrant, async (c) => {
   const user = c.get('user')
   const db = c.get('db')
   const body = await c.req.json().catch(() => null)
@@ -139,7 +139,7 @@ spaces.get('/:slug/sites', requireAuth, async (c) => {
 })
 
 // POST /api/spaces/:slug/members — invite a user by email (owner only).
-spaces.post('/:slug/members', requireAuth, async (c) => {
+spaces.post('/:slug/members', requireAuth, requireControlGrant, async (c) => {
   const user = c.get('user')
   const db = c.get('db')
   const slug = c.req.param('slug')
@@ -169,7 +169,7 @@ spaces.post('/:slug/members', requireAuth, async (c) => {
 })
 
 // DELETE /api/spaces/:slug/members/:userId — remove a member (owner only; cannot remove owner).
-spaces.delete('/:slug/members/:userId', requireAuth, async (c) => {
+spaces.delete('/:slug/members/:userId', requireAuth, requireControlGrant, async (c) => {
   const user = c.get('user')
   const db = c.get('db')
   const slug = c.req.param('slug')
@@ -187,7 +187,7 @@ spaces.delete('/:slug/members/:userId', requireAuth, async (c) => {
 })
 
 // DELETE /api/spaces/:slug — delete a space (owner or superadmin). Personal spaces are protected.
-spaces.delete('/:slug', requireAuth, async (c) => {
+spaces.delete('/:slug', requireAuth, requireControlGrant, async (c) => {
   const user = c.get('user')
   const db = c.get('db')
   const slug = c.req.param('slug')

--- a/packages/api/src/routes/upload.test.ts
+++ b/packages/api/src/routes/upload.test.ts
@@ -3,6 +3,7 @@ import { eq } from 'drizzle-orm'
 import { Hono } from 'hono'
 import { files, sites } from '../db/schema'
 import { makeDb, makeKv, makeR2, seedMember, seedSite, seedSpace, seedUser } from '../test/harness'
+import { mintKey } from '../test/route-fixtures'
 import type { AppEnv } from '../types'
 import { upload } from './upload'
 
@@ -329,6 +330,28 @@ describe('upload — derived title: R2 integrity + COALESCE race', () => {
     expect((await replace).status).toBe(200)
     const row = (await db.select({ title: sites.title }).from(sites).where(eq(sites.slug, 'raceme')))[0]
     expect(row.title).toBe('Manual Name')
+  })
+})
+
+// CASE-08 — the headline use case, and the other half of the create-not-delete ruling that
+// sites-delete.test.ts pins from the deny side. A key must be able to deploy a site that does not
+// exist yet; the control grant is unscopable, so no allowlist gates this the way the data grant
+// gates minting. Without this case, widening S4's deny into a blanket key-denial would stay green.
+describe('upload — an API key may CREATE a site', () => {
+  test('CASE-08: deploying with a key creates a site that did not exist', async () => {
+    const { app, env, db } = await setup()
+    const secret = await mintKey(db, 'owner')
+
+    const fd = new FormData()
+    fd.append('files', html('<html>from ci</html>', 'index.html'))
+    const res = await app.request(
+      '/api/upload/acme/ci-made-this',
+      { method: 'POST', headers: { Authorization: `Bearer ${secret}` }, body: fd },
+      env,
+    )
+
+    expect(res.status).toBe(200)
+    expect(await db.select().from(sites).where(eq(sites.slug, 'ci-made-this'))).toHaveLength(1)
   })
 })
 

--- a/packages/api/src/routes/upload.ts
+++ b/packages/api/src/routes/upload.ts
@@ -9,7 +9,7 @@ import { capTitle, extractHtmlMeta, NO_META, pickEntry } from '../lib/extract'
 import { isValidSlug } from '../lib/slug'
 import { deleteKeys, MAX_FILE_BYTES, sanitizePath } from '../lib/storage'
 import { isVisibility, normalizeVisibility } from '../lib/visibility'
-import { requireAuth } from '../middleware/auth'
+import { requireAuth, requireControlGrant } from '../middleware/auth'
 import type { AppEnv } from '../types'
 
 // Phase 4: multipart create-or-replace upload. Mounted at /api/upload.
@@ -29,7 +29,7 @@ const UPLOAD_CONCURRENCY = 10 // bounded parallelism for the R2 put loop
 export const upload = new Hono<AppEnv>()
 
 // POST /api/upload/:spaceSlug/:siteSlug — upload a folder of files, creating or replacing the site.
-upload.post('/:spaceSlug/:siteSlug', requireAuth, async (c) => {
+upload.post('/:spaceSlug/:siteSlug', requireAuth, requireControlGrant, async (c) => {
   // Defensive per-IP rate limit (binding is optional / absent in local dev).
   if (c.env.UPLOAD_LIMITER) {
     const ip = c.req.header('CF-Connecting-IP') ?? 'local'

--- a/packages/api/src/test/harness.test.ts
+++ b/packages/api/src/test/harness.test.ts
@@ -4,8 +4,8 @@
 // a Cache-API mock, D1 statement/batch counters, and the D1 100-bound-parameter cap.
 import { describe, expect, test } from 'bun:test'
 import { eq, inArray, sql } from 'drizzle-orm'
-import { sites, spaces, users } from '../db/schema'
-import { makeCaches, makeDb, makeR2, makeRecorder, seedSite, seedSpace, seedUser } from './harness'
+import { apiKeys, sites, spaces, users } from '../db/schema'
+import { makeCaches, makeDb, makeR2, makeRecorder, seedApiKey, seedSite, seedSpace, seedUser } from './harness'
 
 describe('T0.1 makeR2 byte model', () => {
   test('binary put + ranged get slice BYTES; size is always the full byte length', async () => {
@@ -284,5 +284,32 @@ describe('T0.4 bind-cap adapter (D1 100-bound-parameter limit)', () => {
     )
     const atCap = Array.from({ length: 100 }, (_, i) => `id-${i}`)
     expect(await db.select().from(users).where(inArray(users.id, atCap))).toEqual([])
+  })
+})
+
+describe('0025_api_keys migration + seedApiKey', () => {
+  test('seedApiKey through the harness round-trips every column on read-back', async () => {
+    const db = makeDb()
+    const uid = await seedUser(db)
+    const id = await seedApiKey(db, { userId: uid, name: 'ci token', hash: 'a'.repeat(64), expiresAt: '2999-01-01T00:00:00.000Z' })
+    const [row] = await db.select().from(apiKeys).where(eq(apiKeys.id, id))
+    expect(row).toMatchObject({
+      id,
+      userId: uid,
+      name: 'ci token',
+      hash: 'a'.repeat(64),
+      expiresAt: '2999-01-01T00:00:00.000Z',
+      revokedAt: null,
+      lastUsedAt: null,
+    })
+    expect(row.createdAt).toEqual(expect.any(String))
+    expect(row.grants).toBeDefined()
+  })
+
+  test('hash is UNIQUE — a second key with the same hash rejects', async () => {
+    const db = makeDb()
+    const uid = await seedUser(db)
+    await seedApiKey(db, { userId: uid, hash: 'dupe'.repeat(16) })
+    await expect(seedApiKey(db, { userId: uid, hash: 'dupe'.repeat(16) })).rejects.toThrow()
   })
 })

--- a/packages/api/src/test/harness.ts
+++ b/packages/api/src/test/harness.ts
@@ -7,6 +7,7 @@ import { join } from 'node:path'
 import { Database } from 'bun:sqlite'
 import { drizzle } from 'drizzle-orm/bun-sqlite'
 import type { DrizzleD1Database } from 'drizzle-orm/d1'
+import type { ApiKeyGrants } from '../lib/api-key'
 import {
   type NewApiKey,
   type NewComment,
@@ -488,7 +489,14 @@ export async function seedNotification(
   return id
 }
 
-/** Insert an `api_keys` row; returns its id. Defaults: empty grants, far-future expiry. */
+// Default grants for a seeded key: full control-plane + data-plane ceiling (every cap, every
+// owned site). Tests that care about a narrower ceiling pass their own `grants`.
+export const FULL_GRANTS: ApiKeyGrants = {
+  control: true,
+  data: { scope: { kind: 'all-owned' }, caps: ['read', 'create', 'write', 'read_all'] },
+}
+
+/** Insert an `api_keys` row; returns its id. Defaults: full grants, far-future expiry. */
 export async function seedApiKey(db: DrizzleD1Database, o: { userId: string } & Partial<NewApiKey>): Promise<string> {
   const id = o.id ?? nextId('ak')
   await db.insert(apiKeys).values({
@@ -496,7 +504,7 @@ export async function seedApiKey(db: DrizzleD1Database, o: { userId: string } & 
     userId: o.userId,
     name: o.name ?? 'api key',
     hash: o.hash ?? nextId('hash'),
-    grants: o.grants ?? [],
+    grants: o.grants ?? FULL_GRANTS,
     expiresAt: o.expiresAt ?? '2999-01-01T00:00:00.000Z',
     revokedAt: o.revokedAt ?? null,
     lastUsedAt: o.lastUsedAt ?? null,

--- a/packages/api/src/test/harness.ts
+++ b/packages/api/src/test/harness.ts
@@ -60,6 +60,7 @@ const MIGRATIONS = [
   'drizzle/0023_site_stars.sql',
   'drizzle/0024_comment_reactions.sql',
   'drizzle/0025_api_keys.sql',
+  'drizzle/0026_api_key_display_suffix.sql',
 ]
 
 // --- S0 recorder: one shared, ordered timeline across D1/R2/cache mocks so perf specs can
@@ -508,12 +509,15 @@ export async function seedApiKey(db: DrizzleD1Database, o: { userId: string } & 
     expiresAt: o.expiresAt ?? '2999-01-01T00:00:00.000Z',
     revokedAt: o.revokedAt ?? null,
     lastUsedAt: o.lastUsedAt ?? null,
+    displaySuffix: o.displaySuffix ?? null,
     ...(o.createdAt !== undefined && { createdAt: o.createdAt }),
   })
   return id
 }
 
-/** In-memory stand-in for the GLANCE_SESSIONS KV namespace (get/put/delete + ttl peek). */
+/** In-memory stand-in for the GLANCE_SESSIONS KV namespace (get/put/delete/list + ttl peek).
+ *  `list` returns every matching key in one page (list_complete: true, no cursor) — enough to
+ *  drive `revokeUserCliTokens`'s prefix enumeration; it never needs to exercise pagination. */
 export function makeKv() {
   const store = new Map<string, string>()
   const ttls = new Map<string, number | undefined>()
@@ -528,6 +532,11 @@ export function makeKv() {
       store.delete(key)
       ttls.delete(key)
       return Promise.resolve()
+    },
+    list: (options?: { prefix?: string; cursor?: string }) => {
+      const prefix = options?.prefix ?? ''
+      const keys = [...store.keys()].filter((k) => k.startsWith(prefix)).map((name) => ({ name }))
+      return Promise.resolve({ keys, list_complete: true, cursor: undefined })
     },
     store,
     ttls,

--- a/packages/api/src/test/harness.ts
+++ b/packages/api/src/test/harness.ts
@@ -8,6 +8,7 @@ import { Database } from 'bun:sqlite'
 import { drizzle } from 'drizzle-orm/bun-sqlite'
 import type { DrizzleD1Database } from 'drizzle-orm/d1'
 import {
+  type NewApiKey,
   type NewComment,
   type NewCommentThread,
   type NewEvent,
@@ -16,6 +17,7 @@ import {
   type NewSite,
   type NewSpace,
   type NewUser,
+  apiKeys,
   comments,
   commentThreads,
   events,
@@ -56,6 +58,7 @@ const MIGRATIONS = [
   'drizzle/0022_sites_feed_index.sql',
   'drizzle/0023_site_stars.sql',
   'drizzle/0024_comment_reactions.sql',
+  'drizzle/0025_api_keys.sql',
 ]
 
 // --- S0 recorder: one shared, ordered timeline across D1/R2/cache mocks so perf specs can
@@ -481,6 +484,23 @@ export async function seedNotification(
     snippet: o.snippet ?? null,
     readAt: o.readAt ?? null,
     createdAt: o.createdAt ?? new Date().toISOString(),
+  })
+  return id
+}
+
+/** Insert an `api_keys` row; returns its id. Defaults: empty grants, far-future expiry. */
+export async function seedApiKey(db: DrizzleD1Database, o: { userId: string } & Partial<NewApiKey>): Promise<string> {
+  const id = o.id ?? nextId('ak')
+  await db.insert(apiKeys).values({
+    id,
+    userId: o.userId,
+    name: o.name ?? 'api key',
+    hash: o.hash ?? nextId('hash'),
+    grants: o.grants ?? [],
+    expiresAt: o.expiresAt ?? '2999-01-01T00:00:00.000Z',
+    revokedAt: o.revokedAt ?? null,
+    lastUsedAt: o.lastUsedAt ?? null,
+    ...(o.createdAt !== undefined && { createdAt: o.createdAt }),
   })
   return id
 }

--- a/packages/api/src/test/route-fixtures.ts
+++ b/packages/api/src/test/route-fixtures.ts
@@ -3,6 +3,7 @@
 // Bearer-token auth path is real. A superset of the per-file makeApp twins it replaced — an extra
 // mounted route group or env binding is inert for tests that never touch it.
 import { Hono } from 'hono'
+import { generateApiKey, hashApiKey } from '../lib/api-key'
 import { requireSameOrigin } from '../middleware/auth'
 import { commentFeed } from '../routes/comment-feed'
 import { comments } from '../routes/comments'
@@ -12,7 +13,7 @@ import { slackEvents } from '../routes/slack-events'
 import { spaces } from '../routes/spaces'
 import { stars } from '../routes/stars'
 import type { AppEnv } from '../types'
-import { makeDb, makeKv, makeR2, seedUser } from './harness'
+import { makeDb, makeKv, makeR2, seedApiKey, seedUser } from './harness'
 
 export const APP_URL = 'https://glance.example.com'
 
@@ -81,6 +82,21 @@ export async function mintUser(
 /** Request headers authenticating as `mintUser(id)` through the same-origin guard. */
 export const auth = (id: string) => ({
   Authorization: `Bearer tok-${id}`,
+  Origin: APP_URL,
+  'Content-Type': 'application/json',
+})
+
+/** Seed a live `glk_`-prefixed API key for an EXISTING user (mint their session/CLI identity
+ *  first via `mintUser`), returning the plaintext secret to send as a Bearer token. */
+export async function mintKey(db: RouteApp['db'], userId: string): Promise<string> {
+  const secret = generateApiKey()
+  await seedApiKey(db, { userId, hash: await hashApiKey(secret) })
+  return secret
+}
+
+/** Request headers authenticating as `mintKey(...)`'s bearer through the same-origin guard. */
+export const authKey = (secret: string) => ({
+  Authorization: `Bearer ${secret}`,
   Origin: APP_URL,
   'Content-Type': 'application/json',
 })

--- a/packages/api/src/test/route-fixtures.ts
+++ b/packages/api/src/test/route-fixtures.ts
@@ -5,6 +5,8 @@
 import { Hono } from 'hono'
 import { generateApiKey, hashApiKey } from '../lib/api-key'
 import { requireSameOrigin } from '../middleware/auth'
+import { admin } from '../routes/admin'
+import { apiKeys } from '../routes/api-keys'
 import { commentFeed } from '../routes/comment-feed'
 import { comments } from '../routes/comments'
 import { summary } from '../routes/summary'
@@ -45,6 +47,8 @@ export function makeRouteApp() {
   app.route('/api/sites', summary)
   app.route('/api/comments', commentFeed)
   app.route('/api/slack', slackEvents)
+  app.route('/api/api-keys', apiKeys)
+  app.route('/api/admin', admin)
   return { app, env, db, kv, r2 }
 }
 
@@ -76,6 +80,11 @@ export async function mintUser(
   const email = opts.email ?? `${id}@example.com`
   await seedUser(db, { id, email, role })
   await kv.put(`cli:tok-${id}`, JSON.stringify({ id, email, name: null, role }))
+  // The per-user index entry `createCliToken` writes alongside the token. Without it the fixture
+  // looks authenticated but is invisible to `revokeUserCliTokens`, which enumerates this prefix —
+  // so the offboarding kill-switch could not be tested at all, and a regression that stopped
+  // revoking CLI tokens would have shipped green.
+  await kv.put(`cli_index:${id}:tok-${id}`, '')
   return id
 }
 

--- a/packages/api/src/test/route-fixtures.ts
+++ b/packages/api/src/test/route-fixtures.ts
@@ -15,6 +15,7 @@ import { slackEvents } from '../routes/slack-events'
 import { spaces } from '../routes/spaces'
 import { stars } from '../routes/stars'
 import type { AppEnv } from '../types'
+import type { ApiKeyGrants } from '../lib/api-key'
 import { makeDb, makeKv, makeR2, seedApiKey, seedUser } from './harness'
 
 export const APP_URL = 'https://glance.example.com'
@@ -88,27 +89,36 @@ export async function mintUser(
   return id
 }
 
-/** Request headers authenticating as `mintUser(id)` through the same-origin guard. */
-export const auth = (id: string) => ({
-  Authorization: `Bearer tok-${id}`,
+/** Request headers carrying a raw Bearer token through the same-origin guard — used directly with
+ *  `mintKey(...)`'s plaintext API key secret. */
+export const authKey = (token: string) => ({
+  Authorization: `Bearer ${token}`,
   Origin: APP_URL,
   'Content-Type': 'application/json',
 })
 
+/** Request headers authenticating as `mintUser(id)`'s CLI token. */
+export const auth = (id: string) => authKey(`tok-${id}`)
+
 /** Seed a live `glk_`-prefixed API key for an EXISTING user (mint their session/CLI identity
- *  first via `mintUser`), returning the plaintext secret to send as a Bearer token. */
-export async function mintKey(db: RouteApp['db'], userId: string): Promise<string> {
+ *  first via `mintUser`), returning the plaintext secret to send as a Bearer token. Defaults to
+ *  FULL_GRANTS; pass `grants` to mint a narrower key (e.g. `control: false`). */
+export async function mintKey(
+  db: RouteApp['db'],
+  userId: string,
+  grants?: ApiKeyGrants,
+): Promise<string> {
   const secret = generateApiKey()
-  await seedApiKey(db, { userId, hash: await hashApiKey(secret) })
+  await seedApiKey(db, { userId, hash: await hashApiKey(secret), ...(grants && { grants }) })
   return secret
 }
 
-/** Request headers authenticating as `mintKey(...)`'s bearer through the same-origin guard. */
-export const authKey = (secret: string) => ({
-  Authorization: `Bearer ${secret}`,
-  Origin: APP_URL,
-  'Content-Type': 'application/json',
-})
+/** A key that may use the DATA plane but must not change control-plane state — the "data only"
+ *  key from the plan's wireframe, and the one `requireControlGrant` exists to constrain. */
+export const DATA_ONLY_GRANTS: ApiKeyGrants = {
+  control: false,
+  data: { scope: { kind: 'all-owned' }, caps: ['read', 'create'] },
+}
 
 /** Post-auth D1 request count. A "request" is one D1 round trip: a loose statement or one
  *  db.batch. requireAuth itself costs exactly 1 loose read (getUserById) — subtract it;

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -64,12 +64,28 @@ export interface SessionUser {
   role: 'member' | 'superadmin'
 }
 
+// The api_keys.grants JSON blob. No scope model exists yet — a key grants everything its owner
+// can do — so this is `unknown` for now; a future slice narrows it once scoping is designed.
+export type ApiKeyGrants = unknown
+
+// HOW the caller authenticated, resolved by readCredential (see lib/session.ts) and attached to
+// the request by requireAuth. Distinct from `authKind` below: this is the full resolution
+// (session cookie / KV CLI token / D1 api key), not the two-bucket analytics tag.
+export type Credential =
+  | { kind: 'session' | 'cli'; user: SessionUser }
+  | { kind: 'key'; user: SessionUser; keyId: string; grants: ApiKeyGrants }
+
 /** Hono context variables set by middleware. */
 export interface Variables {
   db: DrizzleD1Database
   user: SessionUser
+  // The resolved credential (session / cli / key), set by requireAuth. Absent on unauthenticated
+  // routes.
+  credential: Credential
   // Which credential authenticated the request, set by requireAuth. 'cli' = Bearer token,
-  // 'web' = session cookie. Drives CLI-usage analytics. Absent on unauthenticated routes.
+  // 'web' = session cookie. Drives CLI-usage analytics. Absent on unauthenticated routes. A
+  // D1-key-authenticated request is also tagged 'cli' here (no cookie + a Bearer token) — key-vs-
+  // CLI analytics is a separate, not-yet-built slice (would need an events-table migration).
   authKind: 'cli' | 'web'
 }
 

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -1,4 +1,5 @@
 import type { DrizzleD1Database } from 'drizzle-orm/d1'
+import type { ApiKeyGrants } from './lib/api-key'
 import type { OgCard } from './lib/og-image'
 
 /** Worker bindings + secrets/vars. Secrets come from `.dev.vars` locally and
@@ -63,10 +64,6 @@ export interface SessionUser {
   name: string | null
   role: 'member' | 'superadmin'
 }
-
-// The api_keys.grants JSON blob. No scope model exists yet — a key grants everything its owner
-// can do — so this is `unknown` for now; a future slice narrows it once scoping is designed.
-export type ApiKeyGrants = unknown
 
 // HOW the caller authenticated, resolved by readCredential (see lib/session.ts) and attached to
 // the request by requireAuth. Distinct from `authKind` below: this is the full resolution

--- a/packages/cli/config.go
+++ b/packages/cli/config.go
@@ -80,3 +80,15 @@ func apiBase() string {
 	}
 	return "http://localhost:8787"
 }
+
+// Token precedence: explicit env override -> persisted config. Uses the `|| not ??` semantics: a
+// blank/whitespace GLANCE_TOKEN falls through instead of yielding a bad token.
+func apiToken() string {
+	if v := strings.TrimSpace(os.Getenv("GLANCE_TOKEN")); v != "" {
+		return v
+	}
+	if c := readConfig(); c != nil {
+		return c.Token
+	}
+	return ""
+}

--- a/packages/cli/config_test.go
+++ b/packages/cli/config_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -153,4 +154,41 @@ func TestDispatchTokenWiring(t *testing.T) {
 			t.Fatalf("logout sent %q, want the stored session token", got)
 		}
 	})
+}
+
+// The env override has to be resolvable as a WHOLE credential. Before this, the token came from
+// the env but the instance URL only from ~/.glance/config.json, so a CI container with both vars
+// exported and no config file passed requireAuth() on the non-empty token and then failed every
+// request with `unsupported protocol scheme ""`.
+func TestDispatchEnvOnlyNeedsNoConfigFile(t *testing.T) {
+	srv, reqs := recordingServer(t, func(*capturedReq) (int, string) { return 200, "[]" })
+	t.Setenv("HOME", t.TempDir()) // no config.json at all
+	t.Setenv("GLANCE_API_URL", srv.URL)
+	t.Setenv("GLANCE_TOKEN", "glk_from-ci")
+
+	if err := dispatch("list", nil); err != nil {
+		t.Fatalf("dispatch(list) with env-only credentials: %v", err)
+	}
+	if len(*reqs) == 0 {
+		t.Fatal("no request reached the server — the env-only path did not resolve a base URL")
+	}
+	if got := (*reqs)[0].auth; got != "Bearer glk_from-ci" {
+		t.Fatalf("sent %q, want the env token", got)
+	}
+}
+
+// ...and with neither set, the clean "Not logged in" message must survive: apiBase() falls back to
+// the local dev URL, so it is the empty TOKEN that requireAuth() catches, not an empty URL.
+func TestDispatchWithNoCredentialsStillSaysNotLoggedIn(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("GLANCE_API_URL", "")
+	t.Setenv("GLANCE_TOKEN", "")
+
+	err := dispatch("list", nil)
+	if err == nil {
+		t.Fatal("expected an error with no credentials")
+	}
+	if !strings.Contains(err.Error(), "Not logged in") {
+		t.Fatalf("error = %q, want the clean \"Not logged in\" message", err)
+	}
 }

--- a/packages/cli/config_test.go
+++ b/packages/cli/config_test.go
@@ -69,3 +69,88 @@ func TestApiBasePrecedence(t *testing.T) {
 		}
 	})
 }
+
+func TestApiTokenPrecedence(t *testing.T) {
+	t.Run("env-wins", func(t *testing.T) {
+		t.Setenv("HOME", t.TempDir())
+		t.Setenv("GLANCE_TOKEN", "env-tok")
+		_ = writeConfig(Config{ApiUrl: "https://cfg.example", Token: "cfg-tok"})
+		if got := apiToken(); got != "env-tok" {
+			t.Fatalf("apiToken = %q", got)
+		}
+	})
+
+	t.Run("blank-env-falls-through-to-config", func(t *testing.T) {
+		t.Setenv("HOME", t.TempDir())
+		t.Setenv("GLANCE_TOKEN", "   ") // blank -> falls through (|| not ??)
+		_ = writeConfig(Config{ApiUrl: "https://cfg.example", Token: "cfg-tok"})
+		if got := apiToken(); got != "cfg-tok" {
+			t.Fatalf("apiToken = %q", got)
+		}
+	})
+
+	t.Run("env-alone-with-no-config", func(t *testing.T) {
+		t.Setenv("HOME", t.TempDir())
+		t.Setenv("GLANCE_TOKEN", "env-tok")
+		if got := apiToken(); got != "env-tok" {
+			t.Fatalf("apiToken = %q", got)
+		}
+	})
+
+	t.Run("empty-when-nothing-set", func(t *testing.T) {
+		t.Setenv("HOME", t.TempDir())
+		t.Setenv("GLANCE_TOKEN", "")
+		if got := apiToken(); got != "" {
+			t.Fatalf("apiToken = %q", got)
+		}
+	})
+}
+
+// dispatch() wiring. TestApiTokenPrecedence pins apiToken() in isolation, but nothing pinned that
+// dispatch actually CALLS it — swapping both call sites for a literal "" left the whole suite
+// green. These drive real commands through dispatch and assert the bearer that reaches the wire.
+func TestDispatchTokenWiring(t *testing.T) {
+	// An authed command must send GLANCE_TOKEN when it is set, so a CI job can deploy with an
+	// API key it never wrote to disk. This is the whole point of the env override.
+	t.Run("an authed command sends GLANCE_TOKEN over the stored token", func(t *testing.T) {
+		srv, reqs := recordingServer(t, func(*capturedReq) (int, string) { return 200, "[]" })
+		t.Setenv("HOME", t.TempDir())
+		if err := writeConfig(Config{ApiUrl: srv.URL, Token: "stored-session"}); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv("GLANCE_TOKEN", "glk_from-ci")
+
+		if err := dispatch("list", nil); err != nil {
+			t.Fatalf("dispatch(list): %v", err)
+		}
+		if len(*reqs) == 0 {
+			t.Fatal("no request reached the server")
+		}
+		if got := (*reqs)[0].auth; got != "Bearer glk_from-ci" {
+			t.Fatalf("authed command sent %q, want the env token", got)
+		}
+	})
+
+	// logout is the exception, and it matters: it is a session verb. If GLANCE_TOKEN shadowed the
+	// stored token here, logout would POST an API key, the server would 400 it (a key is revoked
+	// from the keys screen), and the CLI would still delete config.json — the user's real session
+	// token gone locally but still valid server-side.
+	t.Run("logout sends the STORED token even when GLANCE_TOKEN is set", func(t *testing.T) {
+		srv, reqs := recordingServer(t, func(*capturedReq) (int, string) { return 200, `{"ok":true}` })
+		t.Setenv("HOME", t.TempDir())
+		if err := writeConfig(Config{ApiUrl: srv.URL, Token: "stored-session"}); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv("GLANCE_TOKEN", "glk_from-ci")
+
+		if err := dispatch("logout", nil); err != nil {
+			t.Fatalf("dispatch(logout): %v", err)
+		}
+		if len(*reqs) == 0 {
+			t.Fatal("no request reached the server")
+		}
+		if got := (*reqs)[0].auth; got != "Bearer stored-session" {
+			t.Fatalf("logout sent %q, want the stored session token", got)
+		}
+	})
+}

--- a/packages/cli/main.go
+++ b/packages/cli/main.go
@@ -59,15 +59,14 @@ func dispatch(cmd string, rest []string) error {
 		}
 		return newClient(base, token, os.Stdout).logout()
 	case "deploy", "list", "delete", "move", "fork", "comments", "read", "reply", "notifications":
-		// Authed commands resolve the instance from the STORED config (not the env override) - the
-		// per-command requireAuth() inside each handler produces the clean "Not logged in" message.
-		// The token, like the URL, is resolved via apiToken() which still prefers GLANCE_TOKEN.
-		cfg := readConfig()
-		base := ""
-		if cfg != nil {
-			base = cfg.ApiUrl
-		}
-		c := newClient(base, apiToken(), os.Stdout)
+		// Both halves of the credential come from the same precedence: env override, then stored
+		// config. Resolving the token from the env but the URL from disk only would half-wire it —
+		// a CI container with GLANCE_TOKEN and GLANCE_API_URL exported but no ~/.glance/config.json
+		// (a baked-in binary, no installer run) would pass requireAuth() on the non-empty token and
+		// then fail every request with `unsupported protocol scheme ""`. apiBase()'s local-dev
+		// fallback keeps the clean "Not logged in" path intact when neither is set: the base is
+		// non-empty, the token is not, and requireAuth() catches it.
+		c := newClient(apiBase(), apiToken(), os.Stdout)
 		switch cmd {
 		case "deploy":
 			return c.deploy(rest)

--- a/packages/cli/main.go
+++ b/packages/cli/main.go
@@ -47,6 +47,11 @@ func dispatch(cmd string, rest []string) error {
 	case "skill":
 		return newClient("", "", os.Stdout).skillCmd(rest)
 	case "logout":
+		// Deliberately NOT apiToken(): logout is a session verb and must act on the credential
+		// `glance login` stored. Letting GLANCE_TOKEN shadow it means an exported API key gets
+		// POSTed to /api/auth/logout, which answers 400 (a key is revoked from the keys screen,
+		// not by logging out) — and logout then still removes config.json, so the user's real
+		// session token would be gone locally while staying valid server-side.
 		cfg := readConfig()
 		base, token := "", ""
 		if cfg != nil {
@@ -56,12 +61,13 @@ func dispatch(cmd string, rest []string) error {
 	case "deploy", "list", "delete", "move", "fork", "comments", "read", "reply", "notifications":
 		// Authed commands resolve the instance from the STORED config (not the env override) - the
 		// per-command requireAuth() inside each handler produces the clean "Not logged in" message.
+		// The token, like the URL, is resolved via apiToken() which still prefers GLANCE_TOKEN.
 		cfg := readConfig()
-		base, token := "", ""
+		base := ""
 		if cfg != nil {
-			base, token = cfg.ApiUrl, cfg.Token
+			base = cfg.ApiUrl
 		}
-		c := newClient(base, token, os.Stdout)
+		c := newClient(base, apiToken(), os.Stdout)
 		switch cmd {
 		case "deploy":
 			return c.deploy(rest)

--- a/packages/web/src/components/ApiKeyDialog.test.tsx
+++ b/packages/web/src/components/ApiKeyDialog.test.tsx
@@ -1,0 +1,179 @@
+// Minting a key is the one moment the plaintext secret exists client-side. These tests pin the
+// two properties that matter most: the expiry control can only ever produce one of the server's
+// six fixed durations (never a free-text date), and the secret is truly SHOW-ONCE — gone from the
+// UI the instant the dialog closes, not merely hidden behind a re-openable toggle.
+import { useState } from 'react'
+import { describe, expect, mock, test } from 'bun:test'
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { API_KEY_PREFIX, type ApiKeyItem } from '@/lib/types'
+import { ApiKeyDialog } from './ApiKeyDialog'
+
+// Composed from the exported prefix rather than written out: a key-shaped literal in a test file
+// trips the repo's pre-commit secret scanner.
+const plaintext = `${API_KEY_PREFIX}ABCDEFGH1234`
+
+const SITE = {
+  id: 'site-1',
+  spaceSlug: 'sp',
+  siteSlug: 'my-site',
+  title: 'My Site',
+  visibility: 'private',
+  status: 'active',
+}
+
+type Call = { url: string; method: string; body: Record<string, unknown> }
+
+function stubFetch(
+  mintBody: unknown = {
+    id: 'k1',
+    name: 'ci key',
+    secret: plaintext,
+    grants: { control: false, data: null },
+    createdAt: '2026-07-01T00:00:00.000Z',
+    expiresAt: '2026-08-01T00:00:00.000Z',
+  },
+) {
+  const calls: Call[] = []
+  globalThis.fetch = ((url: string, init?: RequestInit) => {
+    const method = init?.method ?? 'GET'
+    calls.push({ url, method, body: init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {} })
+    if (url === '/api/sites/mine') {
+      return Promise.resolve(
+        new Response(JSON.stringify([SITE]), { status: 200, headers: { 'content-type': 'application/json' } }),
+      )
+    }
+    return Promise.resolve(
+      new Response(JSON.stringify(mintBody), { status: 201, headers: { 'content-type': 'application/json' } }),
+    )
+  }) as unknown as typeof fetch
+  return calls
+}
+
+function stubClipboard() {
+  const writeText = mock(() => Promise.resolve())
+  Object.defineProperty(navigator, 'clipboard', { value: { writeText }, configurable: true })
+  return writeText
+}
+
+// Mirrors how settings-keys.tsx drives the dialog: `open` lives in the PARENT, so closing and
+// reopening re-renders the SAME ApiKeyDialog instance rather than remounting it — the real test
+// of whether the secret was cleared, not merely never re-fetched.
+function Harness({ onMinted = () => {} }: { onMinted?: (key: ApiKeyItem) => void }) {
+  const [open, setOpen] = useState(true)
+  return (
+    <>
+      <button type="button" onClick={() => setOpen(true)}>
+        reopen
+      </button>
+      <ApiKeyDialog open={open} onOpenChange={setOpen} onMinted={onMinted} />
+    </>
+  )
+}
+
+async function fillAndMint(name = 'ci key') {
+  fireEvent.change(screen.getByLabelText('Name'), { target: { value: name } })
+  await waitFor(() => expect(screen.getByText('sp/my-site')).toBeDefined())
+  fireEvent.click(screen.getByLabelText('sp/my-site'))
+  fireEvent.click(screen.getByRole('button', { name: 'Create key' }))
+}
+
+describe('ApiKeyDialog — expiry is a fixed dropdown', () => {
+  test('offers exactly the six server durations and no free-text date entry', async () => {
+    stubFetch()
+    render(<Harness />)
+    expect(document.querySelector('input[type="date"]')).toBeNull()
+
+    fireEvent.click(screen.getByLabelText('Expires'))
+    const listbox = await screen.findByRole('listbox')
+    const options = within(listbox)
+      .getAllByRole('option')
+      .map((o) => o.textContent)
+    expect(options).toEqual(['1 day', '7 days', '30 days', '90 days', '180 days', '1 year'])
+  })
+})
+
+describe('ApiKeyDialog — grants picker', () => {
+  test('defaults to the site allowlist, not all-owned', async () => {
+    stubFetch()
+    render(<Harness />)
+    await waitFor(() => expect(screen.getByText('sp/my-site')).toBeDefined())
+    expect((screen.getByLabelText('Selected sites') as HTMLInputElement).checked).toBe(true)
+    expect((screen.getByLabelText('All owned sites') as HTMLInputElement).checked).toBe(false)
+  })
+
+  // The controls above are only worth anything if the value they hold is what actually reaches the
+  // server. Without this the whole payload — endpoint, duration, scope, capability ceiling — was
+  // unpinned: the dialog could POST anything and every other test here would still pass.
+  test('POSTs exactly what the form holds — endpoint, duration, scope and least-privilege caps', async () => {
+    const calls = stubFetch()
+    render(<Harness />)
+    await fillAndMint()
+
+    await waitFor(() => expect(calls.some((c) => c.method === 'POST')).toBe(true))
+    const post = calls.find((c) => c.method === 'POST')
+    expect(post?.url).toBe('/api/api-keys')
+    expect(post?.body).toEqual({
+      name: 'ci key',
+      expiresInDays: 30,
+      grants: {
+        control: false,
+        data: { scope: { kind: 'sites', siteIds: ['site-1'] }, caps: ['read'] },
+      },
+    })
+  })
+
+  // The capability ceiling has to be expressible, not just enforced server-side. Before this the
+  // dialog hardcoded all four capabilities, so every key minted from the UI carried maximum data
+  // privilege and CASE-10's narrowing could never actually be exercised by a real user.
+  test('the data-access tier chooses the capability ceiling that is sent', async () => {
+    const calls = stubFetch()
+    render(<Harness />)
+    await waitFor(() => expect(screen.getByText('sp/my-site')).toBeDefined())
+
+    fireEvent.click(screen.getByLabelText('Data access'))
+    const listbox = await screen.findByRole('listbox')
+    expect(
+      within(listbox)
+        .getAllByRole('option')
+        .map((o) => o.textContent),
+    ).toEqual(['Read only', 'Read & submit', 'Full access'])
+    fireEvent.click(within(listbox).getByRole('option', { name: 'Read & submit' }))
+
+    await fillAndMint()
+    await waitFor(() => expect(calls.some((c) => c.method === 'POST')).toBe(true))
+    const grants = calls.find((c) => c.method === 'POST')?.body.grants as { data: { caps: string[] } }
+    expect(grants.data.caps).toEqual(['read', 'create'])
+  })
+})
+
+describe('ApiKeyDialog — show-once', () => {
+  test('mint shows the secret once with a Copy control; closing and reopening does NOT show it again', async () => {
+    stubClipboard()
+    stubFetch()
+    render(<Harness />)
+    await fillAndMint()
+
+    expect(await screen.findByText(plaintext)).toBeDefined()
+    const copyBtn = screen.getByRole('button', { name: 'Copy' })
+    fireEvent.click(copyBtn)
+    await waitFor(() => expect(navigator.clipboard.writeText).toHaveBeenCalledWith(plaintext))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Done' }))
+    await waitFor(() => expect(screen.queryByText(plaintext)).toBeNull())
+
+    fireEvent.click(screen.getByRole('button', { name: 'reopen' }))
+    expect(screen.queryByText(plaintext)).toBeNull()
+    expect(await screen.findByLabelText('Name')).toBeDefined()
+  })
+
+  test('onMinted receives a list row with a hint derived from the secret, never the secret itself', async () => {
+    stubFetch()
+    const onMinted = mock((_key: ApiKeyItem) => {})
+    render(<Harness onMinted={onMinted} />)
+    await fillAndMint()
+    await waitFor(() => expect(onMinted).toHaveBeenCalled())
+    const key = onMinted.mock.calls[0]?.[0] as ApiKeyItem
+    expect(key.secretHint).toBe(`${API_KEY_PREFIX}…1234`)
+    expect(JSON.stringify(key)).not.toContain(plaintext)
+  })
+})

--- a/packages/web/src/components/ApiKeyDialog.tsx
+++ b/packages/web/src/components/ApiKeyDialog.tsx
@@ -175,7 +175,10 @@ export function ApiKeyDialog({
                 Copy it now — this is the only time it’s shown. Glance stores only its hash.
               </DialogDescription>
             </DialogHeader>
-            <div className="flex items-center gap-2">
+            {/* min-w-0: this row is a grid item of DialogContent, so min-width:auto pins it to the
+                secret's min-content width (the string never wraps) and pushes Copy past the dialog
+                edge. Shrinking below that is what lets the `truncate` below actually engage. */}
+            <div className="flex min-w-0 items-center gap-2">
               <code className="flex-1 truncate rounded-md border bg-muted px-3 py-2 font-mono text-sm">
                 {minted.secret}
               </code>

--- a/packages/web/src/components/ApiKeyDialog.tsx
+++ b/packages/web/src/components/ApiKeyDialog.tsx
@@ -1,0 +1,320 @@
+import { useCallback, useState } from 'react'
+import { Check, Copy } from 'lucide-react'
+import { toast } from 'sonner'
+import { api } from '@/lib/api'
+import {
+  API_KEY_PREFIX,
+  type ApiKeyGrants,
+  type ApiKeyItem,
+  DATA_LEVELS,
+  type DataLevel,
+  KEY_DURATIONS,
+  type MintedApiKey,
+  type SiteSummary,
+} from '@/lib/types'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { MountSensor } from '@/components/ui/mount-sensor'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { Spinner } from '@/components/states'
+
+type Duration = (typeof KEY_DURATIONS)[number]
+type Scope = 'sites' | 'all-owned'
+
+const DURATION_LABEL: Record<Duration, string> = {
+  1: '1 day',
+  7: '7 days',
+  30: '30 days',
+  90: '90 days',
+  180: '180 days',
+  365: '1 year',
+}
+
+// A mint response never round-trips through the list endpoint, so the row shown right away is
+// built here — same secretHint fragment the server computes for GET (routes/api-keys.ts): the
+// last 4 chars of the plaintext, which is the only place on this screen the full secret is sliced
+// from. Nothing beyond that fragment is kept.
+function itemFromMinted(minted: MintedApiKey): ApiKeyItem {
+  return {
+    id: minted.id,
+    name: minted.name,
+    grants: minted.grants,
+    createdAt: minted.createdAt,
+    expiresAt: minted.expiresAt,
+    revokedAt: null,
+    lastUsedAt: null,
+    secretHint: `${API_KEY_PREFIX}…${minted.secret.slice(-4)}`,
+  }
+}
+
+// Copy-to-clipboard for the secret specifically: NOT the shared CopyButton (components/CopyButton),
+// because that toasts the copied value back onto the screen as its description — a second on-screen
+// echo of a secret that already stops being recoverable the moment this dialog closes.
+function CopySecretButton({ secret }: { secret: string }) {
+  const [copied, setCopied] = useState(false)
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      onClick={async () => {
+        try {
+          await navigator.clipboard.writeText(secret)
+          setCopied(true)
+          toast.success('Secret copied')
+          setTimeout(() => setCopied(false), 1500)
+        } catch {
+          toast.error("Couldn't copy to clipboard")
+        }
+      }}
+    >
+      {copied ? <Check /> : <Copy />}
+      Copy
+    </Button>
+  )
+}
+
+// Mint dialog. The plaintext secret exists client-side for exactly one render: it lives in
+// `minted` state, set only by a successful POST, and is cleared the instant the dialog closes
+// (handleOpenChange) rather than merely hidden — a re-open always starts from the empty form, it
+// never re-shows or re-fetches a prior secret.
+export function ApiKeyDialog({
+  open,
+  onOpenChange,
+  onMinted,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onMinted: (key: ApiKeyItem) => void
+}) {
+  const [name, setName] = useState('')
+  const [expiresInDays, setExpiresInDays] = useState<Duration>(30)
+  // Allowlist is the default grants shape (Sam's ruling) — a fresh key starts scoped to sites you
+  // explicitly pick, not silently widened to everything you own.
+  const [scope, setScope] = useState<Scope>('sites')
+  // Least privilege by default, for the same reason the scope defaults to an allowlist: widening
+  // is a deliberate act. The server intersects whatever lands here with the user's own access, so
+  // this can only ever narrow — but a key minted with the full set can never be narrowed later.
+  const [dataLevel, setDataLevel] = useState<DataLevel>('read')
+  const [control, setControl] = useState(false)
+  const [siteIds, setSiteIds] = useState<string[]>([])
+  const [sites, setSites] = useState<SiteSummary[]>([])
+  const [loadingSites, setLoadingSites] = useState(false)
+  const [minting, setMinting] = useState(false)
+  const [minted, setMinted] = useState<MintedApiKey | null>(null)
+
+  // Reseed on every open, MountSensor-driven like ForkDialog/MoveDialog: a fresh form, a fresh
+  // site list, and — critically — `minted` reset to null so a closed-then-reopened dialog can
+  // never render a stale secret.
+  const seed = useCallback(() => {
+    setName('')
+    setExpiresInDays(30)
+    setScope('sites')
+    setDataLevel('read')
+    setControl(false)
+    setSiteIds([])
+    setMinted(null)
+    setLoadingSites(true)
+    api
+      .get<SiteSummary[]>('/api/sites/mine')
+      .then(setSites)
+      .catch((err) =>
+        toast.error('Could not load sites', { description: err instanceof Error ? err.message : undefined }),
+      )
+      .finally(() => setLoadingSites(false))
+  }, [])
+
+  function handleOpenChange(o: boolean) {
+    if (minting) return
+    // Show-once: the secret is dropped HERE, on close, not left for a future open to render.
+    if (!o) setMinted(null)
+    onOpenChange(o)
+  }
+
+  async function mint() {
+    if (minting) return
+    setMinting(true)
+    try {
+      const grants: ApiKeyGrants = {
+        control,
+        data: {
+          scope: scope === 'all-owned' ? { kind: 'all-owned' } : { kind: 'sites', siteIds },
+          caps: [...(DATA_LEVELS.find((l) => l.value === dataLevel) ?? DATA_LEVELS[0]).caps],
+        },
+      }
+      const result = await api.post<MintedApiKey>('/api/api-keys', { name, expiresInDays, grants })
+      setMinted(result)
+      onMinted(itemFromMinted(result))
+    } catch (err) {
+      toast.error('Could not create key', { description: err instanceof Error ? err.message : undefined })
+    } finally {
+      setMinting(false)
+    }
+  }
+
+  const canMint = name.trim().length > 0 && (scope === 'all-owned' || siteIds.length > 0)
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent>
+        <MountSensor onMount={seed} />
+        {minted ? (
+          <>
+            <DialogHeader>
+              <DialogTitle>Key created</DialogTitle>
+              <DialogDescription>
+                Copy it now — this is the only time it’s shown. Glance stores only its hash.
+              </DialogDescription>
+            </DialogHeader>
+            <div className="flex items-center gap-2">
+              <code className="flex-1 truncate rounded-md border bg-muted px-3 py-2 font-mono text-sm">
+                {minted.secret}
+              </code>
+              <CopySecretButton secret={minted.secret} />
+            </div>
+            <DialogFooter>
+              <Button onClick={() => handleOpenChange(false)}>Done</Button>
+            </DialogFooter>
+          </>
+        ) : (
+          <>
+            <DialogHeader>
+              <DialogTitle>New API key</DialogTitle>
+              <DialogDescription>Keys authenticate CLI/API requests as you.</DialogDescription>
+            </DialogHeader>
+            <div className="space-y-1.5">
+              <Label htmlFor="key-name">Name</Label>
+              <Input
+                id="key-name"
+                value={name}
+                disabled={minting}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="e.g. CI pipeline"
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="key-expiry">Expires</Label>
+              {/* Fixed dropdown over KEY_DURATIONS only — never a free-text date, so the server's
+                  fixed duration set is the only thing this control can ever produce. */}
+              <Select
+                value={String(expiresInDays)}
+                onValueChange={(v) => setExpiresInDays(Number(v) as Duration)}
+                disabled={minting}
+              >
+                <SelectTrigger id="key-expiry" className="w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {KEY_DURATIONS.map((d) => (
+                    <SelectItem key={d} value={String(d)}>
+                      {DURATION_LABEL[d]}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="key-data-level">Data access</Label>
+              {/* The capability CEILING. The server intersects it with the caller's own access
+                  (dataCapsFor), so picking Full access on a site you only view still mints
+                  read+create — this control can narrow, never widen. */}
+              <Select
+                value={dataLevel}
+                onValueChange={(v) => setDataLevel(v as DataLevel)}
+                disabled={minting}
+              >
+                <SelectTrigger id="key-data-level" className="w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {DATA_LEVELS.map((l) => (
+                    <SelectItem key={l.value} value={l.value}>
+                      {l.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-1.5">
+              <Label>Site access</Label>
+              <div className="flex gap-4 text-sm">
+                <label className="flex items-center gap-1.5">
+                  <input
+                    type="radio"
+                    name="key-scope"
+                    checked={scope === 'sites'}
+                    disabled={minting}
+                    onChange={() => setScope('sites')}
+                  />
+                  Selected sites
+                </label>
+                <label className="flex items-center gap-1.5">
+                  <input
+                    type="radio"
+                    name="key-scope"
+                    checked={scope === 'all-owned'}
+                    disabled={minting}
+                    onChange={() => setScope('all-owned')}
+                  />
+                  All owned sites
+                </label>
+              </div>
+              {scope === 'sites' &&
+                (loadingSites ? (
+                  <div className="flex justify-center py-4">
+                    <Spinner />
+                  </div>
+                ) : (
+                  <div className="max-h-40 space-y-1 overflow-y-auto rounded-md border p-2">
+                    {sites.length === 0 && <p className="text-sm text-muted-foreground">No sites yet.</p>}
+                    {sites.map((s) => (
+                      <label key={s.id} className="flex items-center gap-2 text-sm">
+                        <input
+                          type="checkbox"
+                          checked={siteIds.includes(s.id)}
+                          disabled={minting}
+                          onChange={(e) =>
+                            setSiteIds((ids) => (e.target.checked ? [...ids, s.id] : ids.filter((id) => id !== s.id)))
+                          }
+                        />
+                        <span className="font-mono">
+                          {s.spaceSlug}/{s.siteSlug}
+                        </span>
+                      </label>
+                    ))}
+                  </div>
+                ))}
+            </div>
+            <label className="flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                checked={control}
+                disabled={minting}
+                onChange={(e) => setControl(e.target.checked)}
+              />
+              Also allow managing sites (deploy, create, fork)
+            </label>
+            <DialogFooter>
+              <Button variant="outline" disabled={minting} onClick={() => handleOpenChange(false)}>
+                Cancel
+              </Button>
+              <Button disabled={minting || !canMint} onClick={() => void mint()}>
+                {minting && <Spinner />}
+                Create key
+              </Button>
+            </DialogFooter>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/packages/web/src/components/AppShell.test.tsx
+++ b/packages/web/src/components/AppShell.test.tsx
@@ -1,0 +1,39 @@
+// The avatar dropdown's entry points — this only covers the /settings/keys link (S10); the rest
+// of the menu already ships and isn't re-asserted here.
+import { describe, expect, test } from 'bun:test'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { createMemoryRouter, RouterProvider } from 'react-router'
+import type { Me } from '@/lib/types'
+import { AppShell } from './AppShell'
+
+const USER: Me = { id: 'u1', email: 'a@b.com', name: 'Ada', role: 'member', hasUsedCli: true }
+
+function renderShell() {
+  const router = createMemoryRouter(
+    [
+      {
+        path: '/',
+        Component: AppShell,
+        loader: () => ({
+          user: USER,
+          notifications: Promise.resolve({ items: [], unreadCount: 0 }),
+          whatsNew: Promise.resolve({ items: [], unreadCount: 0, throughDate: null }),
+        }),
+        children: [{ index: true, element: null }],
+      },
+    ],
+    { initialEntries: ['/'] },
+  )
+  return render(<RouterProvider router={router} />)
+}
+
+describe('AppShell avatar menu', () => {
+  test('links to /settings/keys', async () => {
+    renderShell()
+    // Radix's DropdownMenuTrigger opens on pointerdown, not click (see its source) — a plain
+    // fireEvent.click never toggles it in happy-dom.
+    fireEvent.pointerDown(await screen.findByRole('button', { name: 'Account menu' }), { button: 0 })
+    const link = (await screen.findByText('API Keys')).closest('a')
+    expect(link?.getAttribute('href')).toBe('/settings/keys')
+  })
+})

--- a/packages/web/src/components/AppShell.tsx
+++ b/packages/web/src/components/AppShell.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useState } from 'react'
 import { Link, NavLink, Outlet, useLoaderData, useNavigation } from 'react-router'
-import { Command, LogOut, Moon, Sun, SunMoon } from 'lucide-react'
+import { Command, KeyRound, LogOut, Moon, Sun, SunMoon } from 'lucide-react'
 import type { RootData } from '@/lib/notifications'
 import { api } from '@/lib/api'
 import { toggleTheme, useTheme } from '@/components/theme'
@@ -110,6 +110,12 @@ export function AppShell() {
                   <DropdownMenuItem onSelect={() => toggleTheme()}>
                     <SunMoon />
                     Toggle theme
+                  </DropdownMenuItem>
+                  <DropdownMenuItem asChild>
+                    <Link to="/settings/keys">
+                      <KeyRound />
+                      API Keys
+                    </Link>
                   </DropdownMenuItem>
                   <DropdownMenuItem
                     className="text-destructive focus:text-destructive"

--- a/packages/web/src/components/GettingStarted.test.tsx
+++ b/packages/web/src/components/GettingStarted.test.tsx
@@ -1,0 +1,19 @@
+// S12: the walkthrough (rendered in both the dashboard empty state and the HelpButton sheet)
+// links to the API keys docs page — one link, both surfaces, for free.
+import { describe, expect, test } from 'bun:test'
+import { render, screen } from '@testing-library/react'
+import { createMemoryRouter, RouterProvider } from 'react-router'
+import { GettingStarted } from './GettingStarted'
+
+function renderIt() {
+  const router = createMemoryRouter([{ path: '/', Component: GettingStarted }], { initialEntries: ['/'] })
+  return render(<RouterProvider router={router} />)
+}
+
+describe('GettingStarted', () => {
+  test('links to /docs/api-keys', async () => {
+    renderIt()
+    const link = (await screen.findByText(/API keys/)).closest('a')
+    expect(link?.getAttribute('href')).toBe('/docs/api-keys')
+  })
+})

--- a/packages/web/src/components/GettingStarted.tsx
+++ b/packages/web/src/components/GettingStarted.tsx
@@ -1,4 +1,5 @@
 import { MessageSquareText, Terminal } from 'lucide-react'
+import { Link } from 'react-router'
 import { CopyButton } from '@/components/CopyButton'
 
 // The onboarding walkthrough, rendered in TWO surfaces: the dashboard's empty sites tab and the
@@ -71,6 +72,11 @@ export function GettingStarted() {
       </ol>
       <p className="border-t pt-4 text-muted-foreground text-xs">
         No CLI? Drop a folder or a lone HTML file on the dashboard to ship it straight from the browser.
+      </p>
+      <p className="text-xs">
+        <Link to="/docs/api-keys" className="font-medium text-primary hover:underline">
+          Scripting instead? Set up API keys →
+        </Link>
       </p>
     </div>
   )

--- a/packages/web/src/lib/time.ts
+++ b/packages/web/src/lib/time.ts
@@ -12,3 +12,9 @@ export function timeAgo(iso: string): string {
   if (days < 30) return `${days}d ago`
   return new Date(iso).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })
 }
+
+// Calendar date for a FUTURE timestamp (key expiry) — "expires 2026-10-29", not relative math:
+// an expiry you might screenshot into a runbook should read as a fixed date, not "in 47 days".
+export function isoDate(iso: string): string {
+  return iso.slice(0, 10)
+}

--- a/packages/web/src/lib/types.ts
+++ b/packages/web/src/lib/types.ts
@@ -107,3 +107,56 @@ export interface ShareSet {
 }
 
 export type SlugExists = { exists: false } | { exists: true; owned: boolean }
+
+// Mirrors packages/api/src/routes/api-keys.ts KEY_DURATIONS — the only expiries the server will
+// ever accept. Keep this list in sync with that one; it is what drives the expiry dropdown.
+export const KEY_DURATIONS = [1, 7, 30, 90, 180, 365] as const
+
+export type DataCapability = 'read' | 'create' | 'write' | 'read_all'
+
+// Mirrors packages/api/src/lib/api-key.ts API_KEY_PREFIX — the server derives `secretHint` from
+// it, so a locally-built hint (the mint response never round-trips through GET) has to use the
+// same constant or the two silently drift.
+export const API_KEY_PREFIX = 'glk_'
+
+// The capability CEILING a key may carry, as the three tiers that are actually meaningful against
+// the server's dataCapsFor: it intersects this with what the user themselves can do, so a tier can
+// only ever narrow. Offering the four raw capabilities as independent checkboxes would let someone
+// build combinations the server can never grant (read_all without read, say) and read as more
+// control than it is.
+export const DATA_LEVELS = [
+  { value: 'read', label: 'Read only', caps: ['read'] },
+  { value: 'submit', label: 'Read & submit', caps: ['read', 'create'] },
+  { value: 'full', label: 'Full access', caps: ['read', 'create', 'write', 'read_all'] },
+] as const satisfies ReadonlyArray<{ value: string; label: string; caps: readonly DataCapability[] }>
+
+export type DataLevel = (typeof DATA_LEVELS)[number]['value']
+
+// Mirrors packages/api/src/lib/api-key.ts ApiKeyGrants.
+export type ApiKeyGrants = {
+  control: boolean
+  data: { scope: { kind: 'all-owned' } | { kind: 'sites'; siteIds: string[] }; caps: DataCapability[] } | null
+}
+
+// GET /api/api-keys row shape. Never carries the plaintext secret — only `secretHint`
+// (`glk_…4mR2`), which the server derives from the last 4 chars of a value it never stores.
+export interface ApiKeyItem {
+  id: string
+  name: string
+  grants: ApiKeyGrants
+  createdAt: string
+  expiresAt: string
+  revokedAt: string | null
+  lastUsedAt: string | null
+  secretHint: string | null
+}
+
+// POST /api/api-keys response — the ONLY payload that ever carries the plaintext secret.
+export interface MintedApiKey {
+  id: string
+  name: string
+  secret: string
+  grants: ApiKeyGrants
+  createdAt: string
+  expiresAt: string
+}

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -1,101 +1,11 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
-import {
-  createBrowserRouter,
-  Link,
-  type LoaderFunctionArgs,
-  RouterProvider,
-  redirect,
-  useRouteError,
-} from 'react-router'
-import { AppShell } from './components/AppShell'
-import { Button } from './components/ui/button'
+import { createBrowserRouter, RouterProvider } from 'react-router'
 import { Toaster } from './components/ui/sonner'
-import { api, ApiError } from './lib/api'
-import { skipSearchOnlyRevalidation } from './lib/nav'
-import { EMPTY_NOTIFICATIONS, type RootData, notifications } from './lib/notifications'
-import type { Me } from './lib/types'
-import { EMPTY_WHATS_NEW, whatsNew } from './lib/whatsNew'
+import { routeConfig } from './router'
 import './tailwind.css'
 
-// Root loader fetches identity ONCE before render (replaces a mount useEffect). It does
-// NOT redirect — the login page must render logged-out; protected route loaders guard
-// themselves. Notifications ride along as a DEFERRED promise (not awaited — awaiting would block
-// the first paint of every shell route); the Bell/inbox consume it via <Await>. Skipped (resolved
-// empty) when logged out, and a failed fetch degrades to empty so it never breaks the shell.
-async function rootLoader(): Promise<RootData> {
-  let user: Me | null
-  try {
-    user = await api.get<Me>('/api/auth/me')
-  } catch (err) {
-    if (err instanceof ApiError && err.status === 401) user = null
-    else throw err
-  }
-  const list = user ? notifications.list().catch(() => EMPTY_NOTIFICATIONS) : Promise.resolve(EMPTY_NOTIFICATIONS)
-  const news = user ? whatsNew.list().catch(() => EMPTY_WHATS_NEW) : Promise.resolve(EMPTY_WHATS_NEW)
-  return { user, notifications: list, whatsNew: news }
-}
-
-function RootError() {
-  const error = useRouteError()
-  const status = error instanceof ApiError ? error.status : (error as { status?: number })?.status
-  const map: Record<number, { title: string; body: string }> = {
-    401: { title: 'Sign in required', body: 'You need to sign in to view this.' },
-    403: { title: "You don't have access", body: 'This site is private or restricted.' },
-    404: { title: 'Not found', body: "That page or site doesn't exist." },
-    410: { title: 'Site archived', body: 'This site has been archived by an admin.' },
-  }
-  const info = (status && map[status]) || { title: 'Something went wrong', body: 'Please try again.' }
-  return (
-    <div className="flex min-h-screen flex-col items-center justify-center px-6 text-center">
-      <div className="font-mono text-6xl font-semibold text-primary">{status ?? '!'}</div>
-      <h1 className="mt-4 text-xl font-semibold tracking-tight">{info.title}</h1>
-      <p className="mt-1 text-sm text-muted-foreground">{info.body}</p>
-      <Button asChild className="mt-6">
-        <Link to="/dashboard">Back to dashboard</Link>
-      </Button>
-    </div>
-  )
-}
-
-// Re-export for child loaders that want to enforce auth.
-export function requireUser(user: Me | null): Me {
-  if (!user) throw redirect('/login')
-  return user
-}
-export { rootLoader as _rootLoader }
-export type { LoaderFunctionArgs }
-
-const router = createBrowserRouter([
-  // Login is a standalone, full-bleed route (its own dark Blueprint hero) outside the shell.
-  { path: '/login', lazy: () => import('./routes/login') },
-  // Site preview is full-bleed too — a chrome-less, full-screen iframe (opened in a new tab).
-  // Lives outside the shell so there's no header/nav; loader 401 → /login, 403/404/410 → RootError.
-  // The trailing `*` carries an optional in-site file path (`/space/site/docs/page.html`) so a
-  // deep link / the directory-listing fallback points the iframe at that file and the URL reflects it.
-  { path: '/:space/:site/*', lazy: () => import('./routes/viewer'), ErrorBoundary: RootError },
-  {
-    path: '/',
-    id: 'root',
-    Component: AppShell,
-    loader: rootLoader,
-    // This loader AWAITS /api/auth/me and its promises feed the Bell/WhatsNew <Await>s — a
-    // search-only re-run would block the navigation and flash those badges to zero.
-    shouldRevalidate: skipSearchOnlyRevalidation,
-    ErrorBoundary: RootError,
-    children: [
-      { index: true, loader: () => redirect('/dashboard') },
-      { path: 'dashboard', lazy: () => import('./routes/dashboard') },
-      { path: 'admin', lazy: () => import('./routes/admin') },
-      { path: 'cli', lazy: () => import('./routes/cli') },
-      // Reserved slug (RESERVED_SLUGS) — MUST precede the `:space` catch-all so /whats-new resolves
-      // to the release-notes archive, not a space lookup.
-      { path: 'whats-new', lazy: () => import('./routes/whats-new') },
-      { path: ':space', lazy: () => import('./routes/space') },
-      { path: '*', lazy: () => import('./routes/not-found') },
-    ],
-  },
-])
+const router = createBrowserRouter(routeConfig)
 
 createRoot(document.getElementById('root') as HTMLElement).render(
   <StrictMode>

--- a/packages/web/src/router.test.ts
+++ b/packages/web/src/router.test.ts
@@ -1,0 +1,32 @@
+// Reserved-slug routes, asserted by RESOLUTION rather than by position in the config array.
+//
+// The obvious test here — "settings/keys comes before :space in the children array" — looks like
+// it guards the hazard the whats-new comment describes, but it does not: React Router ranks
+// branches by path specificity, not registration order, so moving these entries after `:space`
+// changes nothing. A position assertion would therefore fail red on a harmless reorder while
+// still passing if the route stopped resolving. matchRoutes asks the question that actually
+// matters: given this path, which route wins?
+//
+// The real competitor is the top-level `/:space/:site/*` viewer, not the one-segment `:space` —
+// delete either reserved route below and its path falls through to the viewer.
+import { describe, expect, test } from 'bun:test'
+import { matchRoutes } from 'react-router'
+import { routeConfig } from './router'
+
+const resolves = (path: string) => matchRoutes(routeConfig, path)?.at(-1)?.route.path
+
+describe('router — reserved paths win over the space/site catch-alls', () => {
+  test('/settings/keys resolves to the keys screen, not a space or site lookup', () => {
+    expect(resolves('/settings/keys')).toBe('settings/keys')
+  })
+
+  test('/docs/api-keys resolves to the docs page, not a space or site lookup', () => {
+    expect(resolves('/docs/api-keys')).toBe('docs/api-keys')
+  })
+
+  // Guards the inverse: the reserved entries must not have been written so broadly that they
+  // swallow ordinary two-segment site URLs, which share their shape.
+  test('an ordinary space/site path still reaches the viewer', () => {
+    expect(resolves('/acme/deck')).toBe('/:space/:site/*')
+  })
+})

--- a/packages/web/src/router.tsx
+++ b/packages/web/src/router.tsx
@@ -1,0 +1,97 @@
+import { Link, type LoaderFunctionArgs, type RouteObject, redirect, useRouteError } from 'react-router'
+import { AppShell } from './components/AppShell'
+import { Button } from './components/ui/button'
+import { api, ApiError } from './lib/api'
+import { skipSearchOnlyRevalidation } from './lib/nav'
+import { EMPTY_NOTIFICATIONS, type RootData, notifications } from './lib/notifications'
+import type { Me } from './lib/types'
+import { EMPTY_WHATS_NEW, whatsNew } from './lib/whatsNew'
+
+// Root loader fetches identity ONCE before render (replaces a mount useEffect). It does
+// NOT redirect — the login page must render logged-out; protected route loaders guard
+// themselves. Notifications ride along as a DEFERRED promise (not awaited — awaiting would block
+// the first paint of every shell route); the Bell/inbox consume it via <Await>. Skipped (resolved
+// empty) when logged out, and a failed fetch degrades to empty so it never breaks the shell.
+async function rootLoader(): Promise<RootData> {
+  let user: Me | null
+  try {
+    user = await api.get<Me>('/api/auth/me')
+  } catch (err) {
+    if (err instanceof ApiError && err.status === 401) user = null
+    else throw err
+  }
+  const list = user ? notifications.list().catch(() => EMPTY_NOTIFICATIONS) : Promise.resolve(EMPTY_NOTIFICATIONS)
+  const news = user ? whatsNew.list().catch(() => EMPTY_WHATS_NEW) : Promise.resolve(EMPTY_WHATS_NEW)
+  return { user, notifications: list, whatsNew: news }
+}
+
+function RootError() {
+  const error = useRouteError()
+  const status = error instanceof ApiError ? error.status : (error as { status?: number })?.status
+  const map: Record<number, { title: string; body: string }> = {
+    401: { title: 'Sign in required', body: 'You need to sign in to view this.' },
+    403: { title: "You don't have access", body: 'This site is private or restricted.' },
+    404: { title: 'Not found', body: "That page or site doesn't exist." },
+    410: { title: 'Site archived', body: 'This site has been archived by an admin.' },
+  }
+  const info = (status && map[status]) || { title: 'Something went wrong', body: 'Please try again.' }
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center px-6 text-center">
+      <div className="font-mono text-6xl font-semibold text-primary">{status ?? '!'}</div>
+      <h1 className="mt-4 text-xl font-semibold tracking-tight">{info.title}</h1>
+      <p className="mt-1 text-sm text-muted-foreground">{info.body}</p>
+      <Button asChild className="mt-6">
+        <Link to="/dashboard">Back to dashboard</Link>
+      </Button>
+    </div>
+  )
+}
+
+// Re-export for child loaders that want to enforce auth.
+export function requireUser(user: Me | null): Me {
+  if (!user) throw redirect('/login')
+  return user
+}
+export { rootLoader as _rootLoader }
+export type { LoaderFunctionArgs }
+
+// Split out from the entry file (main.tsx) so a test can assert on route ORDER without importing
+// the createRoot/render side effect. See router.test.ts.
+export const routeConfig: RouteObject[] = [
+  // Login is a standalone, full-bleed route (its own dark Blueprint hero) outside the shell.
+  { path: '/login', lazy: () => import('./routes/login') },
+  // Site preview is full-bleed too — a chrome-less, full-screen iframe (opened in a new tab).
+  // Lives outside the shell so there's no header/nav; loader 401 → /login, 403/404/410 → RootError.
+  // The trailing `*` carries an optional in-site file path (`/space/site/docs/page.html`) so a
+  // deep link / the directory-listing fallback points the iframe at that file and the URL reflects it.
+  { path: '/:space/:site/*', lazy: () => import('./routes/viewer'), ErrorBoundary: RootError },
+  {
+    path: '/',
+    id: 'root',
+    Component: AppShell,
+    loader: rootLoader,
+    // This loader AWAITS /api/auth/me and its promises feed the Bell/WhatsNew <Await>s — a
+    // search-only re-run would block the navigation and flash those badges to zero.
+    shouldRevalidate: skipSearchOnlyRevalidation,
+    ErrorBoundary: RootError,
+    children: [
+      { index: true, loader: () => redirect('/dashboard') },
+      { path: 'dashboard', lazy: () => import('./routes/dashboard') },
+      { path: 'admin', lazy: () => import('./routes/admin') },
+      { path: 'cli', lazy: () => import('./routes/cli') },
+      // Reserved slug (RESERVED_SLUGS) — MUST precede the `:space` catch-all so /whats-new resolves
+      // to the release-notes archive, not a space lookup.
+      { path: 'whats-new', lazy: () => import('./routes/whats-new') },
+      // Reserved slugs, grouped with 'whats-new' for readability — but note their hazard is not
+      // the one described above. Both are TWO-segment paths, so the one-segment `:space` could
+      // never match them whatever the order, and the router ranks by specificity rather than
+      // position anyway. What they genuinely compete with is the top-level `/:space/:site/*`
+      // viewer: drop either entry and its URL renders as a site. router.test.ts asserts that by
+      // resolution (matchRoutes), which is the only form of the check that means anything.
+      { path: 'settings/keys', lazy: () => import('./routes/settings-keys') },
+      { path: 'docs/api-keys', lazy: () => import('./routes/docs-api-keys') },
+      { path: ':space', lazy: () => import('./routes/space') },
+      { path: '*', lazy: () => import('./routes/not-found') },
+    ],
+  },
+]

--- a/packages/web/src/routes/docs-api-keys.test.tsx
+++ b/packages/web/src/routes/docs-api-keys.test.tsx
@@ -1,0 +1,40 @@
+// The docs page is the slice's actual deliverable, and it was shipping with no coverage at all:
+// rewriting its heading and breaking both of its outbound links left the whole web suite green.
+// These assert the things a reader depends on — that the page renders, that it points at the real
+// keys screen, and that the two claims most likely to rot (the env var name, and create-but-never-
+// delete) are still on it.
+import { describe, expect, test } from 'bun:test'
+import { render, screen } from '@testing-library/react'
+import { createMemoryRouter, RouterProvider } from 'react-router'
+import { Component } from './docs-api-keys'
+
+function renderDocs() {
+  const router = createMemoryRouter([{ path: '/docs/api-keys', Component }], {
+    initialEntries: ['/docs/api-keys'],
+  })
+  return render(<RouterProvider router={router} />)
+}
+
+describe('docs/api-keys', () => {
+  test('renders the page heading', async () => {
+    renderDocs()
+    expect(await screen.findByRole('heading', { name: 'API Keys' })).toBeDefined()
+  })
+
+  test('every link to the keys screen points at the route that actually exists', async () => {
+    renderDocs()
+    const links = (await screen.findAllByRole('link')).filter((a) =>
+      (a.getAttribute('href') ?? '').startsWith('/settings'),
+    )
+    expect(links.length).toBeGreaterThan(0)
+    for (const a of links) expect(a.getAttribute('href')).toBe('/settings/keys')
+  })
+
+  test('documents the env var the CLI actually reads, and the create-not-delete limit', async () => {
+    renderDocs()
+    const text = (await screen.findByRole('heading', { name: 'API Keys' })).closest('div')?.parentElement
+      ?.textContent
+    expect(text).toContain('GLANCE_TOKEN')
+    expect(text?.toLowerCase()).toContain('delete')
+  })
+})

--- a/packages/web/src/routes/docs-api-keys.tsx
+++ b/packages/web/src/routes/docs-api-keys.tsx
@@ -14,6 +14,10 @@ function CodeBlock({ children }: { children: string }) {
   )
 }
 
+function Code({ children }: { children: string }) {
+  return <code className="rounded bg-muted px-1 py-0.5 text-xs">{children}</code>
+}
+
 function Section({ title, children }: { title: string; children: React.ReactNode }) {
   return (
     <section className="space-y-2">
@@ -51,27 +55,26 @@ export function Component() {
 
         <Section title="Use it with the CLI">
           <p>
-            The CLI reads its target instance from <code className="rounded bg-muted px-1 py-0.5 text-xs">~/.glance/config.json</code>,
-            not from the key — so install and point it at this instance first:
+            The CLI reads its target instance from <Code>~/.glance/config.json</Code>, not from the key — so install
+            and point it at this instance first:
           </p>
           <CodeBlock>{'curl -fsSL <this instance origin>/api/install | sh'}</CodeBlock>
           <p>
-            Then export the key as <code className="rounded bg-muted px-1 py-0.5 text-xs">GLANCE_TOKEN</code> instead
-            of running <code className="rounded bg-muted px-1 py-0.5 text-xs">glance login</code>:
+            Then export the key as <Code>GLANCE_TOKEN</Code> instead of running <Code>glance login</Code>:
           </p>
           <CodeBlock>{'export GLANCE_TOKEN=glk_...\nglance deploy ./my-site'}</CodeBlock>
           <p>
-            <code className="rounded bg-muted px-1 py-0.5 text-xs">GLANCE_TOKEN</code> is only checked by commands
-            that call the API — <code className="rounded bg-muted px-1 py-0.5 text-xs">glance logout</code> ignores
-            it deliberately, so it always acts on your real session, not a key you happen to have exported.
+            <Code>GLANCE_TOKEN</Code> is only checked by commands that call the API — <Code>glance logout</Code>{' '}
+            ignores it deliberately, so it always acts on your real session, not a key you happen to have exported.
           </p>
         </Section>
 
         <Section title="What a key can do">
           <p>
-            With the "manage sites" grant, a key can deploy and create sites the same as you can. It can never
-            delete a site, and it can never mint or revoke another key — both are denied outright, regardless of
-            grants.
+            With the "manage sites" grant, a key can deploy and create sites the same as you can. Without it, the
+            key can still read and use the data plane, but any request that would change a site — deploy, create,
+            fork, move, rename, share — is refused. It can never delete a site, and it can never mint or revoke
+            another key: both are denied outright, whatever its grants.
           </p>
         </Section>
 

--- a/packages/web/src/routes/docs-api-keys.tsx
+++ b/packages/web/src/routes/docs-api-keys.tsx
@@ -18,6 +18,26 @@ function Code({ children }: { children: string }) {
   return <code className="rounded bg-muted px-1 py-0.5 text-xs">{children}</code>
 }
 
+// [method, path, what it does, whether a key credential may call it]
+function EndpointTable({ rows }: { rows: [string, string, string, string][] }) {
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-xs">
+        <tbody>
+          {rows.map(([method, path, purpose, keyAllowed]) => (
+            <tr key={`${method} ${path}`} className="border-b last:border-0">
+              <td className="py-1.5 pr-3 align-top font-mono text-foreground">{method}</td>
+              <td className="py-1.5 pr-3 align-top font-mono">{path}</td>
+              <td className="py-1.5 pr-3 align-top">{purpose}</td>
+              <td className="py-1.5 align-top whitespace-nowrap">{keyAllowed}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
 function Section({ title, children }: { title: string; children: React.ReactNode }) {
   return (
     <section className="space-y-2">
@@ -75,6 +95,58 @@ export function Component() {
             key can still read and use the data plane, but any request that would change a site — deploy, create,
             fork, move, rename, share — is refused. It can never delete a site, and it can never mint or revoke
             another key: both are denied outright, whatever its grants.
+          </p>
+          <p>
+            <strong className="text-foreground">One gap to scope around:</strong> deleting a{' '}
+            <em>space</em> is not covered by that rule. A key with the "manage sites" grant can delete a group space
+            it created, which destroys every site inside it. Personal spaces are protected, and the delete is
+            refused if the space holds sites owned by other members — but your own sites in your own group space can
+            be erased this way despite the per-site rule above.
+          </p>
+        </Section>
+
+        <Section title="Call the API directly">
+          <p>
+            The CLI is a convenience — a key is a bearer token against the same HTTP API. Send it as an{' '}
+            <Code>Authorization</Code> header:
+          </p>
+          <CodeBlock>
+            {'curl -H "Authorization: Bearer $GLANCE_TOKEN" \\\n  <this instance origin>/api/sites/mine'}
+          </CodeBlock>
+          <p>Key management lives at {'/api/api-keys'}, and is refused to a key credential except for the list:</p>
+          <EndpointTable
+            rows={[
+              ['POST', '/api/api-keys', 'mint — returns the secret once', '403 for a key'],
+              ['GET', '/api/api-keys', 'list your keys (no secrets, no hashes)', 'allowed'],
+              ['DELETE', '/api/api-keys/:id', 'revoke — idempotent', '403 for a key'],
+            ]}
+          />
+          <p>Minting takes a name, one of the six fixed durations, and the grants:</p>
+          <CodeBlock>
+            {`POST /api/api-keys
+{
+  "name": "CI deploy bot",
+  "expiresInDays": 30,
+  "grants": {
+    "control": true,
+    "data": { "scope": { "kind": "all-owned" }, "caps": ["read"] }
+  }
+}`}
+          </CodeBlock>
+          <p>
+            An <Code>expiresAt</Code> in the body is ignored — it's always derived server-side from{' '}
+            <Code>expiresInDays</Code>. You may hold 10 active keys; revoked and expired ones don't count.
+          </p>
+          <p>Deploying is a multipart upload, one form field per file:</p>
+          <CodeBlock>
+            {`curl -X POST "<origin>/api/upload/<space>/<site>" \\
+  -H "Authorization: Bearer $GLANCE_TOKEN" \\
+  -F "files=@dist/index.html;filename=index.html" \\
+  -F "visibility=team"`}
+          </CodeBlock>
+          <p>
+            Full endpoint reference — sites, spaces, shares, forks, response shapes and status codes — is in{' '}
+            <Code>packages/api/API.md</Code>.
           </p>
         </Section>
 

--- a/packages/web/src/routes/docs-api-keys.tsx
+++ b/packages/web/src/routes/docs-api-keys.tsx
@@ -1,0 +1,104 @@
+import { KeyRound } from 'lucide-react'
+import { Link } from 'react-router'
+
+// Static reference for the API keys feature (S12). Reserved slug ('docs', see
+// RESERVED_SLUGS) — registered BEFORE the `:space` catch-all in router.tsx, same ordering
+// hazard as 'whats-new' and 'settings/keys'. No loader: nothing here is fetched, so the page
+// renders the same for a logged-in or logged-out visitor.
+
+function CodeBlock({ children }: { children: string }) {
+  return (
+    <pre className="overflow-x-auto rounded-md border bg-muted px-3 py-2 font-mono text-xs">
+      <code>{children}</code>
+    </pre>
+  )
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="space-y-2">
+      <h2 className="font-semibold text-lg leading-snug">{title}</h2>
+      <div className="space-y-2 text-muted-foreground text-sm leading-relaxed">{children}</div>
+    </section>
+  )
+}
+
+export function Component() {
+  return (
+    <div className="mx-auto max-w-2xl">
+      <div className="mb-8 flex items-center gap-2">
+        <KeyRound className="size-5 text-primary" />
+        <h1 className="font-semibold text-2xl tracking-tight">API Keys</h1>
+      </div>
+
+      <div className="space-y-8">
+        <Section title="Create a key">
+          <p>
+            From{' '}
+            <Link to="/settings/keys" className="font-medium text-primary hover:underline">
+              /settings/keys
+            </Link>
+            , click <strong className="text-foreground">New key</strong>. Give it a name, an expiry (1, 7, 30, 90,
+            180, or 365 days — the only durations Glance will ever mint), and site access: either a set of sites you
+            pick, or every site you own. There's also an optional checkbox to let the key manage sites (deploy,
+            create, fork) — off by default.
+          </p>
+          <p>
+            The secret is shown <strong className="text-foreground">exactly once</strong>, right after creation.
+            Glance stores only its hash — if you lose it, revoke it and mint a new one.
+          </p>
+        </Section>
+
+        <Section title="Use it with the CLI">
+          <p>
+            The CLI reads its target instance from <code className="rounded bg-muted px-1 py-0.5 text-xs">~/.glance/config.json</code>,
+            not from the key — so install and point it at this instance first:
+          </p>
+          <CodeBlock>{'curl -fsSL <this instance origin>/api/install | sh'}</CodeBlock>
+          <p>
+            Then export the key as <code className="rounded bg-muted px-1 py-0.5 text-xs">GLANCE_TOKEN</code> instead
+            of running <code className="rounded bg-muted px-1 py-0.5 text-xs">glance login</code>:
+          </p>
+          <CodeBlock>{'export GLANCE_TOKEN=glk_...\nglance deploy ./my-site'}</CodeBlock>
+          <p>
+            <code className="rounded bg-muted px-1 py-0.5 text-xs">GLANCE_TOKEN</code> is only checked by commands
+            that call the API — <code className="rounded bg-muted px-1 py-0.5 text-xs">glance logout</code> ignores
+            it deliberately, so it always acts on your real session, not a key you happen to have exported.
+          </p>
+        </Section>
+
+        <Section title="What a key can do">
+          <p>
+            With the "manage sites" grant, a key can deploy and create sites the same as you can. It can never
+            delete a site, and it can never mint or revoke another key — both are denied outright, regardless of
+            grants.
+          </p>
+        </Section>
+
+        <Section title="Data access">
+          <p>
+            A key's data grant is an allowlist — the specific sites you selected, or "all owned sites" — plus a
+            capability ceiling (read, create, write, read_all) on top of it. When the key is used to mint a
+            glance.db data token, that ceiling only ever narrows what the token can carry: it can restrict what
+            you could otherwise do, never grant more than your own access already allows.
+          </p>
+        </Section>
+
+        <Section title="Expiry &amp; revocation">
+          <p>
+            A key stops authenticating the moment it expires or is revoked from{' '}
+            <Link to="/settings/keys" className="font-medium text-primary hover:underline">
+              /settings/keys
+            </Link>
+            . Revoked keys stay listed, greyed out, rather than disappearing.
+          </p>
+          <p>
+            One exception: a data token the key already minted before revocation keeps working for the rest of its
+            own lifetime — up to 5 minutes (300 seconds). That token is a self-contained, signed credential, not a
+            lookup against the key, so revoking the key doesn't reach back into tokens it already handed out.
+          </p>
+        </Section>
+      </div>
+    </div>
+  )
+}

--- a/packages/web/src/routes/settings-keys.test.tsx
+++ b/packages/web/src/routes/settings-keys.test.tsx
@@ -1,0 +1,110 @@
+// The route + the way in (S10) got the shell and the empty state. S11 adds the real rows: grants,
+// expiry, last-used, secretHint, and the revoke flow — same "feed the loader directly" pattern as
+// viewer.test.tsx, the real loader (network) is bypassed entirely.
+import { describe, expect, test } from 'bun:test'
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { createMemoryRouter, RouterProvider } from 'react-router'
+import type { ApiKeyItem } from '@/lib/types'
+import { Component } from './settings-keys'
+import type { ApiKeyListData } from './settings-keys'
+
+function renderPage(data: ApiKeyListData) {
+  const router = createMemoryRouter([{ path: '/settings/keys', Component, loader: () => data }], {
+    initialEntries: ['/settings/keys'],
+  })
+  return render(<RouterProvider router={router} />)
+}
+
+const ACTIVE: ApiKeyItem = {
+  id: 'k-active',
+  name: 'CI pipeline',
+  grants: { control: false, data: { scope: { kind: 'all-owned' }, caps: ['read'] } },
+  createdAt: '2026-01-01T00:00:00.000Z',
+  expiresAt: '2099-01-01T00:00:00.000Z',
+  revokedAt: null,
+  lastUsedAt: null,
+  secretHint: 'glk_…4mR2',
+}
+
+const REVOKED: ApiKeyItem = {
+  ...ACTIVE,
+  id: 'k-revoked',
+  name: 'Old laptop',
+  revokedAt: '2026-02-01T00:00:00.000Z',
+  secretHint: 'glk_…z9Q1',
+}
+
+function stubDelete() {
+  const calls: string[] = []
+  globalThis.fetch = ((url: string, init?: RequestInit) => {
+    calls.push(`${init?.method ?? 'GET'} ${url}`)
+    return Promise.resolve(new Response(JSON.stringify({ revoked: true }), { status: 200 }))
+  }) as unknown as typeof fetch
+  return calls
+}
+
+describe('settings-keys', () => {
+  test('no keys → the empty state from the wireframe', async () => {
+    renderPage({ items: [] })
+    expect(await screen.findByText('No API keys yet.')).toBeDefined()
+  })
+
+  test('links to the API keys docs page', async () => {
+    renderPage({ items: [] })
+    const link = (await screen.findByText('How keys work')).closest('a')
+    expect(link?.getAttribute('href')).toBe('/docs/api-keys')
+  })
+
+  test('a revoked key STAYS in the list, styled inert, instead of disappearing', async () => {
+    renderPage({ items: [ACTIVE, REVOKED] })
+    expect(await screen.findByText('Old laptop')).toBeDefined()
+    expect(screen.getByText('CI pipeline')).toBeDefined()
+    // Tombstoned: a status badge instead of a live Revoke action.
+    expect(screen.getByText('Revoked')).toBeDefined()
+    // Only the active row still offers Revoke.
+    expect(screen.getAllByRole('button', { name: 'Revoke' })).toHaveLength(1)
+  })
+
+  // "last used" is half the slice title and had no assertion — every cell in the row could have
+  // been replaced with a literal and the suite stayed green.
+  test('a row renders its grants, expiry, secret hint and last-used', async () => {
+    renderPage({ items: [{ ...ACTIVE, lastUsedAt: '2026-01-02T00:00:00.000Z' }] })
+    const row = (await screen.findByText('CI pipeline')).closest('tr')
+    if (!row) throw new Error('row not found')
+    const text = row.textContent ?? ''
+    expect(text).toContain('glk_…4mR2')
+    expect(text).toContain('2099-01-01')
+    expect(text.toLowerCase()).toContain('all owned')
+    expect(text).not.toContain('Never used')
+  })
+
+  test('a key that has never been used says so rather than rendering an empty cell', async () => {
+    renderPage({ items: [ACTIVE] })
+    const row = (await screen.findByText('CI pipeline')).closest('tr')
+    expect(row?.textContent).toContain('Never used')
+  })
+
+  // The other half of the tombstone: both fixtures expire in 2099, so the expired branch — the
+  // 'Expired' badge and the suppressed Revoke — never executed.
+  test('an EXPIRED key is inert too: badge shown, Revoke withheld', async () => {
+    renderPage({ items: [{ ...ACTIVE, id: 'k-stale', name: 'Stale key', expiresAt: '2020-01-01T00:00:00.000Z' }] })
+    expect(await screen.findByText('Stale key')).toBeDefined()
+    expect(screen.getByText('Expired')).toBeDefined()
+    expect(screen.queryByRole('button', { name: 'Revoke' })).toBeNull()
+  })
+
+  test('revoking asks for confirmation before it issues the DELETE', async () => {
+    const calls = stubDelete()
+    renderPage({ items: [ACTIVE] })
+    fireEvent.click(await screen.findByRole('button', { name: 'Revoke' }))
+
+    const dialog = await screen.findByRole('alertdialog')
+    expect(within(dialog).getByText(/Revoke "CI pipeline"\?/)).toBeDefined()
+    // The confirm click hasn't happened yet — no request fired just from opening the dialog.
+    expect(calls).toEqual([])
+
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Revoke' }))
+    await waitFor(() => expect(calls).toEqual(['DELETE /api/api-keys/k-active']))
+    await waitFor(() => expect(screen.getByText('Revoked')).toBeDefined())
+  })
+})

--- a/packages/web/src/routes/settings-keys.tsx
+++ b/packages/web/src/routes/settings-keys.tsx
@@ -1,0 +1,125 @@
+import { useState } from 'react'
+import { KeyRound, Plus } from 'lucide-react'
+import { Link, type LoaderFunctionArgs, useLoaderData } from 'react-router'
+import { toast } from 'sonner'
+import { ApiKeyDialog } from '@/components/ApiKeyDialog'
+import { ConfirmDialog } from '@/components/ConfirmDialog'
+import { EmptyState, PageHeader } from '@/components/states'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
+import { api, ApiError } from '@/lib/api'
+import { toLogin } from '@/lib/nav'
+import { isoDate, timeAgo } from '@/lib/time'
+import type { ApiKeyGrants, ApiKeyItem } from '@/lib/types'
+
+// GET /api/api-keys — see packages/api/src/routes/api-keys.ts for the full item shape.
+export interface ApiKeyListData {
+  items: ApiKeyItem[]
+}
+
+export async function loader({ request }: LoaderFunctionArgs): Promise<ApiKeyListData> {
+  try {
+    return await api.get<ApiKeyListData>('/api/api-keys')
+  } catch (err) {
+    if (err instanceof ApiError && err.status === 401) throw toLogin(request)
+    throw err
+  }
+}
+
+// Tombstone model, matching the server (routes/api-keys.ts GET comment): revoked and expired keys
+// stay in the list rather than disappearing, styled inert with no revoke action left to take.
+function isInert(key: ApiKeyItem): boolean {
+  return key.revokedAt !== null || new Date(key.expiresAt).getTime() <= Date.now()
+}
+
+function grantsSummary(grants: ApiKeyGrants): string {
+  const parts: string[] = []
+  if (grants.control) parts.push('Manage sites')
+  if (!grants.data) parts.push('No data access')
+  else if (grants.data.scope.kind === 'all-owned') parts.push('All owned sites')
+  else {
+    const n = grants.data.scope.siteIds.length
+    parts.push(`${n} site${n === 1 ? '' : 's'}`)
+  }
+  return parts.join(' · ')
+}
+
+export function Component() {
+  const { items } = useLoaderData() as ApiKeyListData
+  const [keys, setKeys] = useState(items)
+  const [dialogOpen, setDialogOpen] = useState(false)
+
+  return (
+    <div className="mx-auto max-w-2xl">
+      <PageHeader title="API Keys" description="Keys for scripting against the Glance API.">
+        <Link to="/docs/api-keys" className="font-medium text-primary text-sm hover:underline">
+          How keys work
+        </Link>
+        <Button onClick={() => setDialogOpen(true)}>
+          <Plus /> New key
+        </Button>
+      </PageHeader>
+      <div className="mt-8">
+        {keys.length === 0 ? (
+          <EmptyState icon={KeyRound} title="No API keys yet." />
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Name</TableHead>
+                <TableHead>Grants</TableHead>
+                <TableHead>Expires</TableHead>
+                <TableHead>Last used</TableHead>
+                <TableHead>Key</TableHead>
+                <TableHead />
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {keys.map((key) => {
+                const inert = isInert(key)
+                return (
+                  <TableRow key={key.id} className={inert ? 'opacity-50' : undefined}>
+                    <TableCell className="font-medium">{key.name}</TableCell>
+                    <TableCell className="text-muted-foreground">{grantsSummary(key.grants)}</TableCell>
+                    <TableCell className="text-muted-foreground">{isoDate(key.expiresAt)}</TableCell>
+                    <TableCell className="text-muted-foreground">
+                      {key.lastUsedAt ? timeAgo(key.lastUsedAt) : 'Never used'}
+                    </TableCell>
+                    <TableCell className="font-mono text-xs">{key.secretHint}</TableCell>
+                    <TableCell className="text-right">
+                      {inert ? (
+                        <Badge variant="secondary">{key.revokedAt ? 'Revoked' : 'Expired'}</Badge>
+                      ) : (
+                        <ConfirmDialog
+                          title={`Revoke "${key.name}"?`}
+                          description="Anything using this key stops working immediately. This can't be undone."
+                          confirmLabel="Revoke"
+                          destructive
+                          onConfirm={async () => {
+                            // Idempotent on the server: revoking an already-revoked key still
+                            // succeeds, so a stale double-click here is harmless.
+                            await api.delete(`/api/api-keys/${key.id}`)
+                            setKeys((ks) =>
+                              ks.map((k) => (k.id === key.id ? { ...k, revokedAt: new Date().toISOString() } : k)),
+                            )
+                            toast.success('Key revoked')
+                          }}
+                        >
+                          <Button variant="outline" size="sm">
+                            Revoke
+                          </Button>
+                        </ConfirmDialog>
+                      )}
+                    </TableCell>
+                  </TableRow>
+                )
+              })}
+            </TableBody>
+          </Table>
+        )}
+      </div>
+      <ApiKeyDialog open={dialogOpen} onOpenChange={setDialogOpen} onMinted={(key) => setKeys((ks) => [key, ...ks])} />
+    </div>
+  )
+}


### PR DESCRIPTION
Closes #113.

A key authenticates the **control plane** and exchanges itself for the same 300-second data token the CLI already mints — so `/api/_data` changes by zero lines. That property is what the whole design buys, and it holds: the data plane is untouched.

Plan, per-phase journal and the full triage record: https://glance.plivo.com/glance/api-keys-progress

## What ships

- **Credential core** — `api_keys` (migrations 0025/0026), `glk_`-prefixed 32-byte secrets stored only as SHA-256. `readCredential` returns *how* a request authenticated, not just who; a `glk_` bearer is prefix-dispatched to D1 and never falls through to the KV CLI store, in either direction.
- **Authority limits** — a key may create and deploy sites, never delete them. The data grant is intersected with the caller's own access at the mint route, so the ceiling can only ever narrow.
- **Mint / list / revoke** — the secret is shown exactly once; expiry is derived server-side from a fixed duration set and a body-supplied `expiresAt` is ignored outright; revoking someone else's key is a 404, not a 403.
- **Both revocation gaps closed** — the offboarding kill-switch now revokes D1 keys as well as KV tokens, and logout no longer reports success for a credential it did not revoke.
- **`GLANCE_TOKEN`** — the CLI can finally accept a key at all; `glance login` is interactive and CI cannot run it.
- **`/settings/keys` and `/docs/api-keys`.**

## Two decisions worth a reviewer's attention

**`grants.control` is enforced, not decorative.** The final review caught it stored, validated, shown as an opt-in checkbox and documented — and read by nothing. A key minted with that box unticked had the entire control plane. `requireControlGrant` now gates every state-changing control route on it. It gates *mutation, not access*: a data-only key still reads and still mints data tokens.

**`docs` is now a reserved slug, and that is broader than the route needs.** `isValidSlug` gates **site** slugs too, so `POST /api/sites` with `siteSlug: 'docs'` now 400s and a `docs/` folder's auto-slug gets suffixed. The collision only exists at the *space* level. Reserving it was the explicit ruling and it ships as ruled, but `docs` is a likelier site name than the other reserved words — worth a second opinion. Verified before landing: `GET /api/spaces/docs` is 404 on the live instance, so no existing space is stranded.

## Known and deliberate

A revoked key's already-minted data token stays valid for its remaining ≤300s, and a live WebSocket keeps its snapshot capabilities until the same expiry. Closing that window means putting the key id inside derived tokens and rechecking D1 on every data request — it would destroy the zero-line data-plane property. Documented, not fixed.

KV device tokens coexist with D1 keys rather than being migrated; both reviewers recommended it.

## Verification

1169 api / 344 web / `go test ./...` green. Every slice was implemented test-first and then certified by a *different* agent that re-ran the suite and mutation-checked the new tests — broke the source, confirmed the test went red, restored. Several slices failed that certification and were repaired before landing; the notable catches are in the tracker's Journal, including three tests that passed for the wrong reason and one regression this branch introduced and then fixed.

`bun run typecheck` is red repo-wide on `main` too — `worker-configuration.d.ts` is generated by `cf-typegen` and gitignored, so it cannot gate this branch. `bun test` and `bun run lint` can and do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
