### PR TITLE
feat(comments): show the C binding on the selection chip

### DIFF
--- a/packages/web/src/components/review/CommentPopover.test.tsx
+++ b/packages/web/src/components/review/CommentPopover.test.tsx
@@ -65,6 +65,17 @@ describe('A2-ui — the selection chip', () => {
     expect(screen.queryByPlaceholderText('Add a comment…')).toBeNull()
   })
 
+  test('the chip advertises the C binding, without renaming itself for a screen reader', () => {
+    // The binding lives inside the content iframe, so the chip is the only place it can be
+    // discovered — it appears in no menu and no command palette (#117). The keycap must not leak
+    // into the button's accessible name, which is what every other test here selects on.
+    render(<Harness />)
+    const chip = screen.getByRole('button', CHIP)
+
+    expect(chip.querySelector('kbd')?.textContent?.trim()).toBe('C')
+    expect(screen.queryByRole('button', { name: 'Comment C' })).toBeNull()
+  })
+
   test('clicking the chip opens the popover with the quote and a Composer', () => {
     render(<Harness />)
     openComposer()

--- a/packages/web/src/components/review/CommentPopover.tsx
+++ b/packages/web/src/components/review/CommentPopover.tsx
@@ -49,6 +49,13 @@ export function CommentPopover({
         >
           <MessageSquarePlus className="size-3.5" />
           Comment
+          {/* The chip is the ONLY place the C binding is discoverable — it lives in the iframe, so
+              it appears in no menu and no palette (#117). Same keycap treatment as AppShell's ⌘K.
+              Hidden on small screens for the same reason that one is: no keyboard, no hint. The
+              button's aria-label already replaces its content, so this is never announced. */}
+          <kbd className="hidden rounded border bg-muted px-1.5 py-px font-mono text-[10px] text-muted-foreground sm:inline">
+            C
+          </kbd>
         </button>
       )}
       {composer && (


### PR DESCRIPTION
Follow-up to #126. The `C` binding shipped with nothing to announce it — and because it lives inside the content iframe, it appears in no menu and no command palette. The chip is the only place it can be discovered at all.

```
┌──────────────────────┐
│ 💬 Comment    [ C ]  │
└──────────────────────┘
```

Same keycap treatment as `AppShell`'s ⌘K (`rounded border bg-muted px-1.5 py-px font-mono text-[10px]`), including `hidden … sm:inline` — no keyboard, no hint.

The button's `aria-label="Comment on selection"` already replaces its content, so the keycap never reaches the accessible name. Pinned by a test, since every other test in that file selects the chip by that name.

**No screenshot attached** — the chip only exists transiently, over a live text selection inside a sandboxed iframe. Say the word and I'll capture it in a real browser against the dev stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUPXH8c8atcJPSEiiQk1UL