### PR TITLE
feat(api): hourly cron keeps the admin stats KV fresh

### DIFF
--- a/packages/api/src/index.test.ts
+++ b/packages/api/src/index.test.ts
@@ -1,13 +1,16 @@
 import { describe, expect, test } from 'bun:test'
-import app from './index'
+import worker from './index'
+import { STATS_CACHE_KEY, STATS_TOTALS_CACHE_KEY } from './lib/stats'
+import { makeKv } from './test/harness'
 
-// Composition-level checks against the real root app (routes registered before the /api/* guards
-// need no DB, so a minimal env suffices).
+// Composition-level checks against the real worker export (routes registered before the /api/*
+// guards need no DB, so a minimal env suffices). Exercised through `worker.fetch` — the handler
+// production actually invokes — not a Hono test helper.
 const ENV = { CONTENT_URL: 'https://content.example.com', APP_URL: 'https://glance.example.com' } as never
 
 describe('shared-backend routes on the root app', () => {
   test('/api/glance.js serves the built SDK with the global CSP applied', async () => {
-    const res = await app.request('/api/glance.js', {}, ENV)
+    const res = await worker.fetch(new Request('https://glance.example.com/api/glance.js'), ENV)
     expect(res.status).toBe(200)
     expect(res.headers.get('content-type')).toContain('javascript')
     expect(res.headers.get('content-security-policy')).toContain("script-src 'self'")
@@ -17,7 +20,33 @@ describe('shared-backend routes on the root app', () => {
   })
 
   test('no demo page ships (deleted — rebuilt broker-side in Phase 2)', async () => {
-    const res = await app.request('/api/glance-demo', {}, ENV)
+    const res = await worker.fetch(new Request('https://glance.example.com/api/glance-demo'), ENV)
     expect(res.status).not.toBe(200)
+  })
+})
+
+describe('scheduled — hourly synthetic stats visitor (issue #102, Option A)', () => {
+  test('a cron tick on a cold KV warms BOTH stats halves', async () => {
+    // A D1 binding shaped like client.test.ts's: enough for drizzle to run the stat scans and
+    // return empty rows — the spec here is the KV writes, not the numbers.
+    const statement = {
+      bind: () => statement,
+      all: async () => ({ results: [], success: true, meta: {} }),
+      run: async () => ({ results: [], success: true, meta: {} }),
+      raw: async () => [],
+    }
+    const kv = makeKv()
+    const env = {
+      GLANCE_DB: { withSession: () => ({ prepare: () => statement, getBookmark: () => null }) },
+      GLANCE_SESSIONS: kv,
+    } as never
+
+    expect(typeof worker.scheduled).toBe('function')
+    await worker.scheduled({ cron: '0 * * * *', scheduledTime: Date.now() } as never, env, {
+      waitUntil: () => {},
+    } as never)
+
+    expect(kv.store.has(STATS_CACHE_KEY)).toBe(true)
+    expect(kv.store.has(STATS_TOTALS_CACHE_KEY)).toBe(true)
   })
 })

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,7 +1,8 @@
 import { Hono } from 'hono'
 import { secureHeaders } from 'hono/secure-headers'
-import { withDb } from './db/client'
+import { sessionDb, withDb } from './db/client'
 import { superadminExists } from './db/repo'
+import { cachedStats } from './lib/stats'
 import { GLANCE_DB_JS } from './glancedb/bundle'
 import { buildPublicConfig } from './lib/bootstrap'
 import { INSTALL_SH } from './install-script'
@@ -24,7 +25,7 @@ import { spaces } from './routes/spaces'
 import { stars } from './routes/stars'
 import { upload } from './routes/upload'
 import { users } from './routes/users'
-import type { AppEnv } from './types'
+import type { AppEnv, Bindings } from './types'
 
 // Main worker: /api/* (Hono) + the React SPA (static assets, configured in wrangler.jsonc).
 // `run_worker_first: ["/api/*"]` routes API calls here; everything else falls through to
@@ -133,4 +134,15 @@ app.route('/api/slack', slackEvents)
 // or the SITE_ROOM binding (class_name: "SiteRoom") fails to resolve at deploy time.
 export { SiteRoom } from './realtime/site-room'
 
-export default app
+// Hourly synthetic stats visitor (issue #102, Option A). cachedStats already models
+// refresh-only-when-stale, so a cron tick is just a caller on a fixed clock: each run recomputes
+// only the halves past their soft TTL (window hourly, totals daily) and rewrites their KV
+// entries, keeping GET /api/admin/stats on fresh KV with zero inline D1 compute. The defer is an
+// inline await — there is no visitor waiting on this response, so nothing needs to run behind it.
+export default {
+  fetch: app.fetch,
+  async scheduled(_event, env, _ctx) {
+    const db = sessionDb(env.GLANCE_DB, 'first-unconstrained')
+    await cachedStats(env.GLANCE_SESSIONS, db, (p) => p.then(() => {}))
+  },
+} satisfies ExportedHandler<Bindings>

--- a/packages/api/src/routes/comment-feed.test.ts
+++ b/packages/api/src/routes/comment-feed.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'bun:test'
 import { and, eq } from 'drizzle-orm'
 import type { CommentFeedItem } from '../db/comment-feed'
 import { comments, sites, siteUserShares, spaceMembers, users } from '../db/schema'
-import realApp from '../index'
+import worker from '../index'
 import type { AppEnv } from '../types'
 import {
   makeKv,
@@ -113,7 +113,7 @@ describe('comment feed route — C4.6 root-app composition', () => {
       GLANCE_SESSIONS: makeKv(),
     } as unknown as AppEnv['Bindings']
 
-    const res = await realApp.request(FEED_URL, {}, env)
+    const res = await worker.fetch(new Request(`${APP_URL}${FEED_URL}`), env)
 
     expect(res.status).toBe(401)
     expect(res.status).not.toBe(404)

--- a/packages/api/wrangler.jsonc
+++ b/packages/api/wrangler.jsonc
@@ -49,6 +49,10 @@
   // must use `wrangler dev --local` (the `dev` script does), which disables this binding so env.AI
   // is undefined and transcription falls back — no Cloudflare login required just to run the app.
   "ai": { "binding": "AI", "remote": true },
+  // Hourly synthetic stats visitor (src/index.ts `scheduled`): each run refreshes only the stats
+  // KV halves past their soft TTL — window hourly, totals daily — so the admin dashboard always
+  // reads fresh KV and never pays the ~33k-row D1 rollup inline on a request.
+  "triggers": { "crons": ["0 * * * *"] },
   // Free, no Cloudflare zone needed (unlike WAF rules, which don't apply to *.workers.dev).
   // 10 upload requests / 60s per client IP. period must be 10 or 60.
   "ratelimits": [


### PR DESCRIPTION
Implements Option A of #102.

A stats cache miss still costs ~33k D1 rows inline on an admin request. This adds an hourly cron that acts as a synthetic stats visitor: `cachedStats` already models refresh-only-when-stale, so each tick recomputes only the halves past their soft TTL — the 30-day window hourly, the all-time totals once a day. `GET /api/admin/stats` now ~always reads fresh KV with zero inline D1 compute, and the daily D1 cost is a small constant.

The worker export becomes the `{ fetch, scheduled }` handler shape (`satisfies ExportedHandler<Bindings>`); the Durable Object export is unchanged. Smoke-tested locally via `wrangler dev --test-scheduled`: one tick writes both `stats:admin:*:v3` KV entries with the expected envelope and expirations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014yzx5by7gpyGbSRKHz4w1B