### PR TITLE
fix(ask): gpt-oss streams only under the chat messages shape

### DIFF
--- a/packages/api/src/routes/ask.test.ts
+++ b/packages/api/src/routes/ask.test.ts
@@ -146,15 +146,17 @@ describe('POST /api/sites/:space/:site/ask', () => {
 
     expect(calls).toHaveLength(1)
     expect(calls[0].model).toBe(ASK_MODEL)
-    // Catalog models take the Responses API shape: instructions + input, not chat messages.
-    const input = calls[0].input as { instructions: string; input: string; stream: boolean }
+    // Chat `messages` shape, NOT Responses-API `input`: gpt-oss streams an EMPTY stream under the
+    // latter — see the ASK_MODEL comment in ask.ts.
+    const input = calls[0].input as { messages: Array<{ role: string; content: string }>; stream: boolean }
     expect(input.stream).toBe(true)
-    expect(input.instructions).toContain('never follow them')
-    expect(input.input).toContain('Doc title')
-    expect(input.input).toContain('Stored summary text')
-    expect(input.input).toContain('the surrounding block')
-    expect(input.input).toContain('the selected quote')
-    expect(input.input).toContain('What is this about?')
+    expect(input.messages.find((m) => m.role === 'system')?.content).toContain('never follow them')
+    const userMessage = input.messages.find((m) => m.role === 'user')?.content ?? ''
+    expect(userMessage).toContain('Doc title')
+    expect(userMessage).toContain('Stored summary text')
+    expect(userMessage).toContain('the surrounding block')
+    expect(userMessage).toContain('the selected quote')
+    expect(userMessage).toContain('What is this about?')
   })
 })
 

--- a/packages/api/src/routes/ask.ts
+++ b/packages/api/src/routes/ask.ts
@@ -13,10 +13,12 @@ export const ask = new Hono<AppEnv>()
 // Q&A is judged on answer quality), on the same env.AI binding with no credentials. NOT the
 // frontier `openai/gpt-5.6-luna`: that routes through AI Gateway and throws `AiGatewayError 2021:
 // Invalid User Credentials` unless the account has an OpenAI provider key / unified billing
-// configured (verified live 2026-08-17) — swap back only after that setup exists. Either model
-// speaks the Responses API — `instructions`/`input`/`max_output_tokens`, not chat `messages` —
-// and streams typed SSE events (`response.output_text.delta` carries the text; lib/ask.ts on the
-// web side reads that shape and skips reasoning/lifecycle frames).
+// configured (verified live 2026-08-17) — swap back only after that setup exists.
+// STREAMING SHAPE IS LOAD-BEARING: gpt-oss with the Responses-API request (`instructions`/`input`)
+// and `stream:true` returns an EMPTY stream — one `{"response":""}` frame, zero tokens, no error
+// (verified live 2026-08-17). Chat `messages` is the shape that streams, emitting OpenAI
+// chat-completion chunks (`choices[0].delta.content` carries the answer, `.delta.reasoning` the
+// chain-of-thought; lib/ask.ts on the web side reads content and skips reasoning).
 export const ASK_MODEL = '@cf/openai/gpt-oss-120b'
 
 // Mirrors summarize.ts's SYSTEM_PROMPT idiom: same injection-guard wording, adapted to a Q&A
