### PR TITLE
feat(notifications): notify users when a site is directly shared with them

### DIFF
--- a/packages/api/src/db/notifications.ts
+++ b/packages/api/src/db/notifications.ts
@@ -25,7 +25,7 @@ const now = () => new Date().toISOString()
 const NOTIFICATION_INSERT_COLUMN_COUNT = 11
 const NOTIFICATION_ROWS_PER_INSERT = Math.floor(D1_MAX_BOUND_PARAMETERS / NOTIFICATION_INSERT_COLUMN_COUNT)
 
-/** One row to raise. `type` is required ('mention' | 'comment'); id + createdAt are generated.
+/** One row to raise. `type` is required ('mention' | 'comment' | 'share'); id + createdAt are generated.
  *  All targets are optional so a row survives (via denormalized `siteLabel`) after the site/thread/
  *  comment it points at is gone — see the SET NULL FKs in schema. */
 export type NotificationInput = {
@@ -78,10 +78,11 @@ export async function createNotifications(db: DrizzleD1Database, rows: Notificat
 
 /** Why a comment recipient is in the audience — drives the Slack verb (the in-app D1 row stays
  *  `type='comment'`, no migration). Precedence owner > participant > share. Derived from SlackReason
- *  minus 'mention' so the "SlackReason ⊇ CommentAudienceReason" invariant (relied on by the audience
- *  spread in comments.ts) is compiler-guaranteed, not comment-synced. Type-only import — erased at
- *  runtime, and db→lib is the existing dependency direction (cf. lib/access). */
-export type CommentAudienceReason = Exclude<SlackReason, 'mention'>
+ *  minus 'mention' (mentions win upstream) and 'shared' (the non-comment share event) so the
+ *  "SlackReason ⊇ CommentAudienceReason" invariant (relied on by the audience spread in comments.ts)
+ *  is compiler-guaranteed, not comment-synced. Type-only import — erased at runtime, and db→lib is
+ *  the existing dependency direction (cf. lib/access). */
+export type CommentAudienceReason = Exclude<SlackReason, 'mention' | 'shared'>
 export type CommentRecipient = { id: string; reason: CommentAudienceReason }
 
 /** Resolve the normal comment audience from targeted facts, excluding the actor and any mention

--- a/packages/api/src/db/schema.ts
+++ b/packages/api/src/db/schema.ts
@@ -320,8 +320,9 @@ export const events = sqliteTable(
   ],
 )
 
-// Homepage notifications. Notifications carry type 'mention' (@-tag) or 'comment' (activity on your
-// sites / threads you participate in); `commentId` identifies the triggering comment for feed
+// Homepage notifications. Notifications carry type 'mention' (@-tag), 'comment' (activity on your
+// sites / threads you participate in), or 'share' (a site was directly shared with you — user
+// shares only, never group grants); `commentId` identifies the triggering comment for feed
 // dedupe. FK durability mirrors `events`/`comments`: the RECIPIENT cascades (a deleted user's
 // notifications are meaningless), but actor/site/thread/comment are SET NULL so the row survives the
 // deletion of what it points at — `siteLabel` denormalizes "space/slug" (captured from route params
@@ -333,7 +334,7 @@ export const notifications = sqliteTable(
   {
     id: text('id').primaryKey().$defaultFn(() => crypto.randomUUID()),
     recipientId: text('recipientId').notNull().references(() => users.id, { onDelete: 'cascade' }),
-    type: text('type', { enum: ['mention', 'comment'] }).notNull(),
+    type: text('type', { enum: ['mention', 'comment', 'share'] }).notNull(),
     actorId: text('actorId').references(() => users.id, { onDelete: 'set null' }),
     siteId: text('siteId').references(() => sites.id, { onDelete: 'set null' }),
     // Denormalized "space/slug" from the route params at insert — survives a site delete.

--- a/packages/api/src/lib/slack.ts
+++ b/packages/api/src/lib/slack.ts
@@ -7,8 +7,9 @@ import { notificationLink } from './notification-link'
 
 /** Why a recipient is being notified — drives the message verb. Precedence (owner > participant >
  *  share) is resolved upstream in resolveCommentAudience; here each recipient carries one reason.
- *  `mention` recipients always carry reason='mention'. */
-export type SlackReason = 'mention' | 'owner' | 'participant' | 'share'
+ *  `mention` recipients always carry reason='mention'. `shared` is the non-comment event: a site
+ *  was just directly shared with the recipient (notifyForShare). */
+export type SlackReason = 'mention' | 'owner' | 'participant' | 'share' | 'shared'
 
 /** KV + token + fetch handle every Slack HTTP helper needs. `token` optional: unset = kill-switch. */
 export type SlackHttpDeps = {
@@ -156,6 +157,7 @@ const VERB: Record<SlackReason, (siteLabel: string) => string> = {
   owner: (s) => `commented on your site ${s}`,
   participant: (s) => `replied in a thread you commented on · ${s}`,
   share: (s) => `commented on ${s}`,
+  shared: (s) => `shared ${s} with you`,
 }
 
 /** Build the Slack DM text: `*{actor}* {verb clause}` where the site label is a BOLD hyperlink

--- a/packages/api/src/routes/sites-shares.test.ts
+++ b/packages/api/src/routes/sites-shares.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 import { Hono } from 'hono'
+import { listNotifications } from '../db/notifications'
 import { resolveShareRole } from '../db/repo'
 import { requireSameOrigin } from '../middleware/auth'
 import { makeDb, makeKv, seedSite, seedSpace, seedUser } from '../test/harness'
@@ -89,5 +90,62 @@ describe('PUT/GET /shares — roles + backcompat', () => {
     expect(res.status).toBe(400)
     // no direct share smuggled in for the group id
     expect(await resolveShareRole(db, site, grp)).toBeNull()
+  })
+})
+
+// In app.request there is no executionCtx, so fireAndForget awaits inline — the notification
+// fan-out is complete when the PUT resolves.
+describe('PUT /shares — share notifications', () => {
+  test('share.notify.new: a newly granted user gets one unread type=share row', async () => {
+    const { db, app, env } = await setup()
+    expect((await put(app, env, { users: [{ id: 'ed', role: 'viewer' }] })).status).toBe(200)
+    const { items, unreadCount } = await listNotifications(db, 'ed')
+    expect(unreadCount).toBe(1)
+    expect(items[0]).toMatchObject({ type: 'share', actorName: 'owner@example.com', siteLabel: 'mine/doc' })
+  })
+
+  test('share.notify.no-regrant: re-PUT of the same user (even with a role change) raises nothing new', async () => {
+    const { db, app, env } = await setup()
+    await put(app, env, { users: [{ id: 'ed', role: 'viewer' }] })
+    await put(app, env, { users: [{ id: 'ed', role: 'editor' }, { id: 'vw', role: 'viewer' }] })
+    expect((await listNotifications(db, 'ed')).items).toHaveLength(1)
+    expect((await listNotifications(db, 'vw')).items).toHaveLength(1)
+  })
+
+  test('share.notify.removal-silent: dropping a user raises nothing', async () => {
+    const { db, app, env } = await setup()
+    await put(app, env, { users: [{ id: 'ed', role: 'viewer' }] })
+    await put(app, env, { users: [] })
+    expect((await listNotifications(db, 'ed')).items).toHaveLength(1)
+  })
+
+  test('share.notify.groups-silent: a group grant notifies nobody', async () => {
+    const { db, app, env, grp } = await setup()
+    await put(app, env, { groupIds: [grp] })
+    for (const id of ['owner', 'ed', 'vw']) expect((await listNotifications(db, id)).items).toHaveLength(0)
+  })
+
+  test('share.notify.actor-excluded: the caller granting themselves raises nothing', async () => {
+    const { db, app, env } = await setup()
+    await put(app, env, { users: [{ id: 'owner', role: 'viewer' }] })
+    expect((await listNotifications(db, 'owner')).items).toHaveLength(0)
+  })
+
+  test('share.notify.slack: with a bot token, the new user gets a "shared … with you" DM', async () => {
+    const { app, env } = await setup()
+    const posts: { channel: string; text: string }[] = []
+    const fetchImpl = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      if (url.includes('users.lookupByEmail')) return Response.json({ ok: true, user: { id: 'U-ED' } })
+      posts.push(JSON.parse(String(init?.body)))
+      return Response.json({ ok: true })
+    }) as unknown as typeof fetch
+    const slackEnv = { ...env, SLACK_BOT_TOKEN: 'xoxb-test', SLACK_FETCH: fetchImpl } as AppEnv['Bindings']
+    expect((await put(app, slackEnv, { users: [{ id: 'ed', role: 'viewer' }] })).status).toBe(200)
+    expect(posts).toHaveLength(1)
+    expect(posts[0].channel).toBe('U-ED')
+    expect(posts[0].text).toContain('shared')
+    expect(posts[0].text).toContain('with you')
+    expect(posts[0].text).toContain(`${APP_URL}/mine/doc`)
   })
 })

--- a/packages/api/src/routes/sites.ts
+++ b/packages/api/src/routes/sites.ts
@@ -1,6 +1,7 @@
 import { and, desc, eq, inArray, or, sql } from 'drizzle-orm'
 import type { DrizzleD1Database } from 'drizzle-orm/d1'
-import { Hono } from 'hono'
+import { type Context, Hono } from 'hono'
+import { createNotifications, usersEmailsByIds } from '../db/notifications'
 import {
   type ShareUser,
   foldMemberSpaceIds,
@@ -18,10 +19,12 @@ import type { Visibility } from '../db/schema'
 import { files as filesTable, siteStars, sites as sitesTable, spaces, users } from '../db/schema'
 import { canReplace, checkAccess } from '../lib/access'
 import { batchAll, chunk, D1_MAX_IN, FEED_ID_CHUNK } from '../lib/d1'
+import { fireAndForget } from '../lib/events'
 import { resolveIndexPath } from '../lib/extract'
 import { siteFeedColumns, toFeedRow } from '../lib/site-feed'
 import { readSessionOrBearer } from '../lib/session'
 import { fetchAccessFacts, isSharedFromFacts, resolveSite, resolveSiteForAccess } from '../lib/site-access'
+import { deliverSlack, type SlackRecipient, slackDepsFromEnv, slackEnabled } from '../lib/slack'
 import { isValidSlug } from '../lib/slug'
 import { copyObjects, deleteKeys, deleteSiteObjects } from '../lib/storage'
 import { signToken } from '../lib/token'
@@ -430,6 +433,49 @@ export function parseShareGrants(body: unknown): { users: ShareUser[]; groupIds:
   return { users: [...roles].map(([userId, role]) => ({ userId, role })), groupIds }
 }
 
+/** Raise `type='share'` notifications (+ the Slack DM mirror) for users NEWLY granted a direct
+ *  share — never group grants, never re-grants, never the actor. Mirrors notifyForComment: the
+ *  whole body rides fireAndForget with a catch-all, so a notification fault never blocks or fails
+ *  the share that already committed. */
+async function notifyForShare(c: Context<AppEnv>, siteId: string, recipientIds: string[]): Promise<void> {
+  if (recipientIds.length === 0) return
+  const actor = c.get('user')
+  const db = c.get('db')
+  const { spaceSlug, siteSlug } = c.req.param()
+  const siteLabel = `${spaceSlug}/${siteSlug}`
+  await fireAndForget(
+    c,
+    (async () => {
+      try {
+        await createNotifications(
+          db,
+          recipientIds.map((recipientId) => ({
+            recipientId,
+            type: 'share' as const,
+            actorId: actor.id,
+            siteId,
+            siteLabel,
+          })),
+        )
+        if (!slackEnabled(c.env.SLACK_BOT_TOKEN)) return
+        const emails = await usersEmailsByIds(db, recipientIds)
+        const recipients: SlackRecipient[] = recipientIds.map((id) => ({
+          id,
+          email: emails.get(id) ?? null,
+          reason: 'shared' as const,
+        }))
+        await deliverSlack(
+          slackDepsFromEnv(c.env),
+          { actorName: actor.name, actorEmail: actor.email, siteLabel, filePath: null, threadId: null, snippet: null },
+          recipients,
+        )
+      } catch {
+        // Notifications are best-effort — never surface to the caller (mirrors notifyForComment).
+      }
+    })(),
+  )
+}
+
 // GET /api/sites/:spaceSlug/:siteSlug/shares — owner-only: current explicit share lists.
 sites.get('/:spaceSlug/:siteSlug/shares', requireAuth, async (c) => {
   const user = c.get('user')
@@ -477,7 +523,15 @@ sites.put('/:spaceSlug/:siteSlug/shares', requireAuth, requireControlGrant, asyn
       ).map((r) => r.id)
     : []
 
+  // Diff BEFORE the replace so only newly granted users are notified (a re-PUT of the same set,
+  // a role change, or a group grant raises nothing).
+  const prior = new Set((await listSiteShares(db, site.id)).userIds)
   await replaceSiteShares(db, site.id, validUsers, validGroups)
+  await notifyForShare(
+    c,
+    site.id,
+    validUsers.map((u) => u.userId).filter((id) => !prior.has(id) && id !== user.id),
+  )
   return c.json({
     ok: true,
     userIds: validUsers.map((u) => u.userId),

--- a/packages/cli/notifications.go
+++ b/packages/cli/notifications.go
@@ -9,7 +9,7 @@ import (
 )
 
 type notificationItem struct {
-	Type      string  `json:"type"` // "mention" | "comment"
+	Type      string  `json:"type"` // "mention" | "comment" | "share"
 	ActorName *string `json:"actorName"`
 	SiteLabel *string `json:"siteLabel"`
 	FilePath  *string `json:"filePath"`
@@ -92,8 +92,11 @@ func renderNotification(item notificationItem, now time.Time) string {
 		marker = "●"
 	}
 	verb := "commented on"
-	if item.Type == "mention" {
+	switch item.Type {
+	case "mention":
 		verb = "mentioned you on"
+	case "share":
+		verb = "shared"
 	}
 	paren := timeAgo(item.CreatedAt, now)
 	if fp := strOr(item.FilePath, ""); fp != "" {

--- a/packages/cli/notifications_test.go
+++ b/packages/cli/notifications_test.go
@@ -181,6 +181,18 @@ func TestNotificationsCommand(t *testing.T) {
 	})
 }
 
+func TestRenderNotificationShare(t *testing.T) {
+	name := "Ada"
+	site := "team/doc"
+	got := renderNotification(notificationItem{
+		Type: "share", ActorName: &name, SiteLabel: &site, CreatedAt: "2026-07-16T12:00:00Z",
+	}, time.Date(2026, 7, 16, 12, 5, 0, 0, time.UTC))
+	want := "● Ada shared team/doc (5m ago)\n"
+	if got != want {
+		t.Fatalf("renderNotification share = %q, want %q", got, want)
+	}
+}
+
 func TestTimeAgo(t *testing.T) {
 	now := time.Date(2026, 7, 16, 12, 0, 0, 0, time.UTC)
 	cases := []struct {

--- a/packages/web/src/lib/notifications.test.ts
+++ b/packages/web/src/lib/notifications.test.ts
@@ -16,6 +16,13 @@ describe('W1 — notificationLabel: actor + verb for mention/comment', () => {
     })
   })
 
+  test('share → actor name and "shared a site with you"', () => {
+    expect(notificationLabel({ type: 'share', actorName: 'Priya N' })).toEqual({
+      actor: 'Priya N',
+      verb: 'shared a site with you',
+    })
+  })
+
   test('null actorName → "Someone" for both types', () => {
     expect(notificationLabel({ type: 'mention', actorName: null }).actor).toBe('Someone')
     expect(notificationLabel({ type: 'comment', actorName: null }).actor).toBe('Someone')

--- a/packages/web/src/lib/notifications.ts
+++ b/packages/web/src/lib/notifications.ts
@@ -7,7 +7,7 @@ import type { WhatsNewList } from '@/lib/whatsNew'
 
 export interface Notification {
   id: string
-  type: 'mention' | 'comment'
+  type: 'mention' | 'comment' | 'share'
   actorId: string | null
   actorName: string | null // display name (name ?? email); null once the actor is deleted
   siteLabel: string | null // "space/slug"
@@ -23,7 +23,7 @@ export interface Notification {
 export function notificationLabel(n: Pick<Notification, 'type' | 'actorName'>): { actor: string; verb: string } {
   return {
     actor: n.actorName ?? 'Someone',
-    verb: n.type === 'comment' ? 'commented' : 'mentioned you',
+    verb: n.type === 'comment' ? 'commented' : n.type === 'share' ? 'shared a site with you' : 'mentioned you',
   }
 }
 


### PR DESCRIPTION
## Summary
- PUT /shares now diffs the prior direct-share set and raises a `type='share'` notification (bell + CLI + Slack DM mirror) for newly granted users only — group grants, re-grants/role changes, removals, and the actor stay silent.
- Rides the existing `fireAndForget`/`createNotifications`/`deliverSlack` seams; `'share'` is a TS-level enum addition on `notifications.type` (plain text column, no migration).
- Rebased onto current main: preserves main's SET NULL FK + denormalized `siteLabel` notification model, and keeps the pre-existing `'share'` SlackReason (comment-audience) distinct from the new `'shared'` SlackReason (direct-share event) so the `SlackReason ⊇ CommentAudienceReason` invariant still holds.

## Tests run
- `bun test` in `packages/api`: 1262 pass, 0 fail (incl. `src/routes/sites-shares.test.ts`, `src/db/notifications.test.ts`)
- `bun test` in `packages/web`: 485 pass, 0 fail (incl. `src/lib/notifications.test.ts`)
- `go test ./...` in `packages/cli`: ok (incl. `notifications_test.go`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)