### PR TITLE
fix(comments): the reaction tooltip says the names, and only the names

### DIFF
--- a/packages/web/src/components/review/ThreadCard.test.tsx
+++ b/packages/web/src/components/review/ThreadCard.test.tsx
@@ -372,14 +372,14 @@ describe('ThreadCard — who reacted', () => {
         }),
       ],
     })
-    expect((await chipTip('🔥 2')).textContent).toBe('Ada and Bo reacted 🔥')
-    expect((await chipTip('👍 2')).textContent).toBe('You and Ada reacted 👍')
+    expect((await chipTip('🔥 2')).textContent).toBe('Ada and Bo')
+    expect((await chipTip('👍 2')).textContent).toBe('You and Ada')
   })
 
   test('past the server’s name cap the rest are counted, not dropped in silence', async () => {
     const names = ['Ada', 'Bo', 'Cy', 'Di', 'Eli', 'Fay', 'Gus', 'Hal'] // the server sends at most 8
     renderCard({ comments: [mkComment({ id: 'c1', reactions: [{ emoji: '🎉', count: 11, mine: true, names }] })] })
-    expect((await chipTip('🎉 11')).textContent).toBe(`You, ${names.join(', ')} and 2 others reacted 🎉`)
+    expect((await chipTip('🎉 11')).textContent).toBe(`You, ${names.join(', ')} and 2 others`)
   })
 
   test('one unnamed reactor is “1 other”, not “1 others”', () => {

--- a/packages/web/src/components/review/ThreadCard.tsx
+++ b/packages/web/src/components/review/ThreadCard.tsx
@@ -278,7 +278,9 @@ export function ThreadCard({
                                   <span className="tabular-nums">{r.count}</span>
                                 </button>
                               </TooltipTrigger>
-                              <TooltipContent className="max-w-56">{`${who} reacted ${r.emoji}`}</TooltipContent>
+                              {/* Names only. The chip under the cursor already shows the emoji, so
+                                  "reacted 👍" spent the tooltip's width restating what was asked. */}
+                              <TooltipContent className="max-w-56">{who}</TooltipContent>
                             </Tooltip>
                           )
                         })}


### PR DESCRIPTION
"Krishnarjun J reacted 👍" → "Krishnarjun J". The chip being hovered already shows the emoji; the tooltip only owes the reader the part they can't see.

web 444 pass · typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUPXH8c8atcJPSEiiQk1UL