### PR TITLE
feat(comments): delete leaves a tombstone only where one means something (#116)

### DIFF
--- a/packages/api/src/db/comments.ts
+++ b/packages/api/src/db/comments.ts
@@ -456,13 +456,44 @@ export async function editComment(
 /** Soft delete: keep the row (and thread shape); body is redacted on read. Bumps the thread so
  *  the change resurfaces in the updatedAt-sorted rail. Voice asymmetry: the audio is hard-deleted
  *  (the caller fires the R2 delete), so we null `audioKey` here — the row survives redacted, but
- *  hasAudio flips false and the audio route 404s. */
+ *  hasAudio flips false and the audio route 404s.
+ *
+ *  #116 narrowed WHEN this runs: a tombstone is only worth rendering when it holds the context for
+ *  replies that are still there, so this is now the OPENING comment's delete alone. Everything else
+ *  takes `hardDeleteComment` / `deleteThread` below. */
 export async function deleteComment(db: DrizzleD1Database, threadId: string, commentId: string): Promise<void> {
   const ts = now()
   await db.batch([
     db.update(comments).set({ deletedAt: ts, audioKey: null }).where(eq(comments.id, commentId)),
     touchThread(db, threadId, ts),
   ])
+}
+
+/** Hard delete one comment: the row goes, and with it its reactions (comment_reactions.commentId
+ *  cascades). Notifications pointing at it survive — notifications.commentId is `set null`, and the
+ *  row's denormalized siteLabel/filePath/snippet keep it readable; only its deep link stops
+ *  focusing a thread. Same thread bump as the soft path, for the same reason. */
+export async function hardDeleteComment(db: DrizzleD1Database, threadId: string, commentId: string): Promise<void> {
+  await db.batch([db.delete(comments).where(eq(comments.id, commentId)), touchThread(db, threadId, now())])
+}
+
+/** Delete a whole thread — for when its last meaningful comment goes (#116 case 3). One statement:
+ *  comments.threadId cascades from comment_threads, so the thread's comments (and their reactions,
+ *  cascading again) go with it. No thread bump: there is no thread left to resurface. */
+export async function deleteThread(db: DrizzleD1Database, threadId: string): Promise<void> {
+  await db.delete(commentThreads).where(eq(commentThreads.id, threadId))
+}
+
+/** Statement: the thread's comments in the SAME order the list route assembles them (createdAt,
+ *  rowid), so `[0]` is the opening comment by the one definition the rail already renders. Id-keyed
+ *  from the URL, so it fuses into the delete route's access batch. Only what the decision needs:
+ *  identity, tombstone state, and the audio each row would orphan. */
+export function commentsByThreadStmt(db: DrizzleD1Database, threadId: string) {
+  return db
+    .select({ id: comments.id, deletedAt: comments.deletedAt, audioKey: comments.audioKey })
+    .from(comments)
+    .where(eq(comments.threadId, threadId))
+    .orderBy(comments.createdAt, sql`"comments".rowid`)
 }
 
 // --- S9c: id-keyed target-read statements for fusing into the access-facts batch. The ids come

--- a/packages/api/src/routes/comments-access.test.ts
+++ b/packages/api/src/routes/comments-access.test.ts
@@ -411,14 +411,28 @@ describe('comments routes — T9.5 mutations fuse target reads into the access b
     expect(writes(db)).toBe(0)
   })
 
-  test('delete: gate batch of 7, then ONLY the write batch of 2 (text comment — no R2)', async () => {
+  // #116 gave delete a branch, so it gets both arms. Its gate batch is 8, not 7: the thread's
+  // comment list rides it (id-keyed from the URL like every other fused read), because WHICH delete
+  // this is depends on the target's place in that list. Total D1 requests are unchanged either way
+  // — 3 — since the branch it feeds writes at most one batch.
+  test('delete: gate batch of 8, then ONLY the write — 3 D1 requests on both arms (text comment, no R2)', async () => {
     const { app, env, db, kv } = makeRouteApp()
     const owner = await mintUser(db, kv, 'owner')
     const { threadId, commentId } = await seedCommentedSite(db, owner)
+    const del = (id: string) =>
+      app.request(url('acme', 'doc', `/${threadId}/messages/${id}`), { method: 'DELETE', headers: auth(owner) }, env)
+
+    // A reply present ⇒ the opening is soft-deleted: gate (8) + deleteComment's write batch (2).
+    const replyId = await seedComment(db, { threadId, authorId: owner, body: 'a reply' })
     db.resetCounters()
-    const res = await app.request(url('acme', 'doc', `/${threadId}/messages/${commentId}`), { method: 'DELETE', headers: auth(owner) }, env)
-    expect(res.status).toBe(200)
-    shape(db, 1, 2, 9)
+    expect((await del(replyId)).status).toBe(200) // a reply — the hard-delete arm, same write batch
+    shape(db, 1, 2, 10)
+
+    // Nothing else left ⇒ the thread goes, in ONE statement (comments cascade off it), so the write
+    // is a loose delete rather than a batch. Still 1 + 1 + 1 requests.
+    db.resetCounters()
+    expect((await del(commentId)).status).toBe(200)
+    shape(db, 2, 1, 8)
   })
 
   test('voice-audio GET: pre-R2 D1 = 2 requests total (1 loose + 1 fused batch of 7), one R2 get', async () => {

--- a/packages/api/src/routes/comments-reactions.test.ts
+++ b/packages/api/src/routes/comments-reactions.test.ts
@@ -198,6 +198,9 @@ describe('comment reactions — the access gate is the message routes’ own', (
 
   test('a SOFT-DELETED comment takes no reaction — same 404 edit and delete already give it', async () => {
     const ctx = await setup()
+    // A reply is what leaves a tombstone behind at all (#116): delete the opening of a thread with
+    // nothing else in it and the thread goes, taking the very row this test is about.
+    await seedComment(ctx.db, { threadId: ctx.threadId, authorId: ctx.owner, body: 'a reply' })
     await react(ctx, 'member', ctx, { emoji: '🔥' })
     const gone = await ctx.app.request(
       `/api/sites/acme/doc/comments/${ctx.threadId}/messages/${ctx.commentId}`,

--- a/packages/api/src/routes/comments.test.ts
+++ b/packages/api/src/routes/comments.test.ts
@@ -1,7 +1,21 @@
 import { describe, expect, test } from 'bun:test'
+import { eq } from 'drizzle-orm'
 import { Hono } from 'hono'
+import { commentReactions, comments as commentRows, notifications } from '../db/schema'
 import { requireSameOrigin } from '../middleware/auth'
-import { makeDb, makeKv, makeR2, seedComment, seedFile, seedMember, seedSite, seedSpace, seedThread, seedUser } from '../test/harness'
+import {
+  makeDb,
+  makeKv,
+  makeR2,
+  seedComment,
+  seedFile,
+  seedMember,
+  seedNotification,
+  seedSite,
+  seedSpace,
+  seedThread,
+  seedUser,
+} from '../test/harness'
 import type { AppEnv } from '../types'
 import { comments } from './comments'
 import { sites } from './sites'
@@ -171,11 +185,114 @@ describe('comments routes — auth / access / authz', () => {
     const authorDelete = await app.request(msgPath, { method: 'DELETE', headers: auth(member) }, env)
     expect(authorDelete.status).toBe(200)
 
-    // soft-delete-keeps-thread-shape: the comment row survives, body redacted.
+    // #116: that comment was the thread's only one, so there is no tombstone worth rendering and
+    // the thread goes with it. (The surviving tombstone case has its own describe below.)
     const after = await (await app.request(url('?filePath=index.html'), { headers: auth(owner) }, env)).json()
-    expect(after[0].comments).toHaveLength(1)
-    expect(after[0].comments[0].deleted).toBe(true)
-    expect(after[0].comments[0].body).toBeNull()
+    expect(after).toEqual([])
+  })
+})
+
+// #116 — a tombstone is noise unless it holds the context for replies that are still there, so it
+// stopped being what every delete leaves behind. The three outcomes are decided from the target's
+// place in its thread, so each case is driven through the real DELETE route and read back through
+// the real list route: what the rail would actually render.
+describe('comments routes — delete leaves a tombstone only where one carries meaning (#116)', () => {
+  /** A thread of `bodies`, all authored by a fresh owner who can therefore delete any of them. */
+  async function seedConversation(bodies: string[]) {
+    const ctx = await setup()
+    const { db, r2, kv } = ctx
+    const owner = await mintUser(db, kv, { id: 'owner' })
+    const { siteId } = await seedSiteWithFile(db, r2, owner)
+    const threadId = await seedThread(db, { siteId, filePath: 'index.html', createdBy: owner })
+    const ids: string[] = []
+    for (const body of bodies) ids.push(await seedComment(db, { threadId, authorId: owner, body }))
+    const del = (commentId: string) =>
+      ctx.app.request(url(`/${threadId}/messages/${commentId}`), { method: 'DELETE', headers: auth(owner) }, ctx.env)
+    const list = async () => await (await ctx.app.request(url('?filePath=index.html'), { headers: auth(owner) }, ctx.env)).json()
+    return { ...ctx, owner, threadId, ids, del, list }
+  }
+
+  test('a reply is hard-deleted — the row goes, and the rest of the thread is untouched', async () => {
+    const { ids, del, list } = await seedConversation(['the opening', 'a reply', 'another reply'])
+    expect((await del(ids[1])).status).toBe(200)
+
+    const [thread] = await list()
+    expect(thread.comments.map((c: { body: string | null }) => c.body)).toEqual(['the opening', 'another reply'])
+  })
+
+  test('the opening comment is soft-deleted while replies remain — the one surviving tombstone', async () => {
+    const { ids, del, list } = await seedConversation(['the opening', 'a reply'])
+    expect((await del(ids[0])).status).toBe(200)
+
+    const [thread] = await list()
+    expect(thread.comments).toHaveLength(2)
+    expect(thread.comments[0]).toMatchObject({ deleted: true, body: null })
+    expect(thread.comments[1]).toMatchObject({ deleted: false, body: 'a reply' })
+  })
+
+  test('the opening comment with nothing else in the thread takes the whole thread with it', async () => {
+    const { ids, del, list } = await seedConversation(['the only comment'])
+    expect((await del(ids[0])).status).toBe(200)
+    expect(await list()).toEqual([]) // thread gone ⇒ so is its on-page highlight
+  })
+
+  test('deleting the LAST reply off an already-tombstoned opening takes the thread too', async () => {
+    // The edge the rule has to name: a thread of nothing but tombstones is the same noise, however
+    // it got there. Two deletes, in the order a real conversation dies.
+    const { ids, del, list } = await seedConversation(['the opening', 'the last reply'])
+    expect((await del(ids[0])).status).toBe(200)
+    expect((await list())[0].comments).toHaveLength(2) // tombstone + reply, still worth rendering
+
+    expect((await del(ids[1])).status).toBe(200)
+    expect(await list()).toEqual([])
+  })
+
+  test('a hard-deleted comment takes its reactions and leaves its notification readable', async () => {
+    // The FK story the rule rests on: comment_reactions cascades (nothing to clean up), while
+    // notifications.commentId is `set null` — the row survives with its denormalized text, and only
+    // its deep link stops focusing a thread.
+    const { db, owner, threadId, ids, del } = await seedConversation(['the opening', 'a reply'])
+    await db.insert(commentReactions).values({ commentId: ids[1], userId: owner, emoji: '👍', createdAt: new Date().toISOString() })
+    const notificationId = await seedNotification(db, {
+      recipientId: owner,
+      threadId,
+      commentId: ids[1],
+      snippet: 'a reply',
+    })
+
+    expect((await del(ids[1])).status).toBe(200)
+
+    expect(await db.select().from(commentReactions).where(eq(commentReactions.commentId, ids[1]))).toEqual([])
+    const [note] = await db.select().from(notifications).where(eq(notifications.id, notificationId))
+    expect(note).toMatchObject({ commentId: null, threadId, snippet: 'a reply' }) // still readable
+  })
+
+  test('a thread delete sweeps the recordings on the rows it cascades away, not just the target’s', async () => {
+    // The one case that can orphan R2 objects the old route never had to name: the thread delete
+    // takes SIBLING rows with it, so their keys must be collected before the write. Reachable on a
+    // pre-W2-14 tombstone — one soft-deleted back when the delete did not null `audioKey`, so the
+    // row is redacted but its recording is still sitting in R2 under a row about to disappear.
+    const { db, r2, owner, threadId, ids, del } = await seedConversation(['the opening'])
+    await db
+      .update(commentRows)
+      .set({ deletedAt: new Date().toISOString(), audioKey: 'comment-audio/legacy.webm' })
+      .where(eq(commentRows.id, ids[0]))
+    const replyId = await seedComment(db, { threadId, authorId: owner, body: 'the last reply' })
+    await r2.put('comment-audio/legacy.webm', new Uint8Array([1]))
+    expect(r2.store.has('comment-audio/legacy.webm')).toBe(true)
+
+    // Nothing live is left behind ⇒ the thread goes, and the tombstone's audio goes with the row.
+    expect((await del(replyId)).status).toBe(200)
+    expect(r2.store.has('comment-audio/legacy.webm')).toBe(false)
+  })
+
+  test('a hard-deleted voice reply does not orphan its own recording', async () => {
+    const { db, r2, owner, threadId, del } = await seedConversation(['the opening'])
+    const replyId = await seedComment(db, { threadId, authorId: owner, body: 'transcript', audioKey: 'comment-audio/reply.webm' })
+    await r2.put('comment-audio/reply.webm', new Uint8Array([2]))
+
+    expect((await del(replyId)).status).toBe(200)
+    expect(r2.store.has('comment-audio/reply.webm')).toBe(false)
   })
 })
 
@@ -466,6 +583,9 @@ describe('comments routes — input sanitization + lifecycle guards', () => {
     const { siteId } = await seedSiteWithFile(db, r2, owner)
     const threadId = await seedThread(db, { siteId, filePath: 'index.html', createdBy: owner })
     const commentId = await seedComment(db, { threadId, authorId: owner, body: 'mine' })
+    // A reply is what keeps the delete on the SOFT path (#116) — without one the thread would go
+    // and these 404s would prove nothing about the tombstone guard.
+    await seedComment(db, { threadId, authorId: owner, body: 'still here' })
     const path = url(`/${threadId}/messages/${commentId}`)
 
     const del = await app.request(path, { method: 'DELETE', headers: auth(owner) }, env)

--- a/packages/api/src/routes/comments.ts
+++ b/packages/api/src/routes/comments.ts
@@ -8,10 +8,13 @@ import {
   buildCommentCreatedView,
   buildThreadCreatedView,
   commentByIdStmt,
+  commentsByThreadStmt,
   commentsWithAuthorsBySlugsStmt,
   createThread,
   deleteComment,
+  deleteThread,
   editComment,
+  hardDeleteComment,
   type ReactionRow,
   reactionsByComment,
   reactionsByCommentStmt,
@@ -756,17 +759,42 @@ comments.patch('/:space/:site/comments/:threadId/messages/:commentId', async (c)
   return c.json({ ok: true })
 })
 
-// DELETE — soft-delete a comment (author only, like edit). S9c fused pre-write batch.
+// DELETE — remove a comment (author only, like edit). S9c fused pre-write batch, now carrying the
+// thread's whole comment list: which of the three deletes this is depends on the target's place in
+// that list, and the list is id-keyed from the URL like everything else riding the batch.
+//
+// #116 — a tombstone is only worth rendering where it holds the context for replies that are still
+// there, so it stopped being the universal answer:
+//   • nothing meaningful left behind  → the THREAD goes, and its on-page highlight with it. That
+//     covers both "the opening comment was the only one" and the edge where the last live reply is
+//     deleted off an already-tombstoned opening — a thread of nothing but tombstones is the same
+//     noise, however it got there.
+//   • the target IS the opening comment  → soft delete, the one surviving tombstone case.
+//   • anything else (a reply)            → the row goes.
 comments.delete('/:space/:site/comments/:threadId/messages/:commentId', async (c) => {
-  const gate = await siteWithUrlComment(c)
+  const { threadId } = c.req.param()
+  const gate = await siteWithUrlComment(c, commentsByThreadStmt(c.get('db'), threadId))
   if (gate instanceof Response) return gate
   const { comment } = gate
   if (comment.authorId !== c.get('user').id) return c.json({ error: 'forbidden' }, 403)
-  // Capture the audio key before the delete nulls it, then hard-delete the recording off the
-  // serving path — the row survives redacted, the audio does not (documented voice asymmetry).
-  const { audioKey } = comment
-  await deleteComment(c.get('db'), comment.threadId, comment.id)
-  if (audioKey) await fireAndForget(c, deleteKeys(c.env.GLANCE_FILES, [audioKey]))
+
+  const siblings = gate.extras[0].filter((r) => r.id !== comment.id)
+  // Rows come back in the assembler's order, so the head IS the opening comment.
+  const isOpening = gate.extras[0][0]?.id === comment.id
+  const nothingLeft = siblings.every((r) => r.deletedAt !== null)
+
+  // Every recording about to lose its row, captured BEFORE the write — a soft delete nulls the key
+  // and a cascade takes the sibling rows outright, so after the write there is nothing left to read
+  // it off. Only the thread delete can orphan more than the target's own audio.
+  const audioKeys = [comment.audioKey, ...(nothingLeft ? siblings.map((r) => r.audioKey) : [])].filter(
+    (k): k is string => k !== null,
+  )
+
+  if (nothingLeft) await deleteThread(c.get('db'), comment.threadId)
+  else if (isOpening) await deleteComment(c.get('db'), comment.threadId, comment.id)
+  else await hardDeleteComment(c.get('db'), comment.threadId, comment.id)
+
+  if (audioKeys.length > 0) await fireAndForget(c, deleteKeys(c.env.GLANCE_FILES, audioKeys))
   return c.json({ ok: true })
 })
 


### PR DESCRIPTION
Closes #116.

Deleting a comment always left a tombstone — the row survived with its body redacted and the rail rendered "comment deleted". That is noise in the common case. Tombstones now appear only where they carry meaning: holding the context for replies that are still there.

## The rule

| Case | Behaviour |
| --- | --- |
| A reply is deleted | **Hard delete the row.** No tombstone. |
| The thread's **opening** comment is deleted and other comments remain | **Soft delete** — "Comment deleted". Today's behaviour, and the only case that keeps it. |
| The opening comment is deleted and nothing else remains | **Delete the whole thread**, and its on-page highlight with it. |

The edge case from the issue — an opening comment that is already a tombstone whose *last* remaining reply is then deleted — falls out of the same branch: a thread of nothing but tombstones is the same noise, however it got there. That is why the branches order `nothing-left → is-opening → hard` and not the other way round; an `isOpening`-first check would leave a thread holding two tombstones.

## No schema change, and no dangling rows

Checked against `db/schema.ts`, exactly as the issue laid out:

- `comment_reactions.commentId` → **cascade**. Reactions die with the comment.
- `comments.threadId` → **cascade** from `comment_threads`. Deleting the thread row takes its comments.
- `notifications.commentId` / `.threadId` → **set null**. A hard delete does not dangle: the notification survives with its denormalized `siteLabel`/`filePath`/`snippet` intact, and only its deep link stops focusing a thread.

## One thing the issue did not name

The thread-delete arm can orphan **more than the target's own audio** — the cascade removes sibling rows outright. That is reachable on a pre-W2-14 tombstone: one soft-deleted back when the delete did not null `audioKey`, so the row is redacted but its recording is still sitting in R2 under a row about to disappear. Audio keys are now collected from the whole thread before the write, not just off the target.

## Cost

The three-way decision rides one extra statement fused into the existing access batch (`commentsByThreadStmt`, ordered `createdAt, rowid` so `[0]` is the opening comment by the same definition `assembleThreadViews` uses). Total D1 requests per delete are unchanged at 3 on both arms — the gate batch goes 7 → 8, and the thread delete is a single statement rather than a batch. `comments-access.test.ts` pins both arms.

## Tests

Seven new route-level cases driving each outcome through the real DELETE and reading it back through the real list route. Each was mutation-checked against the old universal soft delete — five go red without the change, and the audio sweep goes red without the sibling collection.

Three existing tests encoded the old contract and were updated, not deleted: `delete-is-author-only` (the thread now disappears), and `edit-deleted-comment-404` plus the reactions tombstone test, which both needed a reply seeded to reach the soft path at all.

No web change: the rail already refetches on mutation, and the "comment deleted" rendering stays for the one surviving case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUPXH8c8atcJPSEiiQk1UL