### PR TITLE
docs(whats-new): announce realtime comments, featured

### DIFF
--- a/packages/api/src/routes/whats-new.test.ts
+++ b/packages/api/src/routes/whats-new.test.ts
@@ -14,10 +14,11 @@ import { whatsNew } from './whats-new'
 const APP_URL = 'https://glance.example.com'
 // A watermark inside the real catalog's range: older than 2026-07-01 (voice) but newer than
 // 2026-06-20 (links). Everything published after it counts as unread.
-// CATALOG-COUPLED: the unreadCount literals below (`5`) = the number of releases dated after MID.
+// CATALOG-COUPLED: the unreadCount literals below (`7`) = the number of releases dated after MID.
 // Adding a release note NEWER than MID bumps them — rebuild with `bun run build:whatsnew`, then
 // bump these. (links 06-20 | MID | voice 07-01, comments-tab 07-11, fork 07-14, tldr 07-14T18,
-// live-data 07-29 → 5 unread.)
+// live-data 07-29, star-a-page 07-29T18, realtime-comments 08-01 → 7 unread. The inventory was
+// already one short of the literal before this note landed — star-a-page was never added to it.)
 const MID = '2026-06-25T00:00:00.000Z'
 
 function setup() {
@@ -60,7 +61,7 @@ describe('C6 route.auth.401 — unauthenticated GET and POST both 401, watermark
 })
 
 describe('C7 route.get.exactJSON — exact ordered items, unreadCount, throughDate', () => {
-  test('mid watermark → exact slugs/dates/bodies + unreadCount 6 + throughDate===newest', async () => {
+  test('mid watermark → exact slugs/dates/bodies + unreadCount 7 + throughDate===newest', async () => {
     const { app, db, kv, env } = setup()
     const id = await seedUser(db, { id: 'u1' })
     await db.update(users).set({ lastSeenReleaseAt: MID }).where(eq(users.id, id))
@@ -69,7 +70,7 @@ describe('C7 route.get.exactJSON — exact ordered items, unreadCount, throughDa
     // Whole-response deep-equal, not key-presence: a dropped item field or an extra top-level key fails.
     expect(await res.json()).toEqual({
       items: JSON.parse(JSON.stringify(RELEASES)),
-      unreadCount: 6,
+      unreadCount: 7,
       throughDate: NEWEST_RELEASE_DATE,
     })
   })
@@ -144,6 +145,6 @@ describe('B3 relogin.noReset — the existing-user branch must not clear an exis
     await findOrCreateUser(db, { SUPERADMIN_EMAIL: 'boss@example.com' } as never, { sub: 'g1', name: 'A2' } as never, 'a@example.com')
     expect(await getWatermark(db, first.id)).toBe(before as string)
     const res = await app.request('/api/whats-new', { headers: await mintBearer(kv, first.id) }, env)
-    expect(((await res.json()) as { unreadCount: number }).unreadCount).toBe(6)
+    expect(((await res.json()) as { unreadCount: number }).unreadCount).toBe(7)
   })
 })

--- a/packages/api/src/whats-new/catalog.ts
+++ b/packages/api/src/whats-new/catalog.ts
@@ -4,6 +4,13 @@ import type { Release } from './bake'
 
 export const RELEASES: Release[] = [
   {
+    "slug": "realtime-comments",
+    "title": "Comments arrive live",
+    "date": "2026-08-01T10:00:00.000Z",
+    "featured": true,
+    "bodyHtml": "<p>A comment someone else leaves now shows up while you&#39;re reading. No refresh, no polling, no &quot;let me reload and check&quot;.</p>\n<ul>\n<li><strong>New comments and replies appear as they&#39;re posted</strong> — in the panel and on the page</li>\n<li><strong>You only ever receive what you could already open.</strong> The live feed is gated exactly like the page is; it is not a second way in</li>\n<li><strong>Leave a tab open and it stays honest.</strong> If the connection drops it reconnects and re-reads the thread, so an old tab catches up instead of quietly going stale</li>\n<li><strong>See a reply coming.</strong> While someone is typing a reply, the thread says so</li>\n<li><strong>Nothing to turn on</strong> — open a page with comments and it&#39;s already listening</li>\n</ul>\n<p>The connection renews itself every few minutes. A comment that lands exactly on a renewal arrives a beat later rather than instantly — everything else is immediate.</p>\n"
+  },
+  {
     "slug": "star-a-page",
     "title": "Star a page",
     "image": "star-a-page.png",
@@ -61,4 +68,4 @@ export const RELEASES: Release[] = [
   }
 ]
 
-export const NEWEST_RELEASE_DATE: string | null = "2026-07-29T18:00:00.000Z"
+export const NEWEST_RELEASE_DATE: string | null = "2026-08-01T10:00:00.000Z"

--- a/packages/api/src/whats-new/notes/2026-08-01-realtime-comments.md
+++ b/packages/api/src/whats-new/notes/2026-08-01-realtime-comments.md
@@ -1,0 +1,15 @@
+---
+title: Comments arrive live
+slug: realtime-comments
+date: 2026-08-01T10:00:00.000Z
+featured: true
+---
+A comment someone else leaves now shows up while you're reading. No refresh, no polling, no "let me reload and check".
+
+- **New comments and replies appear as they're posted** — in the panel and on the page
+- **You only ever receive what you could already open.** The live feed is gated exactly like the page is; it is not a second way in
+- **Leave a tab open and it stays honest.** If the connection drops it reconnects and re-reads the thread, so an old tab catches up instead of quietly going stale
+- **See a reply coming.** While someone is typing a reply, the thread says so
+- **Nothing to turn on** — open a page with comments and it's already listening
+
+The connection renews itself every few minutes. A comment that lands exactly on a renewal arrives a beat later rather than instantly — everything else is immediate.


### PR DESCRIPTION
Announces the realtime comments rail shipped in #121 (already on `main` as
`d244ed5`) in the in-app What's New feed, featured.

The feed has no date gating — `listReleases` returns the whole catalog — so
this note goes live the moment it merges. That is why it is its own PR rather
than part of #121: carried there, it would have announced the feature at the
same instant the code landed, with no window to verify anything first.

## MERGE ORDER — read before merging

**#120 should merge first.** It touches the same three things this does:
`catalog.ts` (generated), the `unreadCount` literals in `whats-new.test.ts`,
and nothing else in common. Whichever of the two lands second needs:

1. `cd packages/api && bun run build:whatsnew` — regenerates `catalog.ts`.
   Never hand-edit it.
2. Re-bump the two catalog-coupled literals in `routes/whats-new.test.ts`
   (C7 `route.get.exactJSON`, B3 `relogin.noReset`) — they equal the number of
   releases dated after `MID` (2026-06-25), so #120's four notes push this
   PR's `7` to `11`.

This is documented maintenance, not a weakened test.

## Notes

- The copy mentions the typing indicator, which the draft deliberately left
  out in case Phase 4 was cut. It wasn't — typing shipped in #121 — so a
  featured note that omitted it would undersell the release.
- The header inventory comment in `whats-new.test.ts` was already one short of
  its own literal (`star-a-page` was never added when it landed). Corrected to
  the full list rather than incremented, so the next person can trust it.
- `bun run test` 1656 pass / 0 fail, typecheck clean, lint unchanged (1
  pre-existing info in a bench script; `catalog.ts` raised nothing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)