### PR TITLE
feat(comments): show the ⌘↵ binding on the composer's submit button

### DIFF
--- a/packages/web/src/components/review/Composer.test.tsx
+++ b/packages/web/src/components/review/Composer.test.tsx
@@ -91,6 +91,51 @@ describe('A — Composer text submit', () => {
   })
 })
 
+// The submit button advertises ⌘↵, so the binding it advertises had better exist — and the keycap
+// must not rename the button, which is how 13 selectors across this suite (and every screen reader)
+// refer to it.
+describe('A — ⌘/Ctrl+Enter submits, and the button says so', () => {
+  const enter = (textarea: HTMLTextAreaElement, mods: Record<string, boolean>) =>
+    fireEvent.keyDown(textarea, { key: 'Enter', ...mods })
+
+  // Separate tests, not a loop: renderDeferred mounts into the shared container, so a second render
+  // in one test leaves two composers and every by-placeholder lookup goes ambiguous.
+  for (const [name, mods] of [
+    ['⌘+Enter', { metaKey: true }],
+    ['Ctrl+Enter', { ctrlKey: true }],
+  ] as const) {
+    test(`${name} submits the draft`, () => {
+      const { onSubmit, textarea } = renderDeferred()
+      type(textarea, DRAFT)
+      enter(textarea, mods)
+      expect(onSubmit).toHaveBeenCalledTimes(1)
+      expect(onSubmit.mock.calls[0]).toEqual([DRAFT, []])
+    })
+  }
+
+  test('a bare Enter does NOT submit — it types a newline, which is what a comment box is for', () => {
+    const { onSubmit, textarea } = renderDeferred()
+    type(textarea, DRAFT)
+    enter(textarea, {})
+    expect(onSubmit).toHaveBeenCalledTimes(0)
+  })
+
+  test('an empty draft is not submittable by keyboard either', () => {
+    const { onSubmit, textarea } = renderDeferred()
+    type(textarea, '   ')
+    enter(textarea, { metaKey: true })
+    expect(onSubmit).toHaveBeenCalledTimes(0)
+  })
+
+  test('the keycap is on the button but NOT in its accessible name', () => {
+    const { submitButton } = renderDeferred()
+    expect(submitButton.querySelector('kbd')?.textContent?.trim()).toBe('⌘↵')
+    // The button's own aria-label is what keeps this true; without it the keycap joins the content
+    // and the name becomes "Comment ⌘↵".
+    expect(screen.getByRole('button', { name: 'Comment' })).toBe(submitButton)
+  })
+})
+
 describe('A — emoji picker', () => {
   // Appending to the end would be the easy implementation and the wrong one: the trigger is a click
   // away from a textarea the user is mid-sentence in, so the glyph has to land where the caret was

--- a/packages/web/src/components/review/Composer.tsx
+++ b/packages/web/src/components/review/Composer.tsx
@@ -327,8 +327,17 @@ export function Composer({
               <Mic className="size-3.5" />
             </Button>
           )}
-          <Button type="button" size="sm" disabled={!trimmed || busy} onClick={submit}>
+          {/* The explicit aria-label is load-bearing, not decoration: the keycap below is button
+              CONTENT, so without it the accessible name becomes "Comment ⌘↵" — for every screen
+              reader, and for the 13 `getByRole('button', {name: 'Comment'})` selectors in the
+              suite. Labelling the button pins the name to the word, whatever is rendered inside. */}
+          <Button type="button" size="sm" aria-label={submitLabel} disabled={!trimmed || busy} onClick={submit}>
             {submitLabel}
+            {/* The ⌘/Ctrl+Enter binding on the textarea above, made visible. Tinted off the primary
+                fill rather than `bg-muted` like AppShell's ⌘K, which sits on an outline button. */}
+            <kbd className="hidden rounded border border-primary-foreground/30 bg-primary-foreground/15 px-1 py-px font-mono text-[10px] text-primary-foreground/90 sm:inline">
+              ⌘↵
+            </kbd>
           </Button>
         </div>
       </div>


### PR DESCRIPTION
Follow-up to #128, same idea one step further in: a shortcut is only useful if it is visible where it applies.

**⌘/Ctrl+Enter already submitted** — that binding has been on the textarea since the composer was written (`Composer.tsx`, the `onTextareaKeyDown` handler). It just had nothing to announce it. So this PR is the hint, not the behaviour.

```
┌───────────────────────────┐
│  Comment          ⌘↵      │
└───────────────────────────┘
```

Keycap tinted off the primary fill (`border-primary-foreground/30 bg-primary-foreground/15`) rather than `bg-muted` like AppShell's ⌘K, which sits on an outline button. `hidden … sm:inline` for the same reason as the others.

## The accessible-name trap

The keycap is button **content**, so it lands in the accessible name unless something stops it — "Comment ⌘↵" for every screen reader, and for the 13 `getByRole('button', { name: 'Comment' })` selectors across the suite. The button now carries an explicit `aria-label={submitLabel}`, which pins the name to the word whatever renders inside.

`aria-hidden` on the keycap does the same job and was the first attempt, but biome's `noAriaHiddenOnFocusable` rejects it. Removing the label mutation-checks to **19 failures**, so this is genuinely load-bearing rather than belt-and-braces.

## Tests

The binding turned out to be untested, which is not a great thing to start advertising in the UI. Now pinned: ⌘+Enter submits, Ctrl+Enter submits, a bare Enter does not (it types a newline — this is a comment box), an all-whitespace draft is not submittable by keyboard either, and the keycap is in the button but not in its name.

The voice path is untouched — its submit button lives in a branch where the textarea isn't mounted, so there is no binding there to advertise.

**Note:** the keycap reads ⌘↵ on every platform, matching how AppShell hardcodes ⌘K today. The binding itself accepts Ctrl too, so Windows/Linux users get a working shortcut with a mac-flavoured hint. Worth fixing repo-wide if it bothers you; out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUPXH8c8atcJPSEiiQk1UL