### PR TITLE
feat(ask): animated loading — sparkle pulse + shimmer wait, token fade-in stream

### DIFF
--- a/packages/web/src/components/review/CommentPopover.test.tsx
+++ b/packages/web/src/components/review/CommentPopover.test.tsx
@@ -10,7 +10,7 @@
 // selection" assertion here would be theatre — real geometry is proven in the browser (B4).
 import { describe, expect, mock, test } from 'bun:test'
 import { useReducer } from 'react'
-import { act, fireEvent, render, screen } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { ApiError } from '@/lib/api'
 import { type Anchor, initialPopover, stepPopover } from '@/lib/commentPopover'
 import { CommentPopover } from './CommentPopover'
@@ -232,8 +232,12 @@ describe('the ask panel', () => {
     })
 
     // Streamdown marks semantics with data-streamdown attributes (bold is a styled span).
-    expect(document.querySelector('[data-streamdown="strong"]')?.textContent).toBe('bold')
-    expect(document.querySelector('[data-streamdown="list-item"]')?.textContent?.trim()).toBe('item')
+    // waitFor, not a plain expect: with isAnimating the token fade commits DOM behind animation
+    // frames, so on a slow runner the elements land a tick after the act() above (CI-only flake).
+    await waitFor(() => {
+      expect(document.querySelector('[data-streamdown="strong"]')?.textContent).toBe('bold')
+      expect(document.querySelector('[data-streamdown="list-item"]')?.textContent?.trim()).toBe('item')
+    })
     // The follow-up box locks while streaming — readOnly, not disabled, so the panel keeps focus
     // (and with it the Escape route out).
     expect((screen.getByPlaceholderText('Ask a follow-up…') as HTMLTextAreaElement).readOnly).toBe(true)

--- a/packages/web/src/components/review/CommentPopover.tsx
+++ b/packages/web/src/components/review/CommentPopover.tsx
@@ -310,10 +310,19 @@ function AskPanel({
               </div>
             ) : turn.answer ? (
               <Suspense fallback={<p className="whitespace-pre-wrap text-sm">{turn.answer}</p>}>
-                <Streamdown className="text-sm">{turn.answer}</Streamdown>
+                {/* isAnimating = Streamdown's built-in token fade-in while chunks arrive. */}
+                <Streamdown className="text-sm" isAnimating={turn.status === 'streaming'}>
+                  {turn.answer}
+                </Streamdown>
               </Suspense>
             ) : (
-              <p className="text-muted-foreground text-xs">Thinking…</p>
+              /* The pre-first-token wait: the chip's own sparkle pulsing beside shimmering text.
+                 Classes live in tailwind.css (ask-sparkle / ask-shimmer) with a reduced-motion
+                 collapse to static text. */
+              <span className="inline-flex items-center gap-1.5">
+                <Sparkles className="ask-sparkle size-3.5" aria-hidden />
+                <span className="ask-shimmer text-xs">Thinking…</span>
+              </span>
             )}
           </div>
         ))}

--- a/packages/web/src/tailwind.css
+++ b/packages/web/src/tailwind.css
@@ -185,3 +185,32 @@
   height: 1px;
   background: linear-gradient(to right, var(--border), transparent);
 }
+
+/* Ask panel's pre-first-token wait (AskPanel): the chip's sparkle pulsing beside shimmering
+   "Thinking…". Collapses to static muted text under prefers-reduced-motion. */
+.ask-sparkle {
+  color: var(--primary);
+  transform-origin: center;
+  animation: ask-sparkle 1.6s ease-in-out infinite;
+}
+@keyframes ask-sparkle {
+  0%, 100% { transform: scale(0.85) rotate(0deg); opacity: 0.55; filter: drop-shadow(0 0 0 transparent); }
+  50% { transform: scale(1.12) rotate(20deg); opacity: 1; filter: drop-shadow(0 0 6px color-mix(in oklch, var(--primary) 55%, transparent)); }
+}
+.ask-shimmer {
+  font-weight: 500;
+  background: linear-gradient(90deg, var(--muted-foreground) 30%, var(--foreground) 50%, var(--muted-foreground) 70%);
+  background-size: 200% 100%;
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  animation: ask-shimmer 1.8s linear infinite;
+}
+@keyframes ask-shimmer {
+  0% { background-position: 120% 0; }
+  100% { background-position: -80% 0; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .ask-sparkle { animation: none; }
+  .ask-shimmer { animation: none; background: none; color: var(--muted-foreground); }
+}


### PR DESCRIPTION
User-approved design (from the options wireframe): waiting = the Ask chip's own lucide Sparkles pulsing with a soft primary-colored glow beside shimmer-swept "Thinking…"; streaming = Streamdown's built-in token fade-in (`isAnimating`).

- Pure CSS: `ask-sparkle` / `ask-shimmer` keyframes in tailwind.css, keyed to theme vars so light/dark and the amber brand track automatically
- `prefers-reduced-motion` collapses both to static muted text
- No new dependency; the icon is the chip's existing import

web: 14/14 popover tests, full suite green, typecheck clean, vite build verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014yzx5by7gpyGbSRKHz4w1B