### PR TITLE
Viewport-aware comment popover placement, plus inline comment editing

### DIFF
--- a/packages/web/src/components/review/CommentPopover.tsx
+++ b/packages/web/src/components/review/CommentPopover.tsx
@@ -1,6 +1,6 @@
 import { MessageSquarePlus, Sparkles, X } from 'lucide-react'
 import { lazy, Suspense, useEffect, useLayoutEffect, useRef, useState } from 'react'
-import type { Anchor, PopoverState } from '@/lib/commentPopover'
+import { type Anchor, GAP, placePopover, type PopoverState } from '@/lib/commentPopover'
 import type { DOMRectLike } from '@/lib/parseIntent'
 import type { MentionUser } from '@/lib/mentions'
 import { ApiError } from '@/lib/api'
@@ -20,13 +20,48 @@ const Streamdown = lazy(() => import('streamdown').then((m) => ({ default: m.Str
 // rect it reports in ITS viewport coords is already this element's coordinate space — 1:1 px, no
 // scale math, no getBoundingClientRect of the iframe. Mounting anywhere else would reintroduce all
 // three.
-const GAP = 8
 const below = (r: DOMRectLike): React.CSSProperties => ({ top: r.top + r.height + GAP, left: r.left })
 
 // The ask panel's approximate max height (quote + textarea + a full answer scroller) — the flip
-// decision below compares this against the space actually available, not the panel's live height,
-// so a growing answer can never flip the side it already committed to.
+// decision uses this instead of the panel's live height, so a growing answer can never flip the
+// side it already committed to.
 const ASK_PANEL_MAX = 340
+
+// Viewport-aware position for an element pinned to `rect`: first paint at the raw below-the-rect
+// spot, then — synchronously, before that paint — measure the element and its offsetParent (the
+// iframe wrapper, per the MOUNT POINT note above) and let placePopover flip/shift it back into
+// view. `height` overrides the measured height for panels that grow after placement (the ask
+// panel). Unmeasurable container (happy-dom, or a not-yet-laid-out wrapper) keeps the raw spot.
+function usePlacement(rect: DOMRectLike, height?: number) {
+  const ref = useRef<HTMLDivElement>(null)
+  const [style, setStyle] = useState<React.CSSProperties>(() => below(rect))
+  useLayoutEffect(() => {
+    const el = ref.current
+    const container = el?.offsetParent
+    if (!el || !(container instanceof HTMLElement) || container.clientHeight === 0) {
+      setStyle(below(rect))
+      return
+    }
+    setStyle(
+      placePopover(
+        rect,
+        { width: el.offsetWidth, height: height ?? el.offsetHeight },
+        { width: container.clientWidth, height: container.clientHeight },
+      ),
+    )
+  }, [rect, height])
+  return { ref, style }
+}
+
+/** A div pinned to `rect` that flips/shifts to stay inside the iframe wrapper. */
+function Anchored({
+  rect,
+  height,
+  ...props
+}: { rect: DOMRectLike; height?: number } & React.HTMLAttributes<HTMLDivElement>) {
+  const { ref, style } = usePlacement(rect, height)
+  return <div ref={ref} style={style} {...props} />
+}
 
 export function CommentPopover({
   chip,
@@ -63,7 +98,7 @@ export function CommentPopover({
       {chip && (
         // A single positioned wrapper, not two — the two buttons are one toolbar pinned to one
         // rect, and neither owns the coordinate on its own.
-        <div className="absolute z-20 flex items-center gap-1.5" style={below(chip.rect)}>
+        <Anchored rect={chip.rect} className="absolute z-20 flex items-center gap-1.5">
           <button
             type="button"
             aria-label="Comment on selection"
@@ -94,14 +129,14 @@ export function CommentPopover({
               A
             </kbd>
           </button>
-        </div>
+        </Anchored>
       )}
       {composer && (
-        <div
+        <Anchored
           // A new composer id is a new composer: remounting drops the previous draft, which is what
           // the reducer means when a click on the chip mints a fresh one over an open (even dirty) box.
           key={composer.id}
-          style={below(composer.anchor.rect)}
+          rect={composer.anchor.rect}
           className="absolute z-30 w-80 rounded-lg border bg-popover p-3 text-popover-foreground shadow-lg"
           // Escape closes the popover — but ONLY once the Composer hasn't already claimed it for its
           // open mention menu (it preventDefaults there). Menu first, popover on the next press.
@@ -122,7 +157,7 @@ export function CommentPopover({
             onCancel={onDismiss}
             onDirtyChange={onDirtyChange}
           />
-        </div>
+        </Anchored>
       )}
       {ask && (
         // Same remount-on-id contract as the composer above: a fresh ask id is a fresh question.
@@ -156,7 +191,6 @@ function AskPanel({
   onDismiss: () => void
   onDirtyChange?: (dirty: boolean) => void
 }) {
-  const panelRef = useRef<HTMLDivElement>(null)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const answerRef = useRef<HTMLDivElement>(null)
   const abortRef = useRef<AbortController | null>(null)
@@ -164,23 +198,11 @@ function AskPanel({
   // reading an earlier part of a growing answer isn't yanked back down on the next token.
   const stickToBottom = useRef(true)
 
-  // Which side of the anchor the panel sits on, decided ONCE at open — never mid-stream, or a
-  // growing answer would flip the panel out from under the user's cursor. Starts 'below' (today's
-  // placement) and the layout effect corrects it, synchronously before paint, if the space below
-  // the anchor can't fit the panel's max height against the wrapper div's height (see the MOUNT
-  // POINT comment above: that wrapper is this panel's offsetParent, and the rect is already in its
-  // coordinate space).
-  const [placement, setPlacement] = useState<{ side: 'below' | 'above'; containerHeight: number }>({
-    side: 'below',
-    containerHeight: 0,
-  })
-  // biome-ignore lint/correctness/useExhaustiveDependencies: decided once, on mount only — ask.anchor.rect is stable for this panel's whole life (a new ask id remounts it, see the `key` at the call site).
-  useLayoutEffect(() => {
-    const container = panelRef.current?.offsetParent
-    const containerHeight = container instanceof HTMLElement ? container.clientHeight : 0
-    const spaceBelow = containerHeight - (ask.anchor.rect.top + ask.anchor.rect.height + GAP)
-    setPlacement({ side: spaceBelow < ASK_PANEL_MAX ? 'above' : 'below', containerHeight })
-  }, [])
+  // Placed against ASK_PANEL_MAX, not the panel's live height, and the rect is stable for this
+  // panel's whole life (a new ask id remounts it, see the `key` at the call site) — so the side is
+  // decided once, at open, and a growing answer can never flip the panel out from under the
+  // user's cursor.
+  const { ref: panelRef, style } = usePlacement(ask.anchor.rect, ASK_PANEL_MAX)
 
   const [question, setQuestion] = useState('')
   const [turns, setTurns] = useState<Turn[]>([])
@@ -254,11 +276,6 @@ function AskPanel({
     setTurns((ts) => ts.slice(0, -1))
     void run(q)
   }
-
-  const style =
-    placement.side === 'below'
-      ? below(ask.anchor.rect)
-      : { bottom: placement.containerHeight - ask.anchor.rect.top + GAP, left: ask.anchor.rect.left }
 
   return (
     <div

--- a/packages/web/src/components/review/Composer.tsx
+++ b/packages/web/src/components/review/Composer.tsx
@@ -21,6 +21,7 @@ const KEYCAP =
 export function Composer({
   placeholder,
   submitLabel,
+  initialBody,
   onSubmit,
   onSubmitVoice,
   onCancel,
@@ -35,6 +36,8 @@ export function Composer({
 }: {
   placeholder: string
   submitLabel: string
+  // Seed the draft (editing an existing comment). Mount-time only — this is an uncontrolled draft.
+  initialBody?: string
   onSubmit: (body: string, mentions: string[]) => void | Promise<void>
   // When set, the composer shows a mic that records a clip and submits it here (voice comment).
   onSubmitVoice?: (blob: Blob) => void | Promise<void>
@@ -63,7 +66,7 @@ export function Composer({
   // sitting on their text, still typing — same rule the draft itself follows.
   onTypingStop?: () => void
 }) {
-  const [body, setBody] = useState('')
+  const [body, setBody] = useState(initialBody ?? '')
   const [busy, setBusy] = useState(false)
   const rec = useMediaRecorder()
   const trimmed = body.trim()

--- a/packages/web/src/components/review/ThreadCard.test.tsx
+++ b/packages/web/src/components/review/ThreadCard.test.tsx
@@ -450,3 +450,54 @@ describe('ThreadCard — a refetched reaction list supersedes the local override
     react.mockRestore()
   })
 })
+
+// Editing rewrites a message in place through comments.edit (author only, text only). Like
+// delete/resolve it is NOT pushed by the room, so onChanged({pushed:false}) is the only thing that
+// will ever show the new body to this viewer.
+describe('ThreadCard — inline edit', () => {
+  const mine = (over: Partial<CommentItem> = {}) =>
+    mkComment({ id: 'c1', authorId: ME.id, author: ME.name, body: 'old text', ...over })
+
+  test('Edit seeds the composer with the body, saves through comments.edit, closes on success', async () => {
+    const edit = spyOn(comments, 'edit').mockImplementation(() => Promise.resolve({ ok: true } as never))
+    const { onChanged } = renderCard({ comments: [mine()] })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit comment' }))
+    const box = screen.getByPlaceholderText('Edit comment…') as HTMLTextAreaElement
+    expect(box.value).toBe('old text')
+
+    fireEvent.change(box, { target: { value: 'new text' } })
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    })
+
+    expect(edit).toHaveBeenCalledWith(SITE, 't1', 'c1', 'new text')
+    expect(onChanged).toHaveBeenCalledWith({ pushed: false })
+    expect(screen.queryByPlaceholderText('Edit comment…')).toBeNull() // editor closed, body row back
+    edit.mockRestore()
+  })
+
+  test('a rejected edit leaves the editor mounted with the text intact', async () => {
+    const edit = spyOn(comments, 'edit').mockImplementation(() => Promise.reject(new Error('write failed')))
+    const { onChanged } = renderCard({ comments: [mine()] })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit comment' }))
+    const box = screen.getByPlaceholderText('Edit comment…') as HTMLTextAreaElement
+    fireEvent.change(box, { target: { value: 'new text' } })
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    })
+
+    expect(box.isConnected).toBe(true)
+    expect(box.value).toBe('new text')
+    expect(onChanged).not.toHaveBeenCalled()
+    edit.mockRestore()
+  })
+
+  test("someone else's comment, and voice comments, offer no Edit", () => {
+    renderCard({
+      comments: [mkComment({ id: 'c1' }), mine({ id: 'c2', hasAudio: true })],
+    })
+    expect(screen.queryByRole('button', { name: 'Edit comment' })).toBeNull()
+  })
+})

--- a/packages/web/src/components/review/ThreadCard.tsx
+++ b/packages/web/src/components/review/ThreadCard.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Check, FileText, Mic, RotateCcw, Trash2 } from 'lucide-react'
+import { Check, FileText, Mic, Pencil, RotateCcw, Trash2 } from 'lucide-react'
 import { toast } from 'sonner'
 import { ApiError } from '@/lib/api'
 import { comments, type CommentItem, type CommentReaction, type Thread } from '@/lib/comments'
@@ -44,6 +44,9 @@ export function ThreadCard({
   onFocusAnchor: (thread: Thread) => void
 }) {
   const [replying, setReplying] = useState(false)
+  // Comment id under inline edit, or null. One at a time: starting an edit on another message
+  // simply moves the composer there — the abandoned draft was never sent, so nothing is lost.
+  const [editing, setEditing] = useState<string | null>(null)
   // Reaction lists the server has since re-stated, by comment id. The toggle endpoints answer with
   // the comment's FRESH list, so a successful toggle is already the truth — refetching the thread
   // (what onChanged does) would spend a request to learn what the response just said.
@@ -183,6 +186,18 @@ export function ThreadCard({
                     className="size-6 rounded-sm px-0 text-muted-foreground"
                     onPick={(emoji) => toggle(c, emoji, false)()}
                   />
+                  {/* Edit is text-only: a voice comment's body is its transcript, and rewriting a
+                      transcript out from under its recording would make the two disagree. */}
+                  {c.authorId === me?.id && !c.hasAudio && (
+                    <button
+                      type="button"
+                      onClick={() => setEditing(c.id)}
+                      className="flex size-6 items-center justify-center rounded-sm hover:bg-muted"
+                      aria-label="Edit comment"
+                    >
+                      <Pencil className="size-3.5 text-muted-foreground" />
+                    </button>
+                  )}
                   {c.authorId === me?.id && (
                     <button
                       type="button"
@@ -234,9 +249,27 @@ export function ThreadCard({
                       {c.editedAt && !c.deleted && <span>(edited)</span>}
                     </div>
                   )}
-                  <p className={c.deleted ? 'text-muted-foreground italic' : 'whitespace-pre-wrap'}>
-                    {c.deleted ? 'comment deleted' : c.body}
-                  </p>
+                  {editing === c.id && !c.deleted ? (
+                    <div className="mt-1">
+                      <Composer
+                        autoFocus
+                        initialBody={c.body ?? ''}
+                        placeholder="Edit comment…"
+                        submitLabel="Save"
+                        onCancel={() => setEditing(null)}
+                        onSubmit={async (body) => {
+                          // Not pushed (like delete/resolve): the caller's refetch is the only
+                          // thing that will ever show the new body.
+                          await run(() => comments.edit(site, thread.id, c.id, body), false)
+                          setEditing(null)
+                        }}
+                      />
+                    </div>
+                  ) : (
+                    <p className={c.deleted ? 'text-muted-foreground italic' : 'whitespace-pre-wrap'}>
+                      {c.deleted ? 'comment deleted' : c.body}
+                    </p>
+                  )}
                   {/* Voice comment: the transcript above stays always-visible; the recording plays
                       from the auth-gated audio route (deleted comments lose hasAudio, so they never
                       reach here). */}

--- a/packages/web/src/lib/commentPopover.test.ts
+++ b/packages/web/src/lib/commentPopover.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, test } from 'bun:test'
-import { type Anchor, initialPopover, type PopoverEvent, type PopoverState, stepPopover } from './commentPopover'
+import {
+  type Anchor,
+  initialPopover,
+  placePopover,
+  type PopoverEvent,
+  type PopoverState,
+  stepPopover,
+} from './commentPopover'
 
 // Slice A1 — the select → chip → composer → save lifecycle, pinned at the reducer. A reducer suite
 // cannot prove real-iframe timing (a genuine pointerdown/selectionchange race); it pins the
@@ -122,11 +129,7 @@ describe('C opens the composer in exactly one state (#117)', () => {
   })
 
   test('a saving composer is still a composer: commentKey cannot mint one over an in-flight write', () => {
-    const saving = run([
-      { type: 'select', anchor: A, dirty: false },
-      { type: 'activate' },
-      { type: 'submit' },
-    ])
+    const saving = run([{ type: 'select', anchor: A, dirty: false }, { type: 'activate' }, { type: 'submit' }])
     expect(stepPopover(saving, { type: 'commentKey' })).toBe(saving)
   })
 })
@@ -201,7 +204,7 @@ describe('askActivate / askKey — the ask panel (mirrors activate / commentKey)
     expect(state.composer?.anchor).toEqual(A)
   })
 
-  test("select does NOT re-anchor or close an open ask panel — the answer stays put while reading", () => {
+  test('select does NOT re-anchor or close an open ask panel — the answer stays put while reading', () => {
     const asked = run([{ type: 'select', anchor: A, dirty: false }, { type: 'askActivate' }])
     const state = stepPopover(asked, { type: 'select', anchor: B, dirty: false })
     expect(state.ask).toEqual(asked.ask) // untouched: same id, same anchor (still A)
@@ -422,5 +425,43 @@ describe('dismiss closes; clickAway with dirty:true does NOT close', () => {
     ])
     expect(state.chip).toEqual(B)
     expect(state.composer?.anchor).toEqual(A) // still the dirty draft's anchor
+  })
+})
+
+// placePopover — pure flip/shift geometry. The container is the iframe wrapper (the rect's own
+// coordinate space); measuring real elements is the component's job, so these pin only the math.
+describe('PLACE-POPOVER-STAYS-IN-CONTAINER', () => {
+  const CONTAINER = { width: 800, height: 600 }
+  const SIZE = { width: 320, height: 150 }
+
+  test('fits below: pinned under the rect at its left edge', () => {
+    expect(placePopover({ top: 100, left: 40, width: 200, height: 18 }, SIZE, CONTAINER)).toEqual({
+      top: 100 + 18 + 8,
+      left: 40,
+    })
+  })
+
+  test('near the right edge: shifted left just enough to fit, still below', () => {
+    const p = placePopover({ top: 100, left: 700, width: 80, height: 18 }, SIZE, CONTAINER)
+    expect(p.left).toBe(800 - 320 - 8)
+    expect(p.top).toBe(100 + 18 + 8)
+  })
+
+  test('near the bottom: flipped above, anchored by `bottom` so growth extends upward', () => {
+    const p = placePopover({ top: 550, left: 40, width: 200, height: 18 }, SIZE, CONTAINER)
+    expect(p.top).toBeUndefined()
+    expect(p.bottom).toBe(600 - 550 + 8)
+    expect(p.left).toBe(40)
+  })
+
+  test('fits on neither side: takes the side with more room rather than flipping blindly', () => {
+    // Rect near the top of a short container — below overflows, but above has even less room.
+    const p = placePopover({ top: 20, left: 10, width: 50, height: 12 }, SIZE, { width: 800, height: 300 })
+    expect(p.top).toBe(20 + 12 + 8)
+    expect(p.bottom).toBeUndefined()
+  })
+
+  test('never shifted past the container’s own left inset', () => {
+    expect(placePopover({ top: 100, left: -20, width: 50, height: 12 }, SIZE, CONTAINER).left).toBe(8)
   })
 })

--- a/packages/web/src/lib/commentPopover.ts
+++ b/packages/web/src/lib/commentPopover.ts
@@ -57,6 +57,34 @@ export function initialPopover(): PopoverState {
   return { chip: null, composer: null, saving: null, ask: null, seq: 0 }
 }
 
+/** Gap between the anchor rect and whatever is pinned to it. */
+export const GAP = 8
+/** Minimum inset from the container's edges when a popover has to shift to stay visible. */
+const PAD = 8
+
+/** Positioning for a popover pinned to `rect`: `top` XOR `bottom`, both relative to the container
+ *  (the wrapper div the rect's coordinates already live in — see CommentPopover's MOUNT POINT
+ *  note). A type alias, not an interface — the implicit index signature is what lets it flow
+ *  straight into React's CSSProperties. */
+export type PopoverPlacement = { top?: number; bottom?: number; left: number }
+
+/** Where a popover of `size` goes so it stays inside `container`: below the rect when it fits (or
+ *  when below has at least as much room as above), otherwise flipped above — anchored by `bottom`
+ *  so later growth extends away from the anchor instead of over it. Horizontally it shifts left
+ *  just enough to fit, never past the container's own left edge. Pure math on the numbers the
+ *  iframe reported; measuring is the caller's job. */
+export function placePopover(
+  rect: DOMRectLike,
+  size: { width: number; height: number },
+  container: { width: number; height: number },
+): PopoverPlacement {
+  const left = Math.max(PAD, Math.min(rect.left, container.width - size.width - PAD))
+  const spaceBelow = container.height - (rect.top + rect.height + GAP)
+  const spaceAbove = rect.top - GAP
+  if (size.height <= spaceBelow || spaceBelow >= spaceAbove) return { top: rect.top + rect.height + GAP, left }
+  return { bottom: container.height - rect.top + GAP, left }
+}
+
 export function stepPopover(state: PopoverState, event: PopoverEvent): PopoverState {
   switch (event.type) {
     case 'select': {


### PR DESCRIPTION
## What

**Popover placement** — the selection chip, comment composer, and ask panel were pinned blindly below the selection rect, so selecting near the bottom or right edge pushed them off-screen.
- New pure `placePopover(rect, size, container)` in `lib/commentPopover.ts`: flips above the anchor when below can't fit (anchored by `bottom`, so later growth extends away from the anchor), and shifts horizontally to stay inside the iframe wrapper.
- `usePlacement` hook / `Anchored` wrapper in `CommentPopover.tsx`: first paint at the raw below-the-rect spot, then a layout effect measures the element + its offsetParent and corrects before paint. The AskPanel's ad-hoc flip-only logic folds into the same path (still placed against `ASK_PANEL_MAX`, so a streaming answer never flips a committed side).
- No placement library: the rects live in the iframe wrapper's coordinate space, so floating-ui would need virtual-element plumbing for what is ~10 lines of math.

**Inline comment editing** — the API (`PATCH …/messages/:commentId`) and client (`comments.edit`) already existed; this adds the missing UI.
- Pencil button in the message hover bar for your own text comments; opens the existing Composer seeded with the current body (new `initialBody` prop). Save → `comments.edit` → `onChanged({pushed: false})` (edits aren't fanned out by the room, same as delete/resolve). A failed save keeps the editor open with the text intact.
- Voice comments are excluded: their body is the recording's transcript, and rewriting it out from under the recording would make the two disagree.

## Tests

- 5 `placePopover` geometry cases (below, right-edge shift, bottom flip, fits-neither picks the larger side, left clamp)
- 3 ThreadCard edit cases (seed + save + refetch; rejected edit keeps the editor; no Edit on others'/voice comments)
- Full web suite: 493 pass, typecheck + biome clean

happy-dom does no layout, so real on-screen geometry isn't provable in the suite — worth one manual look in the browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YLXKuFvrpoBYrBHNzDJfcf