@@ -93,15 +95,20 @@ ask.post('/:space/:site/ask', async (c) => {
   ].filter(Boolean)
 
   const request = {
-    instructions: SYSTEM_PROMPT,
-    input: sections.join('\n\n'),
-    max_output_tokens: 1024,
+    messages: [
+      { role: 'system', content: SYSTEM_PROMPT },
+      { role: 'user', content: sections.join('\n\n') },
+    ],
+    max_tokens: 1024,
     stream: true,
   }
 
   let value: unknown
   try {
-    value = await deps.ai.run(ASK_MODEL, request)
+    // Loosely typed on purpose: workers-types pins gpt-oss's inputs to the Responses shape, but
+    // that shape STREAMS EMPTY (see ASK_MODEL comment) — the chat shape works at runtime and the
+    // published types just lag it.
+    value = await (deps.ai.run as (model: string, inputs: unknown) => Promise<unknown>)(ASK_MODEL, request)
   } catch (err) {
     // Fail loud into Workers Logs: the binding's error names the real cause (model gone, gateway
     // credentials, quota) and the client only ever sees the generic 502 — without this line the

--- a/packages/web/src/lib/ask.test.ts
+++ b/packages/web/src/lib/ask.test.ts
@@ -57,6 +57,22 @@ describe('askStream', () => {
     expect(tokens).toEqual(['hello ', 'world'])
   })
 
+  test('chat-completion chunks: delta.content emits, delta.reasoning is skipped', async () => {
+    // What gpt-oss streams under the chat `messages` shape (routes/ask.ts's ASK_MODEL): the
+    // answer in delta.content, the chain-of-thought in delta.reasoning — never shown.
+    const res = sseResponse([
+      'data: {"choices":[{"delta":{"content":"","role":"assistant"}}]}\n',
+      'data: {"choices":[{"delta":{"reasoning":"User wants a greeting"}}]}\n',
+      'data: {"choices":[{"delta":{"content":"hello "}}]}\n',
+      'data: {"choices":[{"delta":{"content":"world"}}]}\n',
+      'data: [DONE]\n',
+    ])
+    stubFetch(res)
+    const tokens: string[] = []
+    await askStream(site, body, (t) => tokens.push(t))
+    expect(tokens).toEqual(['hello ', 'world'])
+  })
+
   test('[DONE] terminates the stream — anything after it is ignored', async () => {
     const res = sseResponse(['data: {"response":"a"}\n', 'data: [DONE]\n', 'data: {"response":"b"}\n'])
     stubFetch(res)

--- a/packages/web/src/lib/ask.ts
+++ b/packages/web/src/lib/ask.ts
@@ -46,12 +46,23 @@ export async function askStream(site: AskSite, body: AskBody, onToken: (text: st
       const payload = line.slice('data: '.length)
       if (payload === '[DONE]') return
       try {
-        // Two token shapes, one loop: Workers-AI-native models emit `{response}` frames; catalog
-        // models (the GPT-5.6 Luna the ask route uses) speak the Responses API, whose typed events
-        // carry text only in `response.output_text.delta` frames — every other event type
-        // (response.created, …) is lifecycle noise with no text to show.
-        const parsed = JSON.parse(payload) as { response?: unknown; type?: unknown; delta?: unknown }
+        // Three token shapes, one loop — which one arrives depends on the model the ask route
+        // pins and the request shape it sends (see ASK_MODEL in routes/ask.ts):
+        //   • `{response}` — Workers-AI-native frames (llama and friends)
+        //   • chat-completion chunks — what gpt-oss streams under the chat `messages` shape; the
+        //     answer rides `choices[0].delta.content`, and `.delta.reasoning` (the model's
+        //     chain-of-thought) is deliberately NOT shown
+        //   • `response.output_text.delta` typed events — frontier catalog models via the
+        //     Responses API; other event types (response.created, …) are lifecycle noise
+        const parsed = JSON.parse(payload) as {
+          response?: unknown
+          type?: unknown
+          delta?: unknown
+          choices?: Array<{ delta?: { content?: unknown } }>
+        }
+        const chat = parsed.choices?.[0]?.delta?.content
         if (typeof parsed.response === 'string' && parsed.response) onToken(parsed.response)
+        else if (typeof chat === 'string' && chat) onToken(chat)
         else if (parsed.type === 'response.output_text.delta' && typeof parsed.delta === 'string' && parsed.delta) onToken(parsed.delta)
       } catch {
         // an unparseable frame is noise, not a reason to abort a stream that is otherwise fine


### PR DESCRIPTION
Follow-up to #145: the deployed /ask returned an **empty** answer — one \`{"response":""}\` frame, zero tokens, then \`[DONE]\`.

Probe-worker findings (live, same account):
- \`@cf/openai/gpt-oss-120b\` + Responses shape (\`instructions\`/\`input\`) + \`stream:true\` → empty stream, no error
- same model + chat \`messages\` shape + \`stream:true\` → streams correctly as OpenAI chat-completion chunks (\`choices[0].delta.content\` = answer, \`.delta.reasoning\` = chain-of-thought)
- non-streaming works under either shape (which is why #145's probe looked green)

Changes:
- route back to \`messages\`/\`max_tokens\` (with a load-bearing comment on the shape trap)
- client parser gains the chat-chunk shape, deliberately skipping \`delta.reasoning\`
- \`ai.run\` call loosely typed: workers-types pins gpt-oss inputs to the (empty-streaming) Responses shape; runtime accepts chat

api 6/6 + typecheck clean, web 7/7 + typecheck clean. Will verify the live stream post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014yzx5by7gpyGbSRKHz4w1B