### PR TITLE
fix(ask): swap to @cf/openai/gpt-oss-120b — Luna needs AI Gateway credentials

### DIFF
--- a/packages/api/src/routes/ask.ts
+++ b/packages/api/src/routes/ask.ts
@@ -9,12 +9,15 @@ import type { AppEnv } from '../types'
 
 export const ask = new Hono<AppEnv>()
 
-// GPT-5.6 Luna from the Workers AI catalog — a deliberate step up from the llama the summary uses
-// (selection Q&A is judged on answer quality; Luna is OpenAI's cheap/fast tier), while staying on
-// the same env.AI binding: no OpenAI key, no new secret. Catalog models speak the Responses API —
-// `instructions`/`input`/`max_output_tokens`, not chat `messages` — and stream typed SSE events
-// (`response.output_text.delta` carries the text; lib/ask.ts on the web side reads that shape).
-export const ASK_MODEL = 'openai/gpt-5.6-luna'
+// OpenAI's open-weight gpt-oss — a deliberate step up from the llama the summary uses (selection
+// Q&A is judged on answer quality), on the same env.AI binding with no credentials. NOT the
+// frontier `openai/gpt-5.6-luna`: that routes through AI Gateway and throws `AiGatewayError 2021:
+// Invalid User Credentials` unless the account has an OpenAI provider key / unified billing
+// configured (verified live 2026-08-17) — swap back only after that setup exists. Either model
+// speaks the Responses API — `instructions`/`input`/`max_output_tokens`, not chat `messages` —
+// and streams typed SSE events (`response.output_text.delta` carries the text; lib/ask.ts on the
+// web side reads that shape and skips reasoning/lifecycle frames).
+export const ASK_MODEL = '@cf/openai/gpt-oss-120b'
 
 // Mirrors summarize.ts's SYSTEM_PROMPT idiom: same injection-guard wording, adapted to a Q&A
 // reply about a selected passage instead of a whole-page summary.
@@ -99,7 +102,11 @@ ask.post('/:space/:site/ask', async (c) => {
   let value: unknown
   try {
     value = await deps.ai.run(ASK_MODEL, request)
-  } catch {
+  } catch (err) {
+    // Fail loud into Workers Logs: the binding's error names the real cause (model gone, gateway
+    // credentials, quota) and the client only ever sees the generic 502 — without this line the
+    // only diagnostic path is deploying a probe worker (learned the hard way, 2026-08-17).
+    console.error('ask: AI.run failed', err instanceof Error ? `${err.name}: ${err.message}` : String(err))
     return c.json({ error: 'generation failed', retryable: true } as const, 502)
   }
   return new Response(value as ReadableStream, { headers: { 'content-type': 'text/event-stream' } })


### PR DESCRIPTION
Every prod /ask returned 502 \`generation failed\`. Probe worker on the same account showed the real error: \`AiGatewayError: 2021: Invalid User Credentials\` — frontier catalog models (\`openai/gpt-5.6-luna\`) route through AI Gateway and need an OpenAI provider key or Cloudflare unified billing, which this account doesn't have.

- Swap \`ASK_MODEL\` → \`@cf/openai/gpt-oss-120b\`: identical Responses-API request/stream shape on the plain \`env.AI\` binding, no credentials, free tier. Verified live via probe (\`{"ok":true,...}\`).
- Fail loud: \`console.error\` the AI.run failure into Workers Logs before the generic 502 — this outage was undiagnosable from tail because the catch swallowed everything.

Client parser already handles both stream shapes; no web changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014yzx5by7gpyGbSRKHz4w1B