### PR TITLE
SKILL.md: drop --theme / Design themes guidance

### DIFF
--- a/packages/cli/SKILL.md
+++ b/packages/cli/SKILL.md
@@ -61,7 +61,6 @@ A key can deploy, create, fork and move, but **never deletes a site** and never 
 - `--name` defaults to the **file name (sans extension)** or **folder name**, slugified. Pass `--name` to override (required if the derived name isn't a valid slug — lowercase, 3–40 chars).
 - `--space` defaults to your **personal space**. Pass `--space` to target a team/group space.
 - `--visibility` defaults to `team`.
-- `--theme <slug>` applies a **design theme** (server-injected stylesheet — see "Design themes" below). `--theme default` (or `none`) resets to the page's own design. Omitted on a replace → the site keeps its current theme.
 - If the site already exists and you own it, prompts `Replace? (y/N)`. If owned by someone else, it aborts.
 - Prints `✓ Deployed → <url>`.
 
@@ -212,18 +211,6 @@ You can update that site's content even though you don't own it and aren't in it
 `team` (default) · `private` · `members`.
 
 `members` = people in the site's own space only (it was renamed from `group`; the old value is still accepted and mapped to `members`). There is no public/anonymous tier — `public` is still accepted on the wire but mapped to `team` (everyone in your org).
-
-## Design themes
-
-A site can carry a **theme** — a server-injected classless stylesheet (element selectors only) that skins its HTML at serve time. Stored files are never modified (`read --pull` stays byte-identical); author classes/inline styles always win, so semantic HTML transforms fully while heavily self-styled pages barely change. `--theme default` resets to the page's own design.
-
-```bash
-curl -s $GLANCE_API_URL/api/themes                  # catalog: slug + name + description
-curl -s $GLANCE_API_URL/api/themes/plivo/DESIGN.md  # a theme's full design brief
-glance deploy report.html --theme plivo             # works on .md too
-```
-
-Building a page in a theme's style? Fetch its `DESIGN.md` first and follow it while writing the HTML (tokens, component recipes, do/don'ts), then deploy with `--theme <slug>`. The theme is a site property, not a file — the owner can switch it later in the UI without a redeploy.
 
 ## Saving data from your pages — `glance.db` (experimental)
 


### PR DESCRIPTION
Agents deploying via the skill were setting design themes (`--theme plivo`) on fully-designed pages, where the injected theme stylesheet overrides the page's own element rules (black-on-dark render on samuel-lawerence/miller-memory). Theme choice belongs to the site owner in the UI toolbar dropdown, not to the deploying agent.

- Removes the `--theme` flag bullet and the "Design themes" section from `packages/cli/SKILL.md`.
- CLI flag and server-side theme support are untouched — humans can still use `--theme`, and owners can still pick a theme in the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YLXKuFvrpoBYrBHNzDJfcf