### PR TITLE
fix(comments): the reaction tooltip names everyone, comma-separated

### DIFF
--- a/packages/api/src/db/comments.ts
+++ b/packages/api/src/db/comments.ts
@@ -38,14 +38,11 @@ function touchThread(db: DrizzleD1Database, threadId: string, ts: string) {
 
 /** One DISTINCT emoji on a comment, aggregated server-side: how many people used it, whether the
  *  caller is one of them, and WHO the others are — a chip that only counts leaves the reader
- *  guessing. `names` are display names in reaction order, capped at REACTION_NAMES_MAX and never
- *  including the caller (that is `mine`), so `count` stays the total and the client says "and N
- *  others" for the remainder. Reactor IDS still never leave the server. */
+ *  guessing. `names` are EVERY other reactor's display name in reaction order, never including the
+ *  caller (that is `mine`), so `count` is `names.length` plus the caller. Uncapped on purpose: the
+ *  tooltip names everyone, and a comment's reactors are bounded by the people who can see the page.
+ *  Reactor IDS still never leave the server. */
 export type CommentReaction = { emoji: string; count: number; mine: boolean; names: string[] }
-
-/** How many reactor names one chip carries. A tooltip nobody can read is no better than a count,
- *  and this is what keeps a wildly popular emoji from growing the list payload without bound. */
-const REACTION_NAMES_MAX = 8
 
 export type CommentView = {
   id: string
@@ -250,12 +247,11 @@ export function reactionsByComment(rows: ReactionRow[], viewerId: string | null)
   return byComment
 }
 
-/** Append one reactor to a chip's `names`, or don't: the caller is `mine` rather than a name, the
- *  list stops at REACTION_NAMES_MAX, and a reactor whose user row is missing (impossible under the
- *  FK, but the join is typed for it) is simply left out. Everyone skipped is still in `count`, so
- *  the client renders them as "and N others" — an omission that reads as one, not as a wrong name. */
+/** Append one reactor to a chip's `names`, or don't: the caller is `mine` rather than a name, and a
+ *  reactor whose user row is missing (impossible under the FK, but the join is typed for it) is
+ *  left out rather than named wrongly — `count` still has them. */
 function addReactorName(entry: CommentReaction, row: ReactionRow, mine: boolean): void {
-  if (mine || entry.names.length >= REACTION_NAMES_MAX) return
+  if (mine) return
   const name = joinedDisplayName(row.userId, row.reactorName, row.reactorEmail)
   if (name !== null) entry.names.push(name)
 }

--- a/packages/api/src/routes/comments-reactions.test.ts
+++ b/packages/api/src/routes/comments-reactions.test.ts
@@ -221,8 +221,8 @@ describe('comment reactions — the access gate is the message routes’ own', (
 })
 
 // A chip that only counts leaves the reader guessing who is behind it, so each one carries the
-// reactors' display names — the caller excluded (that is `mine`), in reaction order, capped so a
-// popular emoji cannot grow the list payload without bound.
+// reactors' display names — the caller excluded (that is `mine`), in reaction order, and ALL of
+// them: a reader hunting for one name gets nothing out of "and 4 others".
 describe('comment reactions — who reacted', () => {
   test('names are the OTHER reactors, in reaction order, and never the caller', async () => {
     const ctx = await setup()
@@ -245,7 +245,7 @@ describe('comment reactions — who reacted', () => {
     ])
   })
 
-  test('names stop at 8; whoever they leave out is still in `count`', async () => {
+  test('a crowd is named in full — the list is not summarised at some cap', async () => {
     const ctx = await setup()
     const crowd = Array.from({ length: 10 }, (_, i) => `fan${i}`)
     for (const who of crowd) {
@@ -254,8 +254,9 @@ describe('comment reactions — who reacted', () => {
       await react(ctx, who, ctx, { emoji: '🔥' })
     }
     const res = await react(ctx, 'member', ctx, { emoji: '🔥' })
+    // Every reactor but the caller, so `count` is exactly `names.length` + 1.
     expect(await res.json()).toEqual([
-      { emoji: '🔥', count: 11, mine: true, names: crowd.slice(0, 8).map((w) => `${w}@example.com`) },
+      { emoji: '🔥', count: 11, mine: true, names: crowd.map((w) => `${w}@example.com`) },
     ])
   })
 

--- a/packages/web/src/components/review/ThreadCard.test.tsx
+++ b/packages/web/src/components/review/ThreadCard.test.tsx
@@ -372,18 +372,18 @@ describe('ThreadCard — who reacted', () => {
         }),
       ],
     })
-    expect((await chipTip('🔥 2')).textContent).toBe('Ada and Bo')
-    expect((await chipTip('👍 2')).textContent).toBe('You and Ada')
+    expect((await chipTip('🔥 2')).textContent).toBe('Ada, Bo')
+    expect((await chipTip('👍 2')).textContent).toBe('You, Ada')
   })
 
-  test('past the server’s name cap the rest are counted, not dropped in silence', async () => {
-    const names = ['Ada', 'Bo', 'Cy', 'Di', 'Eli', 'Fay', 'Gus', 'Hal'] // the server sends at most 8
+  test('a crowd is listed in full — the tooltip does not summarise the tail away', async () => {
+    const names = ['Ada', 'Bo', 'Cy', 'Di', 'Eli', 'Fay', 'Gus', 'Hal', 'Ivy', 'Jo']
     renderCard({ comments: [mkComment({ id: 'c1', reactions: [{ emoji: '🎉', count: 11, mine: true, names }] })] })
-    expect((await chipTip('🎉 11')).textContent).toBe(`You, ${names.join(', ')} and 2 others`)
+    expect((await chipTip('🎉 11')).textContent).toBe(`You, ${names.join(', ')}`)
   })
 
-  test('one unnamed reactor is “1 other”, not “1 others”', () => {
-    expect(reactorList({ emoji: '🎉', count: 2, mine: true, names: [] })).toBe('You and 1 other')
+  test('one reactor is just the one name', () => {
+    expect(reactorList({ emoji: '🎉', count: 1, mine: true, names: [] })).toBe('You')
     expect(reactorList({ emoji: '🎉', count: 1, mine: false, names: ['Ada'] })).toBe('Ada')
   })
 })

--- a/packages/web/src/components/review/ThreadCard.tsx
+++ b/packages/web/src/components/review/ThreadCard.tsx
@@ -365,15 +365,11 @@ export function ThreadCard({
   )
 }
 
-/** Who reacted, in one phrase: the viewer first (as "You" — the server sends `mine`, never the
- *  caller's own name), then the names it did send, then "and N others" for everyone `count` knows
- *  about but the server's name cap left out. The count is the truth; the names are as many of it
- *  as fit. */
+/** Who reacted: the viewer first as "You" (the server sends `mine`, never the caller's own name),
+ *  then everyone else in reaction order, comma-separated. The whole list, however long — a name
+ *  the reader was looking for is no use summarised away. */
 export function reactorList(r: CommentReaction): string {
-  const who = r.mine ? ['You', ...r.names] : [...r.names]
-  const rest = r.count - who.length
-  if (rest > 0) who.push(`${rest} other${rest === 1 ? '' : 's'}`)
-  return who.length > 1 ? `${who.slice(0, -1).join(', ')} and ${who[who.length - 1]}` : who.join('')
+  return (r.mine ? ['You', ...r.names] : r.names).join(', ')
 }
 
 function fmt(iso: string): string {

--- a/packages/web/src/lib/comments.ts
+++ b/packages/web/src/lib/comments.ts
@@ -24,9 +24,8 @@ export interface ElementAnchor {
 }
 
 /** One DISTINCT emoji on a comment, aggregated server-side: how many people used it, whether the
- *  caller is one of them, and the other reactors' display names in reaction order. Mirrors the api
- *  CommentReaction — reactor IDS stay on the server, and `names` is capped there, so it can be
- *  SHORTER than `count` implies: whoever it leaves out is the "and N others" the chip spells out. */
+ *  caller is one of them, and EVERY other reactor's display name in reaction order. Mirrors the api
+ *  CommentReaction — the reactor ids stay on the server; the names do not. */
 export type CommentReaction = { emoji: string; count: number; mine: boolean; names: string[] }
 
 export interface CommentItem {


### PR DESCRIPTION
"You, Ada, Bo" — every reactor, no cap, no "and N others".

- Server: dropped the 8-name cap, so `count` is now exactly `names.length` + the caller.
- Client: plain comma join, no "and" before the last name — it's a list, not a sentence.

api 1253 pass · web 444 pass · typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUPXH8c8atcJPSEiiQk1UL