### PR TITLE
Delegate microphone permission to the viewer content iframe

### DIFF
--- a/packages/web/src/routes/viewer.tsx
+++ b/packages/web/src/routes/viewer.tsx
@@ -651,6 +651,11 @@ function Viewer() {
                 // links (other origins) to target=_blank; these two flags let that click open a REAL
                 // new tab that isn't itself sandboxed, so the destination site loads normally.
                 sandbox="allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox allow-forms allow-top-navigation-by-user-activation"
+                // Delegate mic to the cross-origin content frame: without this, getUserMedia is
+                // rejected before the browser prompt can appear. Nothing is granted silently — the
+                // user still approves via the normal permission prompt. Note: the grant keys to the
+                // viewer's top-level origin, so a persistent allow applies to all hosted sites.
+                allow="microphone"
               />
             )}
             {/* Sibling of the iframe ON PURPOSE: this wrapper is the iframe's own box, so the rect


### PR DESCRIPTION
Fixes mic-based demo pages (reported by Harsha: glance.plivo.com/immaraju-vardhan/klaro-vad). getUserMedia inside the cross-origin content iframe was rejected before the browser prompt could appear.

One-line fix: `allow="microphone"` on the viewer iframe.

Security notes:
- Nothing granted silently — normal browser prompt + tab recording indicator still apply.
- Grant keys to the viewer's top-level origin, so a persistent "allow" covers all hosted sites; acceptable for an internal authenticated tool (Chrome defaults to one-time grants).
- Camera intentionally not delegated (not needed yet).

Tests: web suite 29 pass, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014yzx5by7gpyGbSRKHz4w1B