### PR TITLE
fix(comments): one keycap per physical key on the composer's submit button

### DIFF
--- a/packages/web/src/components/review/Composer.test.tsx
+++ b/packages/web/src/components/review/Composer.test.tsx
@@ -127,9 +127,10 @@ describe('A — ⌘/Ctrl+Enter submits, and the button says so', () => {
     expect(onSubmit).toHaveBeenCalledTimes(0)
   })
 
-  test('the keycap is on the button but NOT in its accessible name', () => {
+  test('the keycaps are on the button but NOT in its accessible name', () => {
     const { submitButton } = renderDeferred()
-    expect(submitButton.querySelector('kbd')?.textContent?.trim()).toBe('⌘↵')
+    // One cap per physical key — two frames, not `⌘↵` sharing one.
+    expect([...submitButton.querySelectorAll('kbd')].map((k) => k.textContent?.trim())).toEqual(['⌘', '↵'])
     // The button's own aria-label is what keeps this true; without it the keycap joins the content
     // and the name becomes "Comment ⌘↵".
     expect(screen.getByRole('button', { name: 'Comment' })).toBe(submitButton)

--- a/packages/web/src/components/review/Composer.tsx
+++ b/packages/web/src/components/review/Composer.tsx
@@ -8,6 +8,11 @@ import { formatTimestamp } from '@/lib/audio'
 import { type MentionUser, filterMentions, insertMention, mentionLabel, mentionQuery } from '@/lib/mentions'
 import { cn } from '@/lib/utils'
 
+/** One key of the submit button's shortcut hint. Sized to sit inside a `size-sm` Button without
+ *  changing its height — `py-px`, not a padding that would grow the row. */
+const KEYCAP =
+  'rounded border border-primary-foreground/30 bg-primary-foreground/15 px-1 py-px font-mono text-[10px] leading-none text-primary-foreground/90'
+
 // Shared composer for a new thread or a flat reply. Text and voice are alternative submit paths:
 // typing submits trimmed non-empty bodies via onSubmit (clears on success); the mic records a clip
 // that submits via onSubmitVoice. When `loadMentions` is set, an `@` opens an autocomplete of
@@ -333,11 +338,14 @@ export function Composer({
               suite. Labelling the button pins the name to the word, whatever is rendered inside. */}
           <Button type="button" size="sm" aria-label={submitLabel} disabled={!trimmed || busy} onClick={submit}>
             {submitLabel}
-            {/* The ⌘/Ctrl+Enter binding on the textarea above, made visible. Tinted off the primary
-                fill rather than `bg-muted` like AppShell's ⌘K, which sits on an outline button. */}
-            <kbd className="hidden rounded border border-primary-foreground/30 bg-primary-foreground/15 px-1 py-px font-mono text-[10px] text-primary-foreground/90 sm:inline">
-              ⌘↵
-            </kbd>
+            {/* The ⌘/Ctrl+Enter binding on the textarea above, made visible. ONE CAP PER PHYSICAL
+                KEY: `⌘↵` sharing a single frame reads as one unfamiliar glyph at 10px rather than
+                as two keys you press together. Tinted off the primary fill rather than `bg-muted`
+                like AppShell's ⌘K, which sits on an outline button. */}
+            <span className="hidden items-center gap-0.5 sm:inline-flex">
+              <kbd className={KEYCAP}>⌘</kbd>
+              <kbd className={KEYCAP}>↵</kbd>
+            </span>
           </Button>
         </div>
       </div>


### PR DESCRIPTION
Follow-up to #129. `⌘↵` sharing a single 10px frame reads as one unfamiliar glyph rather than as two keys you press together — the `↵` in particular disappears into the `⌘`.

```
before   Comment [ ⌘↵ ]
after    Comment [ ⌘ ] [ ↵ ]
```

Splitting them also gives a rule that covers the whole set rather than a one-off: **one box per physical key**. The selection chip's `C` is one key, so one box; this is two keys, so two boxes.

Shared cap styling moves to a `KEYCAP` const instead of being written out twice.

No behaviour change — the binding, the `aria-label` that keeps the caps out of the accessible name, and the `sm:` breakpoint are all untouched. The existing test now asserts the two caps are `['⌘', '↵']` rather than one `'⌘↵'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUPXH8c8atcJPSEiiQk1UL