### PR TITLE
perf(notifications): add recipientId+createdAt index for listNotifications

### DIFF
--- a/packages/api/drizzle/0027_notifications_recipient_created_index.sql
+++ b/packages/api/drizzle/0027_notifications_recipient_created_index.sql
@@ -1,0 +1,5 @@
+-- Performance: listNotifications orders by (recipientId, createdAt desc) with no readAt predicate,
+-- so the existing notifications_recipient_read_created index (recipientId, readAt, createdAt) can't
+-- serve the ordering — readAt sits in the middle and forces a full per-recipient scan + temp b-tree
+-- sort. This index leads with the exact (recipientId, createdAt) pair the list query needs.
+CREATE INDEX IF NOT EXISTS `notifications_recipient_created` ON `notifications` (`recipientId`,`createdAt`);

--- a/packages/api/drizzle/meta/_journal.json
+++ b/packages/api/drizzle/meta/_journal.json
@@ -190,6 +190,13 @@
       "when": 1786100000000,
       "tag": "0026_api_key_display_suffix",
       "breakpoints": true
+    },
+    {
+      "idx": 27,
+      "version": "6",
+      "when": 1786200000000,
+      "tag": "0027_notifications_recipient_created_index",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/src/db/schema.ts
+++ b/packages/api/src/db/schema.ts
@@ -348,8 +348,12 @@ export const notifications = sqliteTable(
     createdAt: text('createdAt').notNull().$defaultFn(() => new Date().toISOString()),
   },
   (t) => [
-    // Unread count + list for one recipient in a single index scan, newest-first.
+    // Unread count for one recipient in a single index scan.
     index('notifications_recipient_read_created').on(t.recipientId, t.readAt, t.createdAt),
+    // The list query orders by createdAt only (readAt isn't a predicate there), so it needs
+    // recipientId+createdAt leading — readAt in the middle of the index above can't serve that
+    // ordering and forces a full recipient scan + temp sort.
+    index('notifications_recipient_created').on(t.recipientId, t.createdAt),
     // Supports comment FK maintenance when a comment is hard-deleted through a site/thread cascade.
     index('notifications_comment').on(t.commentId),
   ],


### PR DESCRIPTION
## Summary
- `listNotifications` runs `WHERE recipientId=? ORDER BY createdAt DESC LIMIT 30`.
- The existing `notifications_recipient_read_created` index is `(recipientId, readAt, createdAt)` — `readAt` in the middle means it can't serve that ordering, so the query scans ALL of a recipient's rows and temp-sorts.
- Adds `notifications_recipient_created` on `(recipientId, createdAt)` (schema.ts + drizzle migration `0027_notifications_recipient_created_index.sql`) so the rows query gets an index-only ordered scan.
- The unread-count query still uses the old `(recipientId, readAt, ...)` index — untouched.

Issue #102 item 4.

## Query plan evidence
EXPLAIN QUERY PLAN for the listNotifications rows query, against an in-memory sqlite db built from all migrations in order (same harness `src/test/harness.ts` uses):

**Before** (index dropped to simulate pre-change state):
```
SEARCH notifications USING INDEX notifications_recipient_read_created (recipientId=?)
USE TEMP B-TREE FOR ORDER BY
```

**After**:
```
SEARCH notifications USING INDEX notifications_recipient_created (recipientId=?)
```
No temp b-tree — the new index serves the ordering directly.

## Test plan
- [x] `bun run typecheck` (after `bun run cf-typegen`) — passes for `@glance/api` and `@glance/web`
- [x] `cd packages/api && bun test` — 1262 pass, 0 fail, 19999 expect() calls
- [x] EXPLAIN QUERY PLAN before/after confirmed above

🤖 Generated with [Claude Code](https://claude.com/claude-code)