### PR TITLE
feat(comments): a reaction chip says who is behind it

### DIFF
--- a/packages/api/src/db/comments.ts
+++ b/packages/api/src/db/comments.ts
@@ -36,10 +36,16 @@ function touchThread(db: DrizzleD1Database, threadId: string, ts: string) {
   return db.update(commentThreads).set({ updatedAt: ts }).where(eq(commentThreads.id, threadId))
 }
 
-/** One DISTINCT emoji on a comment, aggregated server-side: how many people used it and whether
- *  the caller is one of them. The individual reactor ids never leave the server — the client needs
- *  a count and a toggle state, and nothing else. */
-export type CommentReaction = { emoji: string; count: number; mine: boolean }
+/** One DISTINCT emoji on a comment, aggregated server-side: how many people used it, whether the
+ *  caller is one of them, and WHO the others are — a chip that only counts leaves the reader
+ *  guessing. `names` are display names in reaction order, capped at REACTION_NAMES_MAX and never
+ *  including the caller (that is `mine`), so `count` stays the total and the client says "and N
+ *  others" for the remainder. Reactor IDS still never leave the server. */
+export type CommentReaction = { emoji: string; count: number; mine: boolean; names: string[] }
+
+/** How many reactor names one chip carries. A tooltip nobody can read is no better than a count,
+ *  and this is what keeps a wildly popular emoji from growing the list payload without bound. */
+const REACTION_NAMES_MAX = 8
 
 export type CommentView = {
   id: string
@@ -129,15 +135,22 @@ const COMMENT_LIST_COLUMNS = { comment: comments, authorName: users.name, author
 // GROUP BY would be one row per (comment, emoji) — but `mine` needs the caller's own row, so the
 // grouped form would still owe a second correlated read. Folding in JS costs one pass over rows
 // that are already bounded per comment (20 distinct emojis per user) and keeps the read to ONE
-// statement. `createdAt` is read only to order them; the reactor ids never leave the server.
+// statement. `createdAt` is read only to order them; the reactor ids never leave the server —
+// the JOINed name/email do, aggregated into `names` exactly like a comment author's is.
 const REACTION_COLUMNS = {
   commentId: commentReactions.commentId,
   userId: commentReactions.userId,
   emoji: commentReactions.emoji,
+  reactorName: users.name,
+  reactorEmail: users.email,
 }
 
-/** Row shape of both reaction statements — the raw (comment, reactor, emoji) triples. */
-export type ReactionRow = Pick<CommentReactionRow, 'commentId' | 'userId' | 'emoji'>
+/** Row shape of both reaction statements — the raw (comment, reactor, emoji) triples, plus the
+ *  reactor's JOINed user fields (same null-on-miss semantics as the rows above). */
+export type ReactionRow = Pick<CommentReactionRow, 'commentId' | 'userId' | 'emoji'> & {
+  reactorName: string | null
+  reactorEmail: string | null
+}
 
 const reactionOrder = [commentReactions.createdAt, sql`"comment_reactions".rowid`] as const
 
@@ -195,6 +208,7 @@ export function reactionsBySlugsStmt(db: DrizzleD1Database, spaceSlug: string, s
     .innerJoin(commentThreads, eq(comments.threadId, commentThreads.id))
     .innerJoin(sites, eq(commentThreads.siteId, sites.id))
     .innerJoin(spaces, eq(sites.spaceId, spaces.id))
+    .leftJoin(users, eq(commentReactions.userId, users.id))
     .where(slugThreadScope(spaceSlug, siteSlug, filePath))
     .orderBy(...reactionOrder)
 }
@@ -205,6 +219,7 @@ export function reactionsByCommentStmt(db: DrizzleD1Database, commentId: string)
   return db
     .select(REACTION_COLUMNS)
     .from(commentReactions)
+    .leftJoin(users, eq(commentReactions.userId, users.id))
     .where(eq(commentReactions.commentId, commentId))
     .orderBy(...reactionOrder)
 }
@@ -220,13 +235,29 @@ export function reactionsByComment(rows: ReactionRow[], viewerId: string | null)
       list = []
       byComment.set(r.commentId, list)
     }
