### PR TITLE
feat(viewer): the top bar says who can see this site

### DIFF
--- a/packages/web/src/components/ViewerTopBar.test.tsx
+++ b/packages/web/src/components/ViewerTopBar.test.tsx
@@ -11,7 +11,7 @@ const SITE: ViewerSite = {
   spaceSlug: 'sp',
   siteSlug: 'site',
   title: 'T',
-  visibility: 'public',
+  visibility: 'team',
   status: 'active',
   isOwner: false,
   contentUrl: 'https://content.example.com/sp/site/',
@@ -20,14 +20,16 @@ const SITE: ViewerSite = {
 
 // A DATA router, not MemoryRouter: the star control (useStar) calls useRevalidator, which throws
 // outside one — the top bar cannot be rendered bare any more.
-function renderTopBar(overrides: Partial<{ railOpen: boolean; commentCount: number; onToggleRail: () => void }> = {}) {
+function renderTopBar(
+  overrides: Partial<{ railOpen: boolean; commentCount: number; onToggleRail: () => void; site: ViewerSite }> = {},
+) {
   const onToggleRail = overrides.onToggleRail ?? mock(() => {})
   const router = createMemoryRouter([
     {
       path: '/',
       element: (
         <ViewerTopBar
-          site={SITE}
+          site={overrides.site ?? SITE}
           sitePath=""
           railOpen={overrides.railOpen ?? false}
           commentCount={overrides.commentCount ?? 0}
@@ -67,5 +69,19 @@ describe('ViewerTopBar — Comments is an always-present toggle (C2b: Done is go
     expect(screen.getByRole('button', { name: /Comments/ }).textContent).toContain('3')
     renderTopBar({ railOpen: true, commentCount: 5 })
     expect(screen.getAllByRole('button', { name: /Comments/ }).at(-1)?.textContent).toContain('5')
+  })
+})
+
+describe('ViewerTopBar — the visibility tier rides beside the site name', () => {
+  test('a viewer (not the owner) sees the tier as a read-only chip', () => {
+    renderTopBar({ site: { ...SITE, visibility: 'members', isOwner: false } })
+    expect(screen.getByText('Members')).toBeTruthy()
+    // Read-only: the chip is text, not a picker trigger.
+    expect(screen.queryByRole('button', { name: /Members/ })).toBeNull()
+  })
+
+  test('the owner gets the picker trigger for the tier', () => {
+    renderTopBar({ site: { ...SITE, visibility: 'private', isOwner: true } })
+    expect(screen.getByRole('button', { name: /Private/ })).toBeTruthy()
   })
 })

--- a/packages/web/src/components/ViewerTopBar.tsx
+++ b/packages/web/src/components/ViewerTopBar.tsx
@@ -1,14 +1,17 @@
 import { ChevronRight, Command, GitFork, History, Menu, MessageSquare, Share2, Sparkles, Star } from 'lucide-react'
 import { useState } from 'react'
 import { Link } from 'react-router'
+import { toast } from 'sonner'
 import { useStar } from '@/hooks/useStar'
-import type { ViewerSite } from '@/lib/types'
+import { api } from '@/lib/api'
+import type { ViewerSite, Visibility } from '@/lib/types'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu'
 import { ForkDialog } from '@/components/ForkDialog'
 import { ShareDialog } from '@/components/ShareDialog'
 import { SummarySheet } from '@/components/SummarySheet'
+import { VISIBILITY_META, VisibilityBadge, VisibilityMenu } from '@/components/visibility'
 import { BrandMark } from '@/components/states'
 
 // The persistent top chrome for the viewer: brand (→ dashboard) + a breadcrumb, then one action
@@ -65,6 +68,10 @@ export function ViewerTopBar({
           </>
         )}
       </nav>
+
+      {/* Right after the name, so "what site is this — private / members / team" is answered
+          without opening a dialog. The owner gets the live picker; everyone else a read-only chip. */}
+      {site.isOwner ? <ViewerVisibility site={site} /> : <VisibilityBadge value={site.visibility} className="shrink-0" />}
 
       <div className="ml-auto flex shrink-0 items-center gap-2">
         <Button
@@ -147,5 +154,30 @@ export function ViewerTopBar({
         />
       )}
     </header>
+  )
+}
+
+// Owner-only tier picker, same chip as the dashboard table. It holds its own value rather than
+// revalidating: the viewer's loader also re-fires the comments prefetch, and a visibility PATCH is
+// no reason to pay for that — the tier is the only thing that changed.
+function ViewerVisibility({ site }: { site: ViewerSite }) {
+  const [visibility, setVisibility] = useState(site.visibility)
+
+  async function change(v: Visibility) {
+    const prev = visibility
+    setVisibility(v)
+    try {
+      await api.patch(`/api/sites/${site.spaceSlug}/${site.siteSlug}`, { visibility: v })
+      toast.success('Visibility updated', { description: VISIBILITY_META[v].label })
+    } catch (err) {
+      setVisibility(prev)
+      toast.error('Could not update visibility', { description: err instanceof Error ? err.message : undefined })
+    }
+  }
+
+  return (
+    <span className="shrink-0">
+      <VisibilityMenu trigger="chip" value={visibility} onChange={change} />
+    </span>
   )
 }

--- a/packages/web/src/routes/viewer.test.tsx
+++ b/packages/web/src/routes/viewer.test.tsx
@@ -46,7 +46,7 @@ const SITE: ViewerSite = {
   spaceSlug: 'sp',
   siteSlug: 'site',
   title: 'T',
-  visibility: 'public',
+  visibility: 'team',
   status: 'active',
   isOwner: true,
   contentUrl: 'https://content.example.com/sp/site/',


### PR DESCRIPTION
The viewer's breadcrumb named the site but never its tier — answering "is this private, members-only, or team-wide?" meant leaving the page for the dashboard. The visibility chip now sits right after the site name.

- **Owner** → the live `VisibilityMenu` chip, the same control the dashboard table uses. Picking a tier PATCHes `/api/sites/:space/:site`, optimistic, with a revert + error toast if it fails.
- **Everyone else** → a read-only `VisibilityBadge`.

It holds its own value instead of calling `revalidator.revalidate()`: the viewer's loader also re-fires the comments prefetch, and a tier change is no reason to pay for that round-trip.

### Drive-by fix

Two `ViewerSite` test fixtures claimed `visibility: 'public'` — a tier that has not existed since the enum settled on `private | members | team`. `VISIBILITY_META['public']` is `undefined`, so the new chip crashed the render on those fixtures. Both now say `'team'`.

### Verification

- `bun test` in `packages/web`: **446 pass / 0 fail** (two new cases: the owner gets the picker trigger, a non-owner gets a non-interactive chip)
- `tsc --noEmit` and `biome lint` clean

No screenshot attached — the chip lives behind a deployed site + login, so capturing it needs a full local stack. Say the word and I'll bring one up and add before/after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUPXH8c8atcJPSEiiQk1UL