### PR TITLE
docs(api-keys): put the reader's own origin in the curl examples

### DIFF
--- a/packages/web/src/routes/docs-api-keys.test.tsx
+++ b/packages/web/src/routes/docs-api-keys.test.tsx
@@ -37,6 +37,17 @@ describe('docs/api-keys', () => {
     expect(text?.toLowerCase()).toContain('delete')
   })
 
+  // Every curl on this page is meant to be copy-pasteable against THIS instance — a `<origin>`
+  // placeholder creeping back in silently turns them into commands that 404 for whoever runs them.
+  test('the curl examples carry the real instance origin, not a placeholder', async () => {
+    renderDocs()
+    const blocks = (await screen.findByRole('heading', { name: 'API Keys' })).closest('div')?.parentElement
+    const text = blocks?.textContent ?? ''
+    expect(text).not.toContain('<origin>')
+    expect(text).toContain(`${window.location.origin}/api/install`)
+    expect(text).toContain(`${window.location.origin}/api/data-token/`)
+  })
+
   // The reason a script reaches for a key at all is reading/writing a page's data, and that needs
   // BOTH halves: the mint (a key is refused on the data plane) and the CRUD surface it unlocks.
   // Documenting one without the other leaves a reader stuck, so assert the pair.

--- a/packages/web/src/routes/docs-api-keys.tsx
+++ b/packages/web/src/routes/docs-api-keys.tsx
@@ -48,6 +48,12 @@ function Section({ title, children }: { title: string; children: React.ReactNode
 }
 
 export function Component() {
+  // The reader's own instance, so every command below is copy-pasteable as-is rather than a
+  // placeholder they have to substitute. Same treatment as the install command in GettingStarted:
+  // the SPA is served FROM the app origin, so this is always the right host — and the source stays
+  // vendor-neutral for a self-hosted deploy.
+  const origin = window.location.origin
+
   return (
     <div className="mx-auto max-w-2xl">
       <div className="mb-8 flex items-center gap-2">
@@ -80,7 +86,7 @@ export function Component() {
             entirely:
           </p>
           <CodeBlock>
-            {'curl -fsSL <origin>/api/install | sh\nexport GLANCE_TOKEN=glk_...\nglance deploy ./my-site'}
+            {`curl -fsSL ${origin}/api/install | sh\nexport GLANCE_TOKEN=glk_...\nglance deploy ./my-site`}
           </CodeBlock>
           <p>
             The CLI reads its target instance from <Code>~/.glance/config.json</Code>, not from the key, so the install
@@ -111,10 +117,10 @@ export function Component() {
             The CLI is a convenience — a key is a bearer token against the same HTTP API. Send it as an{' '}
             <Code>Authorization</Code> header:
           </p>
-          <CodeBlock>{'curl -H "Authorization: Bearer $GLANCE_TOKEN" \\\n  <origin>/api/sites/mine'}</CodeBlock>
+          <CodeBlock>{`curl -H "Authorization: Bearer $GLANCE_TOKEN" \\\n  ${origin}/api/sites/mine`}</CodeBlock>
           <p>Deploying is a multipart upload, one form field per file:</p>
           <CodeBlock>
-            {`curl -X POST "<origin>/api/upload/<space>/<site>" \\
+            {`curl -X POST "${origin}/api/upload/<space>/<site>" \\
   -H "Authorization: Bearer $GLANCE_TOKEN" \\
   -F "files=@dist/index.html;filename=index.html" \\
   -F "visibility=team"`}
@@ -139,7 +145,7 @@ export function Component() {
           <CodeBlock>
             {`TOKEN=$(curl -fsS -X POST \\
   -H "Authorization: Bearer $GLANCE_TOKEN" \\
-  "<origin>/api/data-token/<space>/<site>" | jq -r .token)`}
+  "${origin}/api/data-token/<space>/<site>" | jq -r .token)`}
           </CodeBlock>
           <p>
             That token lasts <strong className="text-foreground">300 seconds</strong> — mint one per run, never bake it
@@ -171,7 +177,7 @@ export function Component() {
   -H "Authorization: Bearer $TOKEN" \\
   -H "Content-Type: application/json" \\
   -d '{"signups": 412, "mrr": 91400}' \\
-  "<origin>/api/_data/shared-metrics/today"`}
+  "${origin}/api/_data/shared-metrics/today"`}
           </CodeBlock>
           <p>
             <strong className="text-foreground">Two rules worth knowing.</strong> Reads are scoped to your own rows by


### PR DESCRIPTION
Follow-up to #124. Every curl on `/docs/api-keys` carried a literal `<origin>` the reader had to substitute by hand, so nothing on the page was copy-pasteable.

No env var needed: the SPA is served **from** the app origin, so `window.location.origin` is always the right host. `GettingStarted.tsx:42` already builds its install command exactly this way — this just follows the existing convention across all five code blocks.

Renders `https://glance.plivo.com/api/install` on our instance and the correct host on any self-hosted deploy, while the source stays vendor-neutral. `<space>`/`<site>` stay as placeholders — those are per-user.

A test pins it so a placeholder can't creep back in.

## Checks

- `bun run test` — web 420 pass, 0 fail
- `bun run typecheck` — clean
- Verified in a browser: every `<pre>` renders the live origin

🤖 Generated with [Claude Code](https://claude.com/claude-code)