+    const mine = r.userId === viewerId
     const hit = list.find((x) => x.emoji === r.emoji)
     if (hit) {
       hit.count++
-      hit.mine ||= r.userId === viewerId
-    } else list.push({ emoji: r.emoji, count: 1, mine: r.userId === viewerId })
+      hit.mine ||= mine
+      addReactorName(hit, r, mine)
+    } else {
+      const entry = { emoji: r.emoji, count: 1, mine, names: [] }
+      addReactorName(entry, r, mine)
+      list.push(entry)
+    }
   }
   return byComment
+}
+
+/** Append one reactor to a chip's `names`, or don't: the caller is `mine` rather than a name, the
+ *  list stops at REACTION_NAMES_MAX, and a reactor whose user row is missing (impossible under the
+ *  FK, but the join is typed for it) is simply left out. Everyone skipped is still in `count`, so
+ *  the client renders them as "and N others" — an omission that reads as one, not as a wrong name. */
+function addReactorName(entry: CommentReaction, row: ReactionRow, mine: boolean): void {
+  if (mine || entry.names.length >= REACTION_NAMES_MAX) return
+  const name = joinedDisplayName(row.userId, row.reactorName, row.reactorEmail)
+  if (name !== null) entry.names.push(name)
 }
 
 /** Display name from JOINed user fields: null id → null; id whose join found no row (dangling

--- a/packages/api/src/routes/comments-reactions.test.ts
+++ b/packages/api/src/routes/comments-reactions.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test'
-import { commentReactions } from '../db/schema'
+import { eq } from 'drizzle-orm'
+import { commentReactions, users } from '../db/schema'
 import { seedComment, seedMember, seedSite, seedSpace, seedThread } from '../test/harness'
 import { auth, makeRouteApp, mintUser, type RouteApp } from '../test/route-fixtures'
 
@@ -55,11 +56,11 @@ describe('PUT/DELETE comment reactions — the toggle', () => {
     const ctx = await setup()
     const first = await react(ctx, 'member', ctx, { emoji: '🔥' })
     expect(first.status).toBe(200)
-    expect(await first.json()).toEqual([{ emoji: '🔥', count: 1, mine: true }])
+    expect(await first.json()).toEqual([{ emoji: '🔥', count: 1, mine: true, names: [] }])
 
     const again = await react(ctx, 'member', ctx, { emoji: '🔥' })
     expect(again.status).toBe(200)
-    expect(await again.json()).toEqual([{ emoji: '🔥', count: 1, mine: true }])
+    expect(await again.json()).toEqual([{ emoji: '🔥', count: 1, mine: true, names: [] }])
     expect(await ctx.db.select().from(commentReactions)).toHaveLength(1)
   })
 
@@ -83,29 +84,31 @@ describe('PUT/DELETE comment reactions — the toggle', () => {
     const two = await react(ctx, 'member', ctx, { emoji: '🎉' })
     // Order is first-reacted-first — the set is stable across polls, not re-sorted by count.
     expect(await two.json()).toEqual([
-      { emoji: '🔥', count: 1, mine: true },
-      { emoji: '🎉', count: 1, mine: true },
+      { emoji: '🔥', count: 1, mine: true, names: [] },
+      { emoji: '🎉', count: 1, mine: true, names: [] },
     ])
 
     const after = await react(ctx, 'member', ctx, { emoji: '🔥' }, 'DELETE')
-    expect(await after.json()).toEqual([{ emoji: '🎉', count: 1, mine: true }])
+    expect(await after.json()).toEqual([{ emoji: '🎉', count: 1, mine: true, names: [] }])
   })
 
   test('two users on the SAME emoji aggregate to count 2, and `mine` is per caller', async () => {
     const ctx = await setup()
     await react(ctx, 'owner', ctx, { emoji: '👍' })
     const second = await react(ctx, 'member', ctx, { emoji: '👍' })
-    expect(await second.json()).toEqual([{ emoji: '👍', count: 2, mine: true }])
+    expect(await second.json()).toEqual([{ emoji: '👍', count: 2, mine: true, names: ['owner@example.com'] }])
 
     // The owner's view of the same row set: still 2, still mine.
     const ownersView = await react(ctx, 'owner', ctx, { emoji: '👍' })
-    expect(await ownersView.json()).toEqual([{ emoji: '👍', count: 2, mine: true }])
+    expect(await ownersView.json()).toEqual([{ emoji: '👍', count: 2, mine: true, names: ['member@example.com'] }])
 
     // A third user who has not reacted sees the count without `mine`.
     await mintUser(ctx.db, ctx.kv, 'watcher')
     await seedMember(ctx.db, ctx.spaceId, 'watcher')
     const [thread] = await list(ctx, 'watcher')
-    expect(thread.comments[0].reactions).toEqual([{ emoji: '👍', count: 2, mine: false }])
+    expect(thread.comments[0].reactions).toEqual([
+      { emoji: '👍', count: 2, mine: false, names: ['owner@example.com', 'member@example.com'] },
+    ])
   })
 
   test('a MULTI-code-unit emoji round-trips whole (family = 11 UTF-16 units, not one char)', async () => {
@@ -113,7 +116,7 @@ describe('PUT/DELETE comment reactions — the toggle', () => {
     const family = '👨‍👩‍👧‍👦'
     expect(family.length).toBe(11) // the reason the cap is measured generously, not at 1 or 2
     const res = await react(ctx, 'member', ctx, { emoji: family })
-    expect(await res.json()).toEqual([{ emoji: family, count: 1, mine: true }])
+    expect(await res.json()).toEqual([{ emoji: family, count: 1, mine: true, names: [] }])
     expect((await ctx.db.select().from(commentReactions))[0].emoji).toBe(family)
   })
 })
@@ -217,6 +220,54 @@ describe('comment reactions — the access gate is the message routes’ own', (
   })
 })
 
+// A chip that only counts leaves the reader guessing who is behind it, so each one carries the
+// reactors' display names — the caller excluded (that is `mine`), in reaction order, capped so a
+// popular emoji cannot grow the list payload without bound.
+describe('comment reactions — who reacted', () => {
+  test('names are the OTHER reactors, in reaction order, and never the caller', async () => {
+    const ctx = await setup()
+    for (const who of ['watcher', 'member']) {
+      if (who === 'watcher') {
+        await mintUser(ctx.db, ctx.kv, who)
+        await seedMember(ctx.db, ctx.spaceId, who)
+      }
+      await react(ctx, who, ctx, { emoji: '👍' })
+    }
+    const mine = await react(ctx, 'owner', ctx, { emoji: '👍' })
+    // Reaction order, not caller-first: the owner reacted last and is absent from its own list.
+    expect(await mine.json()).toEqual([
+      { emoji: '👍', count: 3, mine: true, names: ['watcher@example.com', 'member@example.com'] },
+    ])
+    // …and the same rows, read by someone who has not reacted, name all three.
+    const [thread] = await list(ctx, 'watcher')
+    expect(thread.comments[0].reactions).toEqual([
+      { emoji: '👍', count: 3, mine: true, names: ['member@example.com', 'owner@example.com'] },
+    ])
+  })
+
+  test('names stop at 8; whoever they leave out is still in `count`', async () => {
+    const ctx = await setup()
+    const crowd = Array.from({ length: 10 }, (_, i) => `fan${i}`)
+    for (const who of crowd) {
+      await mintUser(ctx.db, ctx.kv, who)
+      await seedMember(ctx.db, ctx.spaceId, who)
+      await react(ctx, who, ctx, { emoji: '🔥' })
+    }
+    const res = await react(ctx, 'member', ctx, { emoji: '🔥' })
+    expect(await res.json()).toEqual([
+      { emoji: '🔥', count: 11, mine: true, names: crowd.slice(0, 8).map((w) => `${w}@example.com`) },
+    ])
+  })
+
+  test('a reactor with a name uses it, not the email the fallback would show', async () => {
+    const ctx = await setup()
+    await ctx.db.update(users).set({ name: 'Ada Lovelace' }).where(eq(users.id, ctx.owner))
+    await react(ctx, 'owner', ctx, { emoji: '🎉' })
+    const res = await react(ctx, 'member', ctx, { emoji: '🎉' })
+    expect(await res.json()).toEqual([{ emoji: '🎉', count: 2, mine: true, names: ['Ada Lovelace'] }])
+  })
+})
+
 describe('comment reactions — the GET fold', () => {
   test('reactions ride the list response, and a comment with none reads as []', async () => {
     const ctx = await setup()
@@ -230,8 +281,8 @@ describe('comment reactions — the GET fold', () => {
       [
         ctx.commentId,
         [
-          { emoji: '🔥', count: 2, mine: true },
-          { emoji: '🎉', count: 1, mine: false },
+          { emoji: '🔥', count: 2, mine: true, names: ['owner@example.com'] },
+          { emoji: '🎉', count: 1, mine: false, names: ['owner@example.com'] },
         ],
       ],
       [bare, []],

--- a/packages/web/src/components/review/EmojiPicker.tsx
+++ b/packages/web/src/components/review/EmojiPicker.tsx
@@ -1,4 +1,5 @@
 import { Smile } from 'lucide-react'
+import type * as React from 'react'
 import { useRef, useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from '@/components/ui/command'
@@ -16,14 +17,19 @@ export function EmojiPicker({
   onPick,
   disabled,
   label = 'Insert emoji',
+  variant = 'outline',
   className,
 }: {
   onPick: (emoji: string) => void
   disabled?: boolean
   // The two callers want the same picker under different affordances: the composer's action-row
   // button, and a chip-sized "add reaction" trigger in a thread. Only the trigger differs, so it
-  // takes a label and a class rather than the picker being forked in two.
+  // takes a label, a variant and a class rather than the picker being forked in two.
   label?: string
+  // Outline stands alone in the composer's row; inside the message hover bar, which already draws
+  // its own border, a second border a hair inside the first is the whole reason that bar's corners
+  // looked wrong — `ghost` there matches the delete button beside it.
+  variant?: React.ComponentProps<typeof Button>['variant']
   className?: string
 }) {
   const [open, setOpen] = useState(false)
@@ -49,7 +55,7 @@ export function EmojiPicker({
   return (
     <Popover open={open} onOpenChange={onOpenChange}>
       <PopoverTrigger asChild>
-        <Button type="button" variant="outline" size="sm" disabled={disabled} aria-label={label} className={className}>
+        <Button type="button" variant={variant} size="sm" disabled={disabled} aria-label={label} className={className}>
           <Smile className="size-3.5" />
         </Button>
       </PopoverTrigger>

--- a/packages/web/src/components/review/ThreadCard.test.tsx
+++ b/packages/web/src/components/review/ThreadCard.test.tsx
@@ -7,7 +7,7 @@ import { toast } from 'sonner'
 import { ApiError } from '@/lib/api'
 import { comments, type CommentItem, type CommentReaction, type Thread } from '@/lib/comments'
 import type { Me, ViewerSite } from '@/lib/types'
-import { ThreadCard } from './ThreadCard'
+import { ThreadCard, reactorList } from './ThreadCard'
 
 const SITE: ViewerSite = {
   id: 's1',
@@ -259,8 +259,8 @@ describe('ThreadCard — a failed reply keeps the composer open on its draft', (
 // what re-renders the chips, and onChanged stays untouched.
 describe('ThreadCard — reaction chips', () => {
   const one = (reactions: CommentReaction[]) => [mkComment({ id: 'c1', reactions })]
-  const FIRE_THEIRS: CommentReaction = { emoji: '🔥', count: 2, mine: false }
-  const THUMB_MINE: CommentReaction = { emoji: '👍', count: 1, mine: true }
+  const FIRE_THEIRS: CommentReaction = { emoji: '🔥', count: 2, mine: false, names: ['Ada', 'Bo'] }
+  const THUMB_MINE: CommentReaction = { emoji: '👍', count: 1, mine: true, names: [] }
 
   test('chips render from the comment, with the caller’s own pressed', () => {
     renderCard({ comments: one([FIRE_THEIRS, THUMB_MINE]) })
@@ -277,7 +277,7 @@ describe('ThreadCard — reaction chips', () => {
   test('clicking someone else’s chip reacts, and re-renders from the RESPONSE — no refetch', async () => {
     const { onChanged } = renderCard({ comments: one([FIRE_THEIRS]) })
     const react = spyOn(comments, 'react').mockImplementation(() =>
-      Promise.resolve([{ emoji: '🔥', count: 3, mine: true }]),
+      Promise.resolve([{ emoji: '🔥', count: 3, mine: true, names: ['Ada', 'Bo'] }]),
     )
 
     await act(async () => {
@@ -308,7 +308,7 @@ describe('ThreadCard — reaction chips', () => {
   test('picking from the emoji picker adds a chip', async () => {
     renderCard({ comments: one([]) })
     const react = spyOn(comments, 'react').mockImplementation(() =>
-      Promise.resolve([{ emoji: '🚀', count: 1, mine: true }]),
+      Promise.resolve([{ emoji: '🚀', count: 1, mine: true, names: [] }]),
     )
 
     fireEvent.click(screen.getByRole('button', { name: 'Add reaction' }))
@@ -349,6 +349,45 @@ describe('ThreadCard — reaction chips', () => {
   })
 })
 
+// A chip that only counts is a question, not an answer: "two people liked this — which two?". The
+// names ride the same payload the count does; hover (or focus, which is how the chip is REACHED
+// without a mouse) is what asks.
+describe('ThreadCard — who reacted', () => {
+  const chipTip = async (name: string) => {
+    fireEvent.focus(screen.getByRole('button', { name }))
+    return await screen.findByRole('tooltip')
+  }
+
+  test('a chip names its reactors, and calls the caller “You” rather than repeating their name', async () => {
+    renderCard({
+      comments: [
+        mkComment({
+          id: 'c1',
+          reactions: [
+            { emoji: '🔥', count: 2, mine: false, names: ['Ada', 'Bo'] },
+            // `names` never carries the caller — `mine` is how the caller appears, so the phrase
+            // reads the way the reader thinks of it.
+            { emoji: '👍', count: 2, mine: true, names: ['Ada'] },
+          ],
+        }),
+      ],
+    })
+    expect((await chipTip('🔥 2')).textContent).toBe('Ada and Bo reacted 🔥')
+    expect((await chipTip('👍 2')).textContent).toBe('You and Ada reacted 👍')
+  })
+
+  test('past the server’s name cap the rest are counted, not dropped in silence', async () => {
+    const names = ['Ada', 'Bo', 'Cy', 'Di', 'Eli', 'Fay', 'Gus', 'Hal'] // the server sends at most 8
+    renderCard({ comments: [mkComment({ id: 'c1', reactions: [{ emoji: '🎉', count: 11, mine: true, names }] })] })
+    expect((await chipTip('🎉 11')).textContent).toBe(`You, ${names.join(', ')} and 2 others reacted 🎉`)
+  })
+
+  test('one unnamed reactor is “1 other”, not “1 others”', () => {
+    expect(reactorList({ emoji: '🎉', count: 2, mine: true, names: [] })).toBe('You and 1 other')
+    expect(reactorList({ emoji: '🎉', count: 1, mine: false, names: ['Ada'] })).toBe('Ada')
+  })
+})
+
 // The override that keeps a toggle from refetching has to STOP winning once a refetch happens, or
 // it silently freezes that comment: everything anyone else reacts with afterwards is invisible to
 // this reader until they reload the page. There is no polling, so nothing else would ever correct
@@ -357,10 +396,10 @@ describe('ThreadCard — reaction chips', () => {
 describe('ThreadCard — a refetched reaction list supersedes the local override', () => {
   test('reactions other people added after a toggle still render', async () => {
     const { onChanged, refetch } = renderCard({
-      comments: [mkComment({ id: 'c1', reactions: [{ emoji: '🔥', count: 2, mine: false }] })],
+      comments: [mkComment({ id: 'c1', reactions: [{ emoji: '🔥', count: 2, mine: false, names: ['Ada', 'Bo'] }] })],
     })
     const react = spyOn(comments, 'react').mockImplementation(() =>
-      Promise.resolve([{ emoji: '🔥', count: 3, mine: true }]),
+      Promise.resolve([{ emoji: '🔥', count: 3, mine: true, names: ['Ada', 'Bo'] }]),
     )
 
     await act(async () => {
@@ -375,8 +414,8 @@ describe('ThreadCard — a refetched reaction list supersedes the local override
         mkComment({
           id: 'c1',
           reactions: [
-            { emoji: '🔥', count: 4, mine: true },
-            { emoji: '🎉', count: 1, mine: false },
+            { emoji: '🔥', count: 4, mine: true, names: ['Ada', 'Bo', 'Cy'] },
+            { emoji: '🎉', count: 1, mine: false, names: ['Cy'] },
           ],
         }),
       ])
@@ -393,10 +432,10 @@ describe('ThreadCard — a refetched reaction list supersedes the local override
   test('a re-render that did NOT bring a new list leaves the override in charge', async () => {
     // The other half: React re-renders for all sorts of reasons. Only a genuinely new `reactions`
     // array may discard the toggle's answer, or every unrelated re-render would flash the old count.
-    const stable = [{ emoji: '👍', count: 1, mine: false }]
+    const stable = [{ emoji: '👍', count: 1, mine: false, names: ['Ada'] }]
     const { refetch } = renderCard({ comments: [mkComment({ id: 'c1', reactions: stable })] })
     const react = spyOn(comments, 'react').mockImplementation(() =>
-      Promise.resolve([{ emoji: '👍', count: 2, mine: true }]),
+      Promise.resolve([{ emoji: '👍', count: 2, mine: true, names: ['Ada'] }]),
     )
 
     await act(async () => {

--- a/packages/web/src/components/review/ThreadCard.tsx
+++ b/packages/web/src/components/review/ThreadCard.tsx
@@ -11,6 +11,7 @@ import { AnchorChip } from '@/components/review/AnchorChip'
 import { Composer } from '@/components/review/Composer'
 import { EmojiPicker } from '@/components/review/EmojiPicker'
 import { Badge } from '@/components/ui/badge'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 
 export function ThreadCard({
   site,
@@ -171,16 +172,20 @@ export function ThreadCard({
                   deal touch users get today, minus the desktop clutter. */}
               {!c.deleted && (
                 <div className="absolute -top-2 right-1 z-10 flex items-center gap-0.5 rounded-md border bg-popover p-0.5 opacity-0 shadow-sm transition-opacity focus-within:opacity-100 group-hover/msg:opacity-100 [@media(hover:none)]:opacity-100">
+                  {/* rounded-sm, not the default `rounded`: the bar's own corner is rounded-md and
+                      it holds its buttons 2px in, so a flat 4px child reads as a square in a round
+                      box. The scale's next step down is what CONCENTRIC corners want here. */}
                   <EmojiPicker
                     label="Add reaction"
-                    className="size-6 rounded px-0 text-muted-foreground"
+                    variant="ghost"
+                    className="size-6 rounded-sm px-0 text-muted-foreground"
                     onPick={(emoji) => toggle(c, emoji, false)()}
                   />
                   {c.authorId === me?.id && (
                     <button
                       type="button"
                       onClick={act(() => comments.remove(site, thread.id, c.id))}
-                      className="flex size-6 items-center justify-center rounded hover:bg-muted"
+                      className="flex size-6 items-center justify-center rounded-sm hover:bg-muted"
                       aria-label="Delete comment"
                     >
                       <Trash2 className="size-3.5 text-muted-foreground hover:text-destructive" />
@@ -245,28 +250,40 @@ export function ThreadCard({
                       a comment nobody reacted to now costs nothing here instead of a permanent
                       dashed circle — the single biggest source of dead space on this card. */}
                   {reactionsOf(c).length > 0 && (
-                    <div className="mt-1 flex flex-wrap items-center gap-1">
-                      {reactionsOf(c).map((r) => (
-                        <button
-                          key={r.emoji}
-                          type="button"
-                          // A toggle, so it announces as one: pressed IS `mine`, which is the same
-                          // fact the filled chip shows sighted users.
-                          aria-pressed={r.mine}
-                          aria-label={`${r.emoji} ${r.count}`}
-                          onClick={toggle(c, r.emoji, r.mine)}
-                          className={cn(
-                            'flex items-center gap-1 rounded-full border px-1.5 py-0.5 text-xs transition-colors',
-                            r.mine
-                              ? 'border-primary/40 bg-primary/10 text-foreground'
-                              : 'border-transparent bg-muted text-muted-foreground hover:bg-muted/70',
-                          )}
-                        >
-                          {r.emoji}
-                          <span className="tabular-nums">{r.count}</span>
-                        </button>
-                      ))}
-                    </div>
+                    <TooltipProvider delayDuration={150}>
+                      <div className="mt-1 flex flex-wrap items-center gap-1">
+                        {reactionsOf(c).map((r) => {
+                          // A count alone doesn't say who is behind it. Hover (or focus — radix
+                          // opens on both, and points the trigger's aria-describedby at the content,
+                          // so the names reach a screen reader too) answers that.
+                          const who = reactorList(r)
+                          return (
+                            <Tooltip key={r.emoji}>
+                              <TooltipTrigger asChild>
+                                <button
+                                  type="button"
+                                  // A toggle, so it announces as one: pressed IS `mine`, which is
+                                  // the same fact the filled chip shows sighted users.
+                                  aria-pressed={r.mine}
+                                  aria-label={`${r.emoji} ${r.count}`}
+                                  onClick={toggle(c, r.emoji, r.mine)}
+                                  className={cn(
+                                    'flex items-center gap-1 rounded-full border px-1.5 py-0.5 text-xs transition-colors',
+                                    r.mine
+                                      ? 'border-primary/40 bg-primary/10 text-foreground'
+                                      : 'border-transparent bg-muted text-muted-foreground hover:bg-muted/70',
+                                  )}
+                                >
+                                  {r.emoji}
+                                  <span className="tabular-nums">{r.count}</span>
+                                </button>
+                              </TooltipTrigger>
+                              <TooltipContent className="max-w-56">{`${who} reacted ${r.emoji}`}</TooltipContent>
+                            </Tooltip>
+                          )
+                        })}
+                      </div>
+                    </TooltipProvider>
                   )}
                 </div>
               </div>
@@ -344,6 +361,17 @@ export function ThreadCard({
       )}
     </div>
   )
+}
+
+/** Who reacted, in one phrase: the viewer first (as "You" — the server sends `mine`, never the
+ *  caller's own name), then the names it did send, then "and N others" for everyone `count` knows
+ *  about but the server's name cap left out. The count is the truth; the names are as many of it
+ *  as fit. */
+export function reactorList(r: CommentReaction): string {
+  const who = r.mine ? ['You', ...r.names] : [...r.names]
+  const rest = r.count - who.length
+  if (rest > 0) who.push(`${rest} other${rest === 1 ? '' : 's'}`)
+  return who.length > 1 ? `${who.slice(0, -1).join(', ')} and ${who[who.length - 1]}` : who.join('')
 }
 
 function fmt(iso: string): string {

--- a/packages/web/src/lib/applyCommentEvent.test.ts
+++ b/packages/web/src/lib/applyCommentEvent.test.ts
@@ -79,7 +79,7 @@ describe('applyCommentEvent', () => {
       siteId: SITE,
       filePath: FILE,
       threadId: 't1',
-      comment: mkComment({ id: 'c1', body: 'edited', reactions: [{ emoji: '👍', count: 1, mine: true }] }),
+      comment: mkComment({ id: 'c1', body: 'edited', reactions: [{ emoji: '👍', count: 1, mine: true, names: [] }] }),
     }
     const result = applyCommentEvent(threads, event, FILE)
     expect(result).toBe(threads)

--- a/packages/web/src/lib/comments.ts
+++ b/packages/web/src/lib/comments.ts
@@ -23,10 +23,11 @@ export interface ElementAnchor {
   textFallback: string
 }
 
-/** One DISTINCT emoji on a comment, aggregated server-side: how many people used it and whether
- *  the caller is one of them. Mirrors the api CommentReaction — the reactor ids stay on the server,
- *  so a chip can show a count and a pressed state and nothing else. */
-export type CommentReaction = { emoji: string; count: number; mine: boolean }
+/** One DISTINCT emoji on a comment, aggregated server-side: how many people used it, whether the
+ *  caller is one of them, and the other reactors' display names in reaction order. Mirrors the api
+ *  CommentReaction — reactor IDS stay on the server, and `names` is capped there, so it can be
+ *  SHORTER than `count` implies: whoever it leaves out is the "and N others" the chip spells out. */
+export type CommentReaction = { emoji: string; count: number; mine: boolean; names: string[] }
 
 export interface CommentItem {
   id: string


### PR DESCRIPTION
Hovering a reaction chip now names the people behind it — the question a bare count leaves you with.

- **`names` rides the existing payload.** The list route's reaction statement LEFT JOINs `users`, so it's still 1 loose read + 1 batch of 8 statements, not a second round trip.
- **The caller is never a name.** `mine` is how they appear; the chip renders them as "You" first — "You and Ada reacted 👍".
- **Bounded.** At most 8 names per chip server-side; whoever the cap leaves out stays in `count` and reads as "and 2 others". Reactor IDs still never leave the server.
- **Reachable without a mouse.** Radix opens on focus as well as hover and points the trigger's `aria-describedby` at the content, so screen readers get the same sentence.

Also fixes the message hover bar's corners: `rounded-md` bar holding buttons 2px in, with flat `rounded` (4px, off the theme scale) children — a square in a round box, made visible by the emoji trigger's `outline` variant drawing a second border just inside the bar's. Children are `rounded-sm` now and that trigger is `ghost`, matching the delete button beside it. The composer's picker keeps `outline`.

api 1253 pass · web 444 pass · typecheck clean. New coverage: name order + the cap's remainder + "1 other" vs "1 others", and name-over-email.

Not verified in a browser — the radius fix is geometry, not a screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUPXH8c8atcJPSEiiQk1